### PR TITLE
feat: add language-agnostic analysis packages for pyscn parity

### DIFF
--- a/cbo/cbo.go
+++ b/cbo/cbo.go
@@ -1,0 +1,163 @@
+package cbo
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+// DependencyKind represents the type of dependency between classes.
+type DependencyKind int
+
+const (
+	DepInheritance     DependencyKind = iota // Class inheritance
+	DepTypeHint                              // Type hint/annotation
+	DepInstantiation                         // Object instantiation
+	DepAttributeAccess                       // Attribute access on another class
+	DepImport                                // Import dependency
+)
+
+// String returns the string representation of a DependencyKind.
+func (k DependencyKind) String() string {
+	switch k {
+	case DepInheritance:
+		return "inheritance"
+	case DepTypeHint:
+		return "type_hint"
+	case DepInstantiation:
+		return "instantiation"
+	case DepAttributeAccess:
+		return "attribute_access"
+	case DepImport:
+		return "import"
+	default:
+		return "unknown"
+	}
+}
+
+// ClassDependency represents a single dependency from one class to another.
+type ClassDependency struct {
+	ClassName string
+	Kind      DependencyKind
+}
+
+// ClassInfo holds the information about a class needed for CBO computation.
+// Language-specific analyzers populate this from their AST.
+type ClassInfo struct {
+	Name         string
+	FilePath     string
+	StartLine    int
+	EndLine      int
+	Dependencies []ClassDependency
+	IsAbstract   bool
+	BaseClasses  []string
+	Methods      []string
+	Attributes   []string
+}
+
+// Result holds the CBO analysis result for a single class.
+type Result struct {
+	ClassName           string
+	FilePath            string
+	StartLine           int
+	EndLine             int
+	CouplingCount       int
+	DependencyBreakdown map[DependencyKind]int
+	DependentClasses    []string
+	RiskLevel           domain.RiskLevel
+	IsAbstract          bool
+}
+
+// Config holds configuration for CBO analysis.
+type Config struct {
+	LowThreshold    int
+	MediumThreshold int
+	ExcludePatterns []string
+}
+
+// DefaultConfig returns the default CBO configuration.
+func DefaultConfig() Config {
+	return Config{
+		LowThreshold:    domain.DefaultCBOLowThreshold,
+		MediumThreshold: domain.DefaultCBOMediumThreshold,
+	}
+}
+
+// ComputeCBO computes Coupling Between Objects for each class.
+func ComputeCBO(classes []*ClassInfo, config Config) []*Result {
+	results := make([]*Result, 0, len(classes))
+
+	for _, class := range classes {
+		if class == nil {
+			continue
+		}
+		if len(config.ExcludePatterns) > 0 && MatchesPattern(class.Name, config.ExcludePatterns) {
+			continue
+		}
+
+		// Count unique dependent classes and breakdown by kind
+		uniqueClasses := make(map[string]bool)
+		breakdown := make(map[DependencyKind]int)
+
+		for _, dep := range class.Dependencies {
+			if dep.ClassName != class.Name { // exclude self-references
+				uniqueClasses[dep.ClassName] = true
+				breakdown[dep.Kind]++
+			}
+		}
+
+		// Sort dependent class names for deterministic output
+		depClasses := make([]string, 0, len(uniqueClasses))
+		for name := range uniqueClasses {
+			depClasses = append(depClasses, name)
+		}
+		sort.Strings(depClasses)
+
+		cbo := len(uniqueClasses)
+
+		results = append(results, &Result{
+			ClassName:           class.Name,
+			FilePath:            class.FilePath,
+			StartLine:           class.StartLine,
+			EndLine:             class.EndLine,
+			CouplingCount:       cbo,
+			DependencyBreakdown: breakdown,
+			DependentClasses:    depClasses,
+			RiskLevel:           AssessRisk(cbo, config),
+			IsAbstract:          class.IsAbstract,
+		})
+	}
+
+	return results
+}
+
+// AssessRisk determines the risk level based on the CBO count and config thresholds.
+func AssessRisk(cbo int, config Config) domain.RiskLevel {
+	if cbo <= config.LowThreshold {
+		return domain.RiskLevelLow
+	}
+	if cbo <= config.MediumThreshold {
+		return domain.RiskLevelMedium
+	}
+	return domain.RiskLevelHigh
+}
+
+// MatchesPattern checks if a name matches any of the given wildcard patterns.
+// Patterns support '*' as a wildcard using filepath.Match semantics.
+func MatchesPattern(name string, patterns []string) bool {
+	for _, pattern := range patterns {
+		// Try matching the full name
+		if matched, err := filepath.Match(pattern, name); err == nil && matched {
+			return true
+		}
+		// Also try case-insensitive prefix match for simple patterns
+		if !strings.Contains(pattern, "*") && !strings.Contains(pattern, "?") {
+			if strings.EqualFold(name, pattern) {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/cbo/cbo_test.go
+++ b/cbo/cbo_test.go
@@ -1,0 +1,345 @@
+package cbo
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+func TestComputeCBO_EmptyInput(t *testing.T) {
+	results := ComputeCBO(nil, DefaultConfig())
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results, got %d", len(results))
+	}
+
+	results = ComputeCBO([]*ClassInfo{}, DefaultConfig())
+	if len(results) != 0 {
+		t.Fatalf("expected 0 results for empty slice, got %d", len(results))
+	}
+}
+
+func TestComputeCBO_NilClassSkipped(t *testing.T) {
+	classes := []*ClassInfo{
+		nil,
+		{Name: "Foo", FilePath: "foo.py", StartLine: 1, EndLine: 10},
+		nil,
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result (nil skipped), got %d", len(results))
+	}
+	if results[0].ClassName != "Foo" {
+		t.Fatalf("expected class Foo, got %s", results[0].ClassName)
+	}
+}
+
+func TestComputeCBO_NoDependencies(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:      "Isolated",
+			FilePath:  "isolated.py",
+			StartLine: 1,
+			EndLine:   20,
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	r := results[0]
+	if r.CouplingCount != 0 {
+		t.Errorf("expected CBO=0, got %d", r.CouplingCount)
+	}
+	if r.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("expected low risk, got %s", r.RiskLevel)
+	}
+	if len(r.DependentClasses) != 0 {
+		t.Errorf("expected no dependent classes, got %v", r.DependentClasses)
+	}
+}
+
+func TestComputeCBO_LowRisk(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:     "Service",
+			FilePath: "service.py",
+			Dependencies: []ClassDependency{
+				{ClassName: "Repo", Kind: DepInstantiation},
+				{ClassName: "Logger", Kind: DepTypeHint},
+				{ClassName: "Config", Kind: DepImport},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+	if r.CouplingCount != 3 {
+		t.Errorf("expected CBO=3, got %d", r.CouplingCount)
+	}
+	if r.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("expected low risk for CBO=3, got %s", r.RiskLevel)
+	}
+}
+
+func TestComputeCBO_MediumRisk(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:     "Controller",
+			FilePath: "controller.py",
+			Dependencies: []ClassDependency{
+				{ClassName: "A", Kind: DepImport},
+				{ClassName: "B", Kind: DepImport},
+				{ClassName: "C", Kind: DepImport},
+				{ClassName: "D", Kind: DepImport},
+				{ClassName: "E", Kind: DepTypeHint},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+	if r.CouplingCount != 5 {
+		t.Errorf("expected CBO=5, got %d", r.CouplingCount)
+	}
+	if r.RiskLevel != domain.RiskLevelMedium {
+		t.Errorf("expected medium risk for CBO=5, got %s", r.RiskLevel)
+	}
+}
+
+func TestComputeCBO_HighRisk(t *testing.T) {
+	deps := make([]ClassDependency, 8)
+	for i := range deps {
+		deps[i] = ClassDependency{
+			ClassName: string(rune('A' + i)),
+			Kind:      DepImport,
+		}
+	}
+	classes := []*ClassInfo{
+		{
+			Name:         "GodClass",
+			FilePath:     "god.py",
+			Dependencies: deps,
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+	if r.CouplingCount != 8 {
+		t.Errorf("expected CBO=8, got %d", r.CouplingCount)
+	}
+	if r.RiskLevel != domain.RiskLevelHigh {
+		t.Errorf("expected high risk for CBO=8, got %s", r.RiskLevel)
+	}
+}
+
+func TestComputeCBO_SelfReferenceExcluded(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:     "Node",
+			FilePath: "node.py",
+			Dependencies: []ClassDependency{
+				{ClassName: "Node", Kind: DepTypeHint},       // self-ref
+				{ClassName: "Node", Kind: DepInstantiation},  // self-ref
+				{ClassName: "Other", Kind: DepInheritance},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+	if r.CouplingCount != 1 {
+		t.Errorf("expected CBO=1 (self-refs excluded), got %d", r.CouplingCount)
+	}
+	if len(r.DependentClasses) != 1 || r.DependentClasses[0] != "Other" {
+		t.Errorf("expected [Other], got %v", r.DependentClasses)
+	}
+}
+
+func TestComputeCBO_ExcludePatterns(t *testing.T) {
+	classes := []*ClassInfo{
+		{Name: "TestHelper", FilePath: "test_helper.py"},
+		{Name: "Service", FilePath: "service.py"},
+		{Name: "MockRepo", FilePath: "mock_repo.py"},
+	}
+	config := DefaultConfig()
+	config.ExcludePatterns = []string{"Test*", "Mock*"}
+
+	results := ComputeCBO(classes, config)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result after exclusion, got %d", len(results))
+	}
+	if results[0].ClassName != "Service" {
+		t.Errorf("expected Service, got %s", results[0].ClassName)
+	}
+}
+
+func TestComputeCBO_DependencyBreakdown(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:     "Handler",
+			FilePath: "handler.py",
+			Dependencies: []ClassDependency{
+				{ClassName: "Base", Kind: DepInheritance},
+				{ClassName: "Logger", Kind: DepTypeHint},
+				{ClassName: "Logger", Kind: DepInstantiation},
+				{ClassName: "Config", Kind: DepImport},
+				{ClassName: "Config", Kind: DepAttributeAccess},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+
+	// 3 unique classes: Base, Logger, Config
+	if r.CouplingCount != 3 {
+		t.Errorf("expected CBO=3, got %d", r.CouplingCount)
+	}
+
+	expected := map[DependencyKind]int{
+		DepInheritance:     1,
+		DepTypeHint:        1,
+		DepInstantiation:   1,
+		DepImport:          1,
+		DepAttributeAccess: 1,
+	}
+	for kind, count := range expected {
+		if r.DependencyBreakdown[kind] != count {
+			t.Errorf("expected %s=%d, got %d", kind, count, r.DependencyBreakdown[kind])
+		}
+	}
+}
+
+func TestComputeCBO_DependentClassesSorted(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:     "X",
+			FilePath: "x.py",
+			Dependencies: []ClassDependency{
+				{ClassName: "Zebra", Kind: DepImport},
+				{ClassName: "Apple", Kind: DepImport},
+				{ClassName: "Mango", Kind: DepImport},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	deps := results[0].DependentClasses
+
+	if len(deps) != 3 {
+		t.Fatalf("expected 3 dependent classes, got %d", len(deps))
+	}
+	if deps[0] != "Apple" || deps[1] != "Mango" || deps[2] != "Zebra" {
+		t.Errorf("expected [Apple Mango Zebra], got %v", deps)
+	}
+}
+
+func TestAssessRisk_BoundaryValues(t *testing.T) {
+	config := DefaultConfig() // low=3, medium=7
+
+	tests := []struct {
+		cbo      int
+		expected domain.RiskLevel
+	}{
+		{0, domain.RiskLevelLow},
+		{3, domain.RiskLevelLow},      // exactly at low threshold
+		{4, domain.RiskLevelMedium},   // one above low threshold
+		{7, domain.RiskLevelMedium},   // exactly at medium threshold
+		{8, domain.RiskLevelHigh},     // one above medium threshold
+		{100, domain.RiskLevelHigh},
+	}
+
+	for _, tt := range tests {
+		got := AssessRisk(tt.cbo, config)
+		if got != tt.expected {
+			t.Errorf("AssessRisk(%d): expected %s, got %s", tt.cbo, tt.expected, got)
+		}
+	}
+}
+
+func TestMatchesPattern(t *testing.T) {
+	tests := []struct {
+		name     string
+		patterns []string
+		expected bool
+	}{
+		{"TestHelper", []string{"Test*"}, true},
+		{"MockRepo", []string{"Mock*"}, true},
+		{"Service", []string{"Test*", "Mock*"}, false},
+		{"myclass", []string{"MyClass"}, true},   // case-insensitive exact
+		{"MyClass", []string{"MyClass"}, true},
+		{"FooBar", []string{"Foo*"}, true},
+		{"FooBar", []string{"*Bar"}, true},
+		{"FooBar", []string{"Baz*"}, false},
+		{"A", []string{}, false},
+	}
+
+	for _, tt := range tests {
+		got := MatchesPattern(tt.name, tt.patterns)
+		if got != tt.expected {
+			t.Errorf("MatchesPattern(%q, %v): expected %v, got %v",
+				tt.name, tt.patterns, tt.expected, got)
+		}
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+	if config.LowThreshold != 3 {
+		t.Errorf("expected LowThreshold=3, got %d", config.LowThreshold)
+	}
+	if config.MediumThreshold != 7 {
+		t.Errorf("expected MediumThreshold=7, got %d", config.MediumThreshold)
+	}
+	if config.ExcludePatterns != nil {
+		t.Errorf("expected nil ExcludePatterns, got %v", config.ExcludePatterns)
+	}
+}
+
+func TestDependencyKind_String(t *testing.T) {
+	tests := []struct {
+		kind     DependencyKind
+		expected string
+	}{
+		{DepInheritance, "inheritance"},
+		{DepTypeHint, "type_hint"},
+		{DepInstantiation, "instantiation"},
+		{DepAttributeAccess, "attribute_access"},
+		{DepImport, "import"},
+		{DependencyKind(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		got := tt.kind.String()
+		if got != tt.expected {
+			t.Errorf("DependencyKind(%d).String(): expected %q, got %q", tt.kind, tt.expected, got)
+		}
+	}
+}
+
+func TestComputeCBO_ResultFieldsPopulated(t *testing.T) {
+	classes := []*ClassInfo{
+		{
+			Name:       "MyClass",
+			FilePath:   "my_class.py",
+			StartLine:  10,
+			EndLine:    50,
+			IsAbstract: true,
+			Dependencies: []ClassDependency{
+				{ClassName: "Base", Kind: DepInheritance},
+			},
+		},
+	}
+	results := ComputeCBO(classes, DefaultConfig())
+	r := results[0]
+
+	if r.ClassName != "MyClass" {
+		t.Errorf("expected ClassName=MyClass, got %s", r.ClassName)
+	}
+	if r.FilePath != "my_class.py" {
+		t.Errorf("expected FilePath=my_class.py, got %s", r.FilePath)
+	}
+	if r.StartLine != 10 {
+		t.Errorf("expected StartLine=10, got %d", r.StartLine)
+	}
+	if r.EndLine != 50 {
+		t.Errorf("expected EndLine=50, got %d", r.EndLine)
+	}
+	if !r.IsAbstract {
+		t.Error("expected IsAbstract=true")
+	}
+}

--- a/clone/classifier.go
+++ b/clone/classifier.go
@@ -1,0 +1,147 @@
+package clone
+
+import (
+	"sort"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+// ClassifierConfig holds configuration for the clone classifier.
+type ClassifierConfig struct {
+	Type1Threshold            float64
+	Type2Threshold            float64
+	Type3Threshold            float64
+	Type4Threshold            float64
+	EnableType1               bool
+	EnableType2               bool
+	EnableType3               bool
+	EnableType4               bool
+	JaccardPreFilterThreshold float64
+}
+
+// DefaultClassifierConfig returns the default classifier configuration.
+func DefaultClassifierConfig() ClassifierConfig {
+	return ClassifierConfig{
+		Type1Threshold:            domain.DefaultType1CloneThreshold,
+		Type2Threshold:            domain.DefaultType2CloneThreshold,
+		Type3Threshold:            domain.DefaultType3CloneThreshold,
+		Type4Threshold:            domain.DefaultType4CloneThreshold,
+		EnableType1:               true,
+		EnableType2:               true,
+		EnableType3:               true,
+		EnableType4:               true,
+		JaccardPreFilterThreshold: 0.0,
+	}
+}
+
+// ClassificationResult holds the result of classifying a clone pair.
+type ClassificationResult struct {
+	CloneType    domain.CloneType
+	Similarity   float64
+	Confidence   float64
+	AnalyzerName string
+}
+
+// Classifier performs cascade classification of clone pairs.
+type Classifier struct {
+	config    ClassifierConfig
+	analyzers map[domain.CloneType]SimilarityAnalyzer
+}
+
+// NewClassifier creates a new classifier with the given configuration.
+func NewClassifier(config ClassifierConfig) *Classifier {
+	return &Classifier{
+		config:    config,
+		analyzers: make(map[domain.CloneType]SimilarityAnalyzer),
+	}
+}
+
+// RegisterAnalyzer registers a similarity analyzer for the given clone type.
+func (c *Classifier) RegisterAnalyzer(cloneType domain.CloneType, analyzer SimilarityAnalyzer) {
+	c.analyzers[cloneType] = analyzer
+}
+
+// Classify classifies a pair of code fragments using cascade classification.
+// It tries Type-1 first (highest threshold), then Type-2, Type-3, Type-4.
+// Returns nil if similarity is below all thresholds.
+func (c *Classifier) Classify(f1, f2 *CodeFragment) *ClassificationResult {
+	if f1 == nil || f2 == nil {
+		return nil
+	}
+
+	// Try each type in cascade order (strictest to most lenient)
+	types := []struct {
+		ct        domain.CloneType
+		threshold float64
+		enabled   bool
+	}{
+		{domain.Type1Clone, c.config.Type1Threshold, c.config.EnableType1},
+		{domain.Type2Clone, c.config.Type2Threshold, c.config.EnableType2},
+		{domain.Type3Clone, c.config.Type3Threshold, c.config.EnableType3},
+		{domain.Type4Clone, c.config.Type4Threshold, c.config.EnableType4},
+	}
+
+	for _, t := range types {
+		if !t.enabled {
+			continue
+		}
+
+		analyzer, ok := c.analyzers[t.ct]
+		if !ok {
+			continue
+		}
+
+		sim := analyzer.ComputeSimilarity(f1, f2)
+		if sim >= t.threshold {
+			// Confidence is how far above the threshold the similarity is,
+			// normalized to 0-1 range above the threshold
+			confidence := 1.0
+			if t.threshold < 1.0 {
+				confidence = (sim - t.threshold) / (1.0 - t.threshold)
+			}
+			if confidence > 1.0 {
+				confidence = 1.0
+			}
+
+			return &ClassificationResult{
+				CloneType:    t.ct,
+				Similarity:   sim,
+				Confidence:   confidence,
+				AnalyzerName: analyzer.Name(),
+			}
+		}
+	}
+
+	return nil
+}
+
+// ClassifyBatch classifies multiple pairs and returns the results as ClonePairs.
+// Pairs that don't meet any threshold are excluded from the result.
+func (c *Classifier) ClassifyBatch(pairs [][2]*CodeFragment) []*ClonePair {
+	results := make([]*ClonePair, 0, len(pairs))
+
+	for _, pair := range pairs {
+		result := c.Classify(pair[0], pair[1])
+		if result == nil {
+			continue
+		}
+		results = append(results, &ClonePair{
+			Fragment1:    pair[0],
+			Fragment2:    pair[1],
+			Similarity:   result.Similarity,
+			CloneType:    result.CloneType,
+			Confidence:   result.Confidence,
+			AnalyzerName: result.AnalyzerName,
+		})
+	}
+
+	// Sort by similarity descending for deterministic output
+	sort.Slice(results, func(i, j int) bool {
+		if results[i].Similarity != results[j].Similarity {
+			return results[i].Similarity > results[j].Similarity
+		}
+		return results[i].Fragment1.ItemKey() < results[j].Fragment1.ItemKey()
+	})
+
+	return results
+}

--- a/clone/classifier_test.go
+++ b/clone/classifier_test.go
@@ -1,0 +1,247 @@
+package clone
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+type mockAnalyzer struct {
+	similarity float64
+	name       string
+}
+
+func (m *mockAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 { return m.similarity }
+func (m *mockAnalyzer) Name() string                                   { return m.name }
+
+func newTestClassifier(sim float64) *Classifier {
+	cfg := DefaultClassifierConfig()
+	c := NewClassifier(cfg)
+	mock := &mockAnalyzer{similarity: sim, name: "mock"}
+	c.RegisterAnalyzer(domain.Type1Clone, mock)
+	c.RegisterAnalyzer(domain.Type2Clone, mock)
+	c.RegisterAnalyzer(domain.Type3Clone, mock)
+	c.RegisterAnalyzer(domain.Type4Clone, mock)
+	return c
+}
+
+func TestClassifyNilFragments(t *testing.T) {
+	c := newTestClassifier(0.9)
+	f := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+
+	if r := c.Classify(nil, f); r != nil {
+		t.Error("expected nil for nil f1")
+	}
+	if r := c.Classify(f, nil); r != nil {
+		t.Error("expected nil for nil f2")
+	}
+	if r := c.Classify(nil, nil); r != nil {
+		t.Error("expected nil for both nil")
+	}
+}
+
+func TestClassifyHighSimilarityReturnsType1(t *testing.T) {
+	c := newTestClassifier(0.95)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.CloneType != domain.Type1Clone {
+		t.Errorf("CloneType = %v, want Type1Clone", r.CloneType)
+	}
+	if r.Similarity != 0.95 {
+		t.Errorf("Similarity = %f, want 0.95", r.Similarity)
+	}
+	if r.AnalyzerName != "mock" {
+		t.Errorf("AnalyzerName = %q, want %q", r.AnalyzerName, "mock")
+	}
+}
+
+func TestClassifyMediumSimilarityReturnsType2(t *testing.T) {
+	// 0.82 is above Type2 threshold (0.80) but below Type1 threshold (0.85)
+	c := newTestClassifier(0.82)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.CloneType != domain.Type2Clone {
+		t.Errorf("CloneType = %v, want Type2Clone", r.CloneType)
+	}
+}
+
+func TestClassifyType3Similarity(t *testing.T) {
+	// 0.75 is above Type3 threshold (0.70) but below Type2 threshold (0.80)
+	c := newTestClassifier(0.75)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.CloneType != domain.Type3Clone {
+		t.Errorf("CloneType = %v, want Type3Clone", r.CloneType)
+	}
+}
+
+func TestClassifyType4Similarity(t *testing.T) {
+	// 0.67 is above Type4 threshold (0.65) but below Type3 threshold (0.70)
+	c := newTestClassifier(0.67)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.CloneType != domain.Type4Clone {
+		t.Errorf("CloneType = %v, want Type4Clone", r.CloneType)
+	}
+}
+
+func TestClassifyBelowAllThresholds(t *testing.T) {
+	c := newTestClassifier(0.50)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r != nil {
+		t.Errorf("expected nil for similarity below all thresholds, got %+v", r)
+	}
+}
+
+func TestClassifyDisabledType(t *testing.T) {
+	cfg := DefaultClassifierConfig()
+	cfg.EnableType1 = false
+	c := NewClassifier(cfg)
+	mock := &mockAnalyzer{similarity: 0.95, name: "mock"}
+	c.RegisterAnalyzer(domain.Type1Clone, mock)
+	c.RegisterAnalyzer(domain.Type2Clone, mock)
+	c.RegisterAnalyzer(domain.Type3Clone, mock)
+	c.RegisterAnalyzer(domain.Type4Clone, mock)
+
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	// Type-1 is disabled, so it should fall through to Type-2
+	if r.CloneType != domain.Type2Clone {
+		t.Errorf("CloneType = %v, want Type2Clone (Type1 disabled)", r.CloneType)
+	}
+}
+
+func TestClassifyBatch(t *testing.T) {
+	cfg := DefaultClassifierConfig()
+	c := NewClassifier(cfg)
+
+	highMock := &mockAnalyzer{similarity: 0.90, name: "high"}
+	lowMock := &mockAnalyzer{similarity: 0.50, name: "low"}
+
+	// Register high analyzer for Type1, low for all others
+	c.RegisterAnalyzer(domain.Type1Clone, highMock)
+	c.RegisterAnalyzer(domain.Type2Clone, lowMock)
+	c.RegisterAnalyzer(domain.Type3Clone, lowMock)
+	c.RegisterAnalyzer(domain.Type4Clone, lowMock)
+
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+	f3 := &CodeFragment{ID: 3, FilePath: "c.go", StartLine: 1, EndLine: 10}
+
+	pairs := [][2]*CodeFragment{
+		{f1, f2}, // high similarity -> Type1
+		{f2, f3}, // high similarity -> Type1
+		{f1, f3}, // high similarity -> Type1
+	}
+
+	results := c.ClassifyBatch(pairs)
+	if len(results) != 3 {
+		t.Fatalf("expected 3 results, got %d", len(results))
+	}
+
+	for _, r := range results {
+		if r.CloneType != domain.Type1Clone {
+			t.Errorf("expected Type1Clone, got %v", r.CloneType)
+		}
+	}
+}
+
+func TestClassifyBatchFiltersBelowThreshold(t *testing.T) {
+	cfg := DefaultClassifierConfig()
+	c := NewClassifier(cfg)
+
+	lowMock := &mockAnalyzer{similarity: 0.30, name: "low"}
+	c.RegisterAnalyzer(domain.Type1Clone, lowMock)
+	c.RegisterAnalyzer(domain.Type2Clone, lowMock)
+	c.RegisterAnalyzer(domain.Type3Clone, lowMock)
+	c.RegisterAnalyzer(domain.Type4Clone, lowMock)
+
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	pairs := [][2]*CodeFragment{{f1, f2}}
+	results := c.ClassifyBatch(pairs)
+	if len(results) != 0 {
+		t.Errorf("expected 0 results for below-threshold pairs, got %d", len(results))
+	}
+}
+
+func TestDefaultClassifierConfig(t *testing.T) {
+	cfg := DefaultClassifierConfig()
+
+	if cfg.Type1Threshold != domain.DefaultType1CloneThreshold {
+		t.Errorf("Type1Threshold = %f, want %f", cfg.Type1Threshold, domain.DefaultType1CloneThreshold)
+	}
+	if cfg.Type2Threshold != domain.DefaultType2CloneThreshold {
+		t.Errorf("Type2Threshold = %f, want %f", cfg.Type2Threshold, domain.DefaultType2CloneThreshold)
+	}
+	if cfg.Type3Threshold != domain.DefaultType3CloneThreshold {
+		t.Errorf("Type3Threshold = %f, want %f", cfg.Type3Threshold, domain.DefaultType3CloneThreshold)
+	}
+	if cfg.Type4Threshold != domain.DefaultType4CloneThreshold {
+		t.Errorf("Type4Threshold = %f, want %f", cfg.Type4Threshold, domain.DefaultType4CloneThreshold)
+	}
+	if !cfg.EnableType1 || !cfg.EnableType2 || !cfg.EnableType3 || !cfg.EnableType4 {
+		t.Error("all clone types should be enabled by default")
+	}
+	if cfg.JaccardPreFilterThreshold != 0.0 {
+		t.Errorf("JaccardPreFilterThreshold = %f, want 0.0", cfg.JaccardPreFilterThreshold)
+	}
+}
+
+func TestClassifyConfidence(t *testing.T) {
+	// With similarity=1.0 and threshold=0.85, confidence should be 1.0
+	c := newTestClassifier(1.0)
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r == nil {
+		t.Fatal("expected non-nil result")
+	}
+	if r.Confidence != 1.0 {
+		t.Errorf("Confidence = %f, want 1.0", r.Confidence)
+	}
+}
+
+func TestClassifyNoAnalyzerRegistered(t *testing.T) {
+	cfg := DefaultClassifierConfig()
+	c := NewClassifier(cfg)
+	// No analyzers registered
+
+	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+
+	r := c.Classify(f1, f2)
+	if r != nil {
+		t.Errorf("expected nil with no analyzers registered, got %+v", r)
+	}
+}

--- a/clone/fragment.go
+++ b/clone/fragment.go
@@ -1,0 +1,59 @@
+package clone
+
+import (
+	"fmt"
+
+	"github.com/ludo-technologies/codescan-core/apted"
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+// CodeFragment represents a code fragment for clone detection.
+// It implements GroupableItem so it can be used with the grouping framework.
+type CodeFragment struct {
+	ID        int
+	FilePath  string
+	StartLine int
+	EndLine   int
+	StartCol  int
+	EndCol    int
+	Content   string
+	ASTNode   *apted.TreeNode
+	NodeCount int
+	LineCount int
+}
+
+// ItemID returns the fragment's unique ID for GroupableItem.
+func (f *CodeFragment) ItemID() int {
+	return f.ID
+}
+
+// ItemKey returns the sorting key for GroupableItem.
+func (f *CodeFragment) ItemKey() string {
+	return fmt.Sprintf("%s|%d|%d|%d|%d", f.FilePath, f.StartLine, f.EndLine, f.StartCol, f.EndCol)
+}
+
+// ClonePair represents a detected clone pair between two code fragments.
+type ClonePair struct {
+	Fragment1    *CodeFragment
+	Fragment2    *CodeFragment
+	Similarity   float64
+	CloneType    domain.CloneType
+	Confidence   float64
+	AnalyzerName string
+}
+
+// CloneGroup represents a group of code fragments that are clones of each other.
+type CloneGroup struct {
+	ID            int
+	Fragments     []*CodeFragment
+	CloneType     domain.CloneType
+	AvgSimilarity float64
+}
+
+// CloneStatistics holds aggregate statistics about clone detection results.
+type CloneStatistics struct {
+	TotalFragments int
+	TotalPairs     int
+	TypeCounts     map[domain.CloneType]int
+	AvgSimilarity  float64
+}

--- a/clone/fragment_test.go
+++ b/clone/fragment_test.go
@@ -1,0 +1,31 @@
+package clone
+
+import (
+	"testing"
+)
+
+func TestCodeFragmentItemID(t *testing.T) {
+	f := &CodeFragment{ID: 42}
+	if f.ItemID() != 42 {
+		t.Errorf("ItemID() = %d, want 42", f.ItemID())
+	}
+}
+
+func TestCodeFragmentItemKey(t *testing.T) {
+	f := &CodeFragment{
+		ID:        1,
+		FilePath:  "main.go",
+		StartLine: 10,
+		EndLine:   20,
+		StartCol:  0,
+		EndCol:    80,
+	}
+	want := "main.go|10|20|0|80"
+	if got := f.ItemKey(); got != want {
+		t.Errorf("ItemKey() = %q, want %q", got, want)
+	}
+}
+
+func TestCodeFragmentImplementsGroupableItem(t *testing.T) {
+	var _ GroupableItem = &CodeFragment{}
+}

--- a/clone/similarity.go
+++ b/clone/similarity.go
@@ -1,0 +1,39 @@
+package clone
+
+import (
+	"github.com/ludo-technologies/codescan-core/apted"
+)
+
+// SimilarityAnalyzer computes similarity between two code fragments.
+type SimilarityAnalyzer interface {
+	ComputeSimilarity(f1, f2 *CodeFragment) float64
+	Name() string
+}
+
+// StructuralAnalyzer computes structural similarity using APTED tree edit distance.
+type StructuralAnalyzer struct {
+	analyzer *apted.APTEDAnalyzer
+}
+
+// NewStructuralAnalyzer creates a new structural similarity analyzer.
+func NewStructuralAnalyzer(costModel apted.CostModel, normMode apted.NormalizationMode) *StructuralAnalyzer {
+	return &StructuralAnalyzer{
+		analyzer: apted.NewAPTEDAnalyzerWithNormalization(costModel, normMode),
+	}
+}
+
+// ComputeSimilarity computes the structural similarity between two fragments using APTED.
+func (s *StructuralAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+	if f1.ASTNode == nil || f2.ASTNode == nil {
+		return 0.0
+	}
+	return s.analyzer.ComputeSimilarity(f1.ASTNode, f2.ASTNode)
+}
+
+// Name returns the name of this analyzer.
+func (s *StructuralAnalyzer) Name() string {
+	return "structural"
+}

--- a/clone/similarity_test.go
+++ b/clone/similarity_test.go
@@ -1,0 +1,88 @@
+package clone
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/apted"
+)
+
+func TestStructuralAnalyzerNilFragments(t *testing.T) {
+	sa := NewStructuralAnalyzer(apted.NewDefaultCostModel(), apted.NormalizeByMax)
+	f := &CodeFragment{ID: 1, ASTNode: apted.NewTreeNode(0, "A")}
+
+	if sim := sa.ComputeSimilarity(nil, f); sim != 0.0 {
+		t.Errorf("nil f1: got %f, want 0.0", sim)
+	}
+	if sim := sa.ComputeSimilarity(f, nil); sim != 0.0 {
+		t.Errorf("nil f2: got %f, want 0.0", sim)
+	}
+	if sim := sa.ComputeSimilarity(nil, nil); sim != 0.0 {
+		t.Errorf("both nil: got %f, want 0.0", sim)
+	}
+}
+
+func TestStructuralAnalyzerNilASTNodes(t *testing.T) {
+	sa := NewStructuralAnalyzer(apted.NewDefaultCostModel(), apted.NormalizeByMax)
+	f1 := &CodeFragment{ID: 1}
+	f2 := &CodeFragment{ID: 2, ASTNode: apted.NewTreeNode(0, "A")}
+
+	if sim := sa.ComputeSimilarity(f1, f2); sim != 0.0 {
+		t.Errorf("nil ASTNode f1: got %f, want 0.0", sim)
+	}
+	if sim := sa.ComputeSimilarity(f2, f1); sim != 0.0 {
+		t.Errorf("nil ASTNode f2: got %f, want 0.0", sim)
+	}
+}
+
+func TestStructuralAnalyzerIdenticalTrees(t *testing.T) {
+	sa := NewStructuralAnalyzer(apted.NewDefaultCostModel(), apted.NormalizeByMax)
+
+	tree1 := apted.NewTreeNode(0, "FunctionDef")
+	tree1.AddChild(apted.NewTreeNode(1, "If"))
+	tree1.AddChild(apted.NewTreeNode(2, "Return"))
+
+	tree2 := apted.NewTreeNode(0, "FunctionDef")
+	tree2.AddChild(apted.NewTreeNode(1, "If"))
+	tree2.AddChild(apted.NewTreeNode(2, "Return"))
+
+	f1 := &CodeFragment{ID: 1, ASTNode: tree1}
+	f2 := &CodeFragment{ID: 2, ASTNode: tree2}
+
+	sim := sa.ComputeSimilarity(f1, f2)
+	if sim != 1.0 {
+		t.Errorf("identical trees: got %f, want 1.0", sim)
+	}
+}
+
+func TestStructuralAnalyzerDifferentTrees(t *testing.T) {
+	sa := NewStructuralAnalyzer(apted.NewDefaultCostModel(), apted.NormalizeByMax)
+
+	tree1 := apted.NewTreeNode(0, "FunctionDef")
+	tree1.AddChild(apted.NewTreeNode(1, "If"))
+
+	tree2 := apted.NewTreeNode(0, "FunctionDef")
+	tree2.AddChild(apted.NewTreeNode(1, "For"))
+	tree2.AddChild(apted.NewTreeNode(2, "Return"))
+
+	f1 := &CodeFragment{ID: 1, ASTNode: tree1}
+	f2 := &CodeFragment{ID: 2, ASTNode: tree2}
+
+	sim := sa.ComputeSimilarity(f1, f2)
+	if sim >= 1.0 {
+		t.Errorf("different trees: got %f, want < 1.0", sim)
+	}
+	if sim <= 0.0 {
+		t.Errorf("different trees: got %f, want > 0.0", sim)
+	}
+}
+
+func TestStructuralAnalyzerName(t *testing.T) {
+	sa := NewStructuralAnalyzer(apted.NewDefaultCostModel(), apted.NormalizeByMax)
+	if name := sa.Name(); name != "structural" {
+		t.Errorf("Name() = %q, want %q", name, "structural")
+	}
+}
+
+func TestStructuralAnalyzerImplementsInterface(t *testing.T) {
+	var _ SimilarityAnalyzer = &StructuralAnalyzer{}
+}

--- a/dfa/builder.go
+++ b/dfa/builder.go
@@ -1,0 +1,162 @@
+package dfa
+
+import (
+	"errors"
+
+	"github.com/ludo-technologies/codescan-core/cfg"
+)
+
+// RefExtractor is the language-specific interface for extracting variable references.
+// Language adapters (e.g. pyscn, jscan) implement this to extract definitions and uses
+// from their AST nodes stored in BasicBlock.Statements.
+type RefExtractor interface {
+	ExtractDefinitions(stmt any, block *cfg.BasicBlock, pos int) []*VarReference
+	ExtractUses(stmt any, block *cfg.BasicBlock, pos int) []*VarReference
+}
+
+// DFABuilder builds DFA information from a CFG using a language-specific RefExtractor.
+type DFABuilder struct {
+	extractor RefExtractor
+}
+
+// NewDFABuilder creates a new DFABuilder with the given reference extractor.
+func NewDFABuilder(extractor RefExtractor) *DFABuilder {
+	return &DFABuilder{extractor: extractor}
+}
+
+// Build performs data flow analysis on the given CFG.
+// It collects definitions, collects uses, then links def-use pairs.
+func (b *DFABuilder) Build(c *cfg.CFG) (*DFAInfo, error) {
+	if c == nil {
+		return NewDFAInfo(nil), nil
+	}
+	if b.extractor == nil {
+		return nil, errors.New("dfa: RefExtractor is nil")
+	}
+
+	info := NewDFAInfo(c)
+
+	// Phase 1: Collect definitions from all blocks
+	b.collectDefinitions(c, info)
+
+	// Phase 2: Collect uses from all blocks
+	b.collectUses(c, info)
+
+	// Phase 3: Link definitions to uses (reaching definitions)
+	b.linkDefUse(c, info)
+
+	return info, nil
+}
+
+// collectDefinitions extracts all variable definitions from the CFG.
+func (b *DFABuilder) collectDefinitions(c *cfg.CFG, info *DFAInfo) {
+	for _, block := range c.Blocks {
+		for pos, stmt := range block.Statements {
+			defs := b.extractor.ExtractDefinitions(stmt, block, pos)
+			for _, def := range defs {
+				info.AddDef(def)
+			}
+		}
+	}
+}
+
+// collectUses extracts all variable uses from the CFG.
+func (b *DFABuilder) collectUses(c *cfg.CFG, info *DFAInfo) {
+	for _, block := range c.Blocks {
+		for pos, stmt := range block.Statements {
+			uses := b.extractor.ExtractUses(stmt, block, pos)
+			for _, use := range uses {
+				info.AddUse(use)
+			}
+		}
+	}
+}
+
+// linkDefUse links definitions to uses by finding reaching definitions.
+// Uses an approximate reaching definition algorithm:
+// 1. Look for definitions in the same block before the use
+// 2. If none found, BFS through predecessor blocks
+func (b *DFABuilder) linkDefUse(_ *cfg.CFG, info *DFAInfo) {
+	for varName, chain := range info.Chains {
+		for _, use := range chain.Uses {
+			def := b.findReachingDef(varName, use, info)
+			if def != nil {
+				pair := NewDefUsePair(def, use)
+				chain.AddPair(pair)
+			}
+		}
+	}
+}
+
+// findReachingDef finds the reaching definition for a use.
+func (b *DFABuilder) findReachingDef(varName string, use *VarReference, info *DFAInfo) *VarReference {
+	if use.Block == nil {
+		return nil
+	}
+
+	// First: look in the same block before the use position
+	def := b.findDefInBlockBefore(varName, use.Block, use.Position, info)
+	if def != nil {
+		return def
+	}
+
+	// Second: BFS through predecessor blocks
+	return b.findDefInPredecessors(varName, use.Block, info)
+}
+
+// findDefInBlockBefore finds the latest definition of varName in block before the given position.
+func (b *DFABuilder) findDefInBlockBefore(varName string, block *cfg.BasicBlock, beforePos int, info *DFAInfo) *VarReference {
+	defs := info.BlockDefs[block.ID]
+	var latest *VarReference
+	for _, def := range defs {
+		if def.Name == varName && def.Position < beforePos {
+			if latest == nil || def.Position > latest.Position {
+				latest = def
+			}
+		}
+	}
+	return latest
+}
+
+// findDefInPredecessors searches predecessor blocks for the most recent definition using BFS.
+func (b *DFABuilder) findDefInPredecessors(varName string, block *cfg.BasicBlock, info *DFAInfo) *VarReference {
+	visited := make(map[string]bool)
+	visited[block.ID] = true
+
+	queue := make([]*cfg.BasicBlock, 0)
+	for _, edge := range block.Predecessors {
+		if edge.From != nil && !visited[edge.From.ID] {
+			queue = append(queue, edge.From)
+			visited[edge.From.ID] = true
+		}
+	}
+
+	for len(queue) > 0 {
+		current := queue[0]
+		queue = queue[1:]
+
+		// Look for the latest def in this block (any position)
+		defs := info.BlockDefs[current.ID]
+		var latest *VarReference
+		for _, def := range defs {
+			if def.Name == varName {
+				if latest == nil || def.Position > latest.Position {
+					latest = def
+				}
+			}
+		}
+		if latest != nil {
+			return latest
+		}
+
+		// Continue searching predecessors
+		for _, edge := range current.Predecessors {
+			if edge.From != nil && !visited[edge.From.ID] {
+				queue = append(queue, edge.From)
+				visited[edge.From.ID] = true
+			}
+		}
+	}
+
+	return nil
+}

--- a/dfa/dfa.go
+++ b/dfa/dfa.go
@@ -1,0 +1,300 @@
+package dfa
+
+import (
+	"fmt"
+	"github.com/ludo-technologies/codescan-core/cfg"
+)
+
+// DefUseKind represents the kind of definition or use of a variable.
+type DefUseKind int
+
+const (
+	DefKindAssign    DefUseKind = iota // Assignment (x = ...)
+	DefKindAugAssign                    // Augmented assignment (x += ...)
+	DefKindParam                        // Function parameter
+	DefKindImport                       // Import statement
+	DefKindFor                          // For-loop variable
+	DefKindWith                         // With-statement variable
+	DefKindExcept                       // Exception handler variable
+	DefKindGlobal                       // Global declaration
+	DefKindNonlocal                     // Nonlocal declaration
+	DefKindDelete                       // Delete statement
+	UseKindLoad                         // Simple name load
+	UseKindAttribute                    // Attribute access
+	UseKindCall                         // Function call
+	UseKindSubscript                    // Subscript access
+)
+
+// String returns the string representation of a DefUseKind.
+func (k DefUseKind) String() string {
+	switch k {
+	case DefKindAssign:
+		return "assign"
+	case DefKindAugAssign:
+		return "aug_assign"
+	case DefKindParam:
+		return "param"
+	case DefKindImport:
+		return "import"
+	case DefKindFor:
+		return "for"
+	case DefKindWith:
+		return "with"
+	case DefKindExcept:
+		return "except"
+	case DefKindGlobal:
+		return "global"
+	case DefKindNonlocal:
+		return "nonlocal"
+	case DefKindDelete:
+		return "delete"
+	case UseKindLoad:
+		return "load"
+	case UseKindAttribute:
+		return "attribute"
+	case UseKindCall:
+		return "call"
+	case UseKindSubscript:
+		return "subscript"
+	default:
+		return fmt.Sprintf("unknown(%d)", int(k))
+	}
+}
+
+// IsDef returns true if this kind represents a definition.
+func (k DefUseKind) IsDef() bool {
+	return k >= DefKindAssign && k <= DefKindDelete
+}
+
+// IsUse returns true if this kind represents a use.
+func (k DefUseKind) IsUse() bool {
+	return k >= UseKindLoad && k <= UseKindSubscript
+}
+
+// VarReference represents a reference to a variable (definition or use).
+type VarReference struct {
+	Name      string
+	Kind      DefUseKind
+	Block     *cfg.BasicBlock
+	Statement any
+	Position  int
+}
+
+// NewVarReference creates a new variable reference.
+func NewVarReference(name string, kind DefUseKind, block *cfg.BasicBlock, stmt any, pos int) *VarReference {
+	return &VarReference{
+		Name:      name,
+		Kind:      kind,
+		Block:     block,
+		Statement: stmt,
+		Position:  pos,
+	}
+}
+
+// DefUsePair represents a definition-use pair.
+type DefUsePair struct {
+	Def *VarReference
+	Use *VarReference
+}
+
+// NewDefUsePair creates a new def-use pair.
+func NewDefUsePair(def, use *VarReference) *DefUsePair {
+	return &DefUsePair{Def: def, Use: use}
+}
+
+// IsCrossBlock returns true if the def and use are in different blocks.
+func (p *DefUsePair) IsCrossBlock() bool {
+	if p.Def == nil || p.Use == nil {
+		return false
+	}
+	if p.Def.Block == nil || p.Use.Block == nil {
+		return false
+	}
+	return p.Def.Block.ID != p.Use.Block.ID
+}
+
+// DefUseChain represents a chain of definitions and uses for a single variable.
+type DefUseChain struct {
+	Variable string
+	Defs     []*VarReference
+	Uses     []*VarReference
+	Pairs    []*DefUsePair
+}
+
+// NewDefUseChain creates a new def-use chain for the given variable.
+func NewDefUseChain(variable string) *DefUseChain {
+	return &DefUseChain{
+		Variable: variable,
+		Defs:     []*VarReference{},
+		Uses:     []*VarReference{},
+		Pairs:    []*DefUsePair{},
+	}
+}
+
+// AddDef adds a definition to the chain.
+func (c *DefUseChain) AddDef(ref *VarReference) {
+	if ref != nil {
+		c.Defs = append(c.Defs, ref)
+	}
+}
+
+// AddUse adds a use to the chain.
+func (c *DefUseChain) AddUse(ref *VarReference) {
+	if ref != nil {
+		c.Uses = append(c.Uses, ref)
+	}
+}
+
+// AddPair adds a def-use pair to the chain.
+func (c *DefUseChain) AddPair(pair *DefUsePair) {
+	if pair != nil {
+		c.Pairs = append(c.Pairs, pair)
+	}
+}
+
+// DFAInfo holds the complete data flow analysis results for a CFG.
+type DFAInfo struct {
+	CFG       *cfg.CFG
+	Chains    map[string]*DefUseChain
+	BlockDefs map[string][]*VarReference // block ID -> definitions
+	BlockUses map[string][]*VarReference // block ID -> uses
+}
+
+// NewDFAInfo creates a new DFAInfo for the given CFG.
+func NewDFAInfo(c *cfg.CFG) *DFAInfo {
+	return &DFAInfo{
+		CFG:       c,
+		Chains:    make(map[string]*DefUseChain),
+		BlockDefs: make(map[string][]*VarReference),
+		BlockUses: make(map[string][]*VarReference),
+	}
+}
+
+// GetChain returns the def-use chain for the given variable, creating it if needed.
+func (d *DFAInfo) GetChain(variable string) *DefUseChain {
+	chain, ok := d.Chains[variable]
+	if !ok {
+		chain = NewDefUseChain(variable)
+		d.Chains[variable] = chain
+	}
+	return chain
+}
+
+// AddDef records a definition in the DFA info.
+func (d *DFAInfo) AddDef(ref *VarReference) {
+	if ref == nil {
+		return
+	}
+	chain := d.GetChain(ref.Name)
+	chain.AddDef(ref)
+	if ref.Block != nil {
+		d.BlockDefs[ref.Block.ID] = append(d.BlockDefs[ref.Block.ID], ref)
+	}
+}
+
+// AddUse records a use in the DFA info.
+func (d *DFAInfo) AddUse(ref *VarReference) {
+	if ref == nil {
+		return
+	}
+	chain := d.GetChain(ref.Name)
+	chain.AddUse(ref)
+	if ref.Block != nil {
+		d.BlockUses[ref.Block.ID] = append(d.BlockUses[ref.Block.ID], ref)
+	}
+}
+
+// TotalDefs returns the total number of definitions across all chains.
+func (d *DFAInfo) TotalDefs() int {
+	total := 0
+	for _, chain := range d.Chains {
+		total += len(chain.Defs)
+	}
+	return total
+}
+
+// TotalUses returns the total number of uses across all chains.
+func (d *DFAInfo) TotalUses() int {
+	total := 0
+	for _, chain := range d.Chains {
+		total += len(chain.Uses)
+	}
+	return total
+}
+
+// TotalPairs returns the total number of def-use pairs across all chains.
+func (d *DFAInfo) TotalPairs() int {
+	total := 0
+	for _, chain := range d.Chains {
+		total += len(chain.Pairs)
+	}
+	return total
+}
+
+// UniqueVariables returns the number of unique variables.
+func (d *DFAInfo) UniqueVariables() int {
+	return len(d.Chains)
+}
+
+// DFAFeatures holds extracted DFA feature values for similarity comparison.
+type DFAFeatures struct {
+	PairCount       int
+	AvgChainLength  float64
+	CrossBlockRatio float64
+	DefKindDist     map[DefUseKind]int
+	UseKindDist     map[DefUseKind]int
+}
+
+// NewDFAFeatures creates an empty DFAFeatures.
+func NewDFAFeatures() *DFAFeatures {
+	return &DFAFeatures{
+		DefKindDist: make(map[DefUseKind]int),
+		UseKindDist: make(map[DefUseKind]int),
+	}
+}
+
+// ExtractDFAFeatures extracts DFA features from DFAInfo for similarity comparison.
+func ExtractDFAFeatures(info *DFAInfo) *DFAFeatures {
+	if info == nil {
+		return NewDFAFeatures()
+	}
+
+	features := NewDFAFeatures()
+	features.PairCount = info.TotalPairs()
+
+	// Average chain length
+	totalChainLen := 0
+	chainCount := 0
+	for _, chain := range info.Chains {
+		totalChainLen += len(chain.Defs) + len(chain.Uses)
+		chainCount++
+	}
+	if chainCount > 0 {
+		features.AvgChainLength = float64(totalChainLen) / float64(chainCount)
+	}
+
+	// Cross-block ratio
+	crossBlock := 0
+	for _, chain := range info.Chains {
+		for _, pair := range chain.Pairs {
+			if pair.IsCrossBlock() {
+				crossBlock++
+			}
+		}
+	}
+	if features.PairCount > 0 {
+		features.CrossBlockRatio = float64(crossBlock) / float64(features.PairCount)
+	}
+
+	// Def/Use kind distributions
+	for _, chain := range info.Chains {
+		for _, def := range chain.Defs {
+			features.DefKindDist[def.Kind]++
+		}
+		for _, use := range chain.Uses {
+			features.UseKindDist[use.Kind]++
+		}
+	}
+
+	return features
+}

--- a/dfa/dfa_test.go
+++ b/dfa/dfa_test.go
@@ -1,0 +1,810 @@
+package dfa
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/cfg"
+)
+
+// ---------------------------------------------------------------------------
+// DefUseKind tests
+// ---------------------------------------------------------------------------
+
+func TestDefUseKind_String(t *testing.T) {
+	tests := []struct {
+		kind     DefUseKind
+		expected string
+	}{
+		{DefKindAssign, "assign"},
+		{DefKindAugAssign, "aug_assign"},
+		{DefKindParam, "param"},
+		{DefKindImport, "import"},
+		{DefKindFor, "for"},
+		{DefKindWith, "with"},
+		{DefKindExcept, "except"},
+		{DefKindGlobal, "global"},
+		{DefKindNonlocal, "nonlocal"},
+		{DefKindDelete, "delete"},
+		{UseKindLoad, "load"},
+		{UseKindAttribute, "attribute"},
+		{UseKindCall, "call"},
+		{UseKindSubscript, "subscript"},
+		{DefUseKind(99), "unknown(99)"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.kind.String(); got != tt.expected {
+			t.Errorf("DefUseKind(%d).String() = %q, want %q", tt.kind, got, tt.expected)
+		}
+	}
+}
+
+func TestDefUseKind_IsDef(t *testing.T) {
+	defKinds := []DefUseKind{
+		DefKindAssign, DefKindAugAssign, DefKindParam, DefKindImport,
+		DefKindFor, DefKindWith, DefKindExcept, DefKindGlobal,
+		DefKindNonlocal, DefKindDelete,
+	}
+	for _, k := range defKinds {
+		if !k.IsDef() {
+			t.Errorf("%s.IsDef() = false, want true", k)
+		}
+		if k.IsUse() {
+			t.Errorf("%s.IsUse() = true, want false", k)
+		}
+	}
+
+	useKinds := []DefUseKind{UseKindLoad, UseKindAttribute, UseKindCall, UseKindSubscript}
+	for _, k := range useKinds {
+		if k.IsDef() {
+			t.Errorf("%s.IsDef() = true, want false", k)
+		}
+		if !k.IsUse() {
+			t.Errorf("%s.IsUse() = false, want true", k)
+		}
+	}
+
+	// Unknown kind is neither def nor use
+	unknown := DefUseKind(99)
+	if unknown.IsDef() {
+		t.Error("unknown.IsDef() = true, want false")
+	}
+	if unknown.IsUse() {
+		t.Error("unknown.IsUse() = true, want false")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// VarReference tests
+// ---------------------------------------------------------------------------
+
+func TestNewVarReference(t *testing.T) {
+	block := cfg.NewBasicBlock("bb0")
+	ref := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+
+	if ref.Name != "x" {
+		t.Errorf("Name = %q, want %q", ref.Name, "x")
+	}
+	if ref.Kind != DefKindAssign {
+		t.Errorf("Kind = %v, want %v", ref.Kind, DefKindAssign)
+	}
+	if ref.Block != block {
+		t.Error("Block mismatch")
+	}
+	if ref.Statement != "x = 1" {
+		t.Errorf("Statement = %v, want %q", ref.Statement, "x = 1")
+	}
+	if ref.Position != 0 {
+		t.Errorf("Position = %d, want 0", ref.Position)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DefUsePair tests
+// ---------------------------------------------------------------------------
+
+func TestDefUsePair_IsCrossBlock_SameBlock(t *testing.T) {
+	block := cfg.NewBasicBlock("bb0")
+	def := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block, "print(x)", 1)
+	pair := NewDefUsePair(def, use)
+
+	if pair.IsCrossBlock() {
+		t.Error("Same block pair should not be cross-block")
+	}
+}
+
+func TestDefUsePair_IsCrossBlock_DifferentBlock(t *testing.T) {
+	block1 := cfg.NewBasicBlock("bb0")
+	block2 := cfg.NewBasicBlock("bb1")
+	def := NewVarReference("x", DefKindAssign, block1, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block2, "print(x)", 0)
+	pair := NewDefUsePair(def, use)
+
+	if !pair.IsCrossBlock() {
+		t.Error("Different block pair should be cross-block")
+	}
+}
+
+func TestDefUsePair_IsCrossBlock_NilDef(t *testing.T) {
+	block := cfg.NewBasicBlock("bb0")
+	use := NewVarReference("x", UseKindLoad, block, "print(x)", 0)
+	pair := NewDefUsePair(nil, use)
+
+	if pair.IsCrossBlock() {
+		t.Error("Nil def pair should not be cross-block")
+	}
+}
+
+func TestDefUsePair_IsCrossBlock_NilUse(t *testing.T) {
+	block := cfg.NewBasicBlock("bb0")
+	def := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	pair := NewDefUsePair(def, nil)
+
+	if pair.IsCrossBlock() {
+		t.Error("Nil use pair should not be cross-block")
+	}
+}
+
+func TestDefUsePair_IsCrossBlock_NilBlock(t *testing.T) {
+	def := NewVarReference("x", DefKindAssign, nil, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, nil, "print(x)", 0)
+	pair := NewDefUsePair(def, use)
+
+	if pair.IsCrossBlock() {
+		t.Error("Nil block pair should not be cross-block")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DefUseChain tests
+// ---------------------------------------------------------------------------
+
+func TestDefUseChain_AddDef(t *testing.T) {
+	chain := NewDefUseChain("x")
+	block := cfg.NewBasicBlock("bb0")
+	ref := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+
+	chain.AddDef(ref)
+	chain.AddDef(nil) // should be ignored
+
+	if len(chain.Defs) != 1 {
+		t.Errorf("Expected 1 def, got %d", len(chain.Defs))
+	}
+	if chain.Defs[0] != ref {
+		t.Error("Def mismatch")
+	}
+}
+
+func TestDefUseChain_AddUse(t *testing.T) {
+	chain := NewDefUseChain("x")
+	block := cfg.NewBasicBlock("bb0")
+	ref := NewVarReference("x", UseKindLoad, block, "print(x)", 0)
+
+	chain.AddUse(ref)
+	chain.AddUse(nil) // should be ignored
+
+	if len(chain.Uses) != 1 {
+		t.Errorf("Expected 1 use, got %d", len(chain.Uses))
+	}
+	if chain.Uses[0] != ref {
+		t.Error("Use mismatch")
+	}
+}
+
+func TestDefUseChain_AddPair(t *testing.T) {
+	chain := NewDefUseChain("x")
+	block := cfg.NewBasicBlock("bb0")
+	def := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block, "print(x)", 1)
+	pair := NewDefUsePair(def, use)
+
+	chain.AddPair(pair)
+	chain.AddPair(nil) // should be ignored
+
+	if len(chain.Pairs) != 1 {
+		t.Errorf("Expected 1 pair, got %d", len(chain.Pairs))
+	}
+	if chain.Pairs[0] != pair {
+		t.Error("Pair mismatch")
+	}
+}
+
+func TestNewDefUseChain(t *testing.T) {
+	chain := NewDefUseChain("y")
+	if chain.Variable != "y" {
+		t.Errorf("Variable = %q, want %q", chain.Variable, "y")
+	}
+	if len(chain.Defs) != 0 {
+		t.Error("Expected empty defs")
+	}
+	if len(chain.Uses) != 0 {
+		t.Error("Expected empty uses")
+	}
+	if len(chain.Pairs) != 0 {
+		t.Error("Expected empty pairs")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DFAInfo tests
+// ---------------------------------------------------------------------------
+
+func TestDFAInfo_AddDef(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block := cfg.NewBasicBlock("bb0")
+	ref := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	info.AddDef(ref)
+	info.AddDef(nil) // should be ignored
+
+	if info.TotalDefs() != 1 {
+		t.Errorf("TotalDefs = %d, want 1", info.TotalDefs())
+	}
+	if len(info.BlockDefs["bb0"]) != 1 {
+		t.Errorf("BlockDefs[bb0] = %d, want 1", len(info.BlockDefs["bb0"]))
+	}
+}
+
+func TestDFAInfo_AddUse(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block := cfg.NewBasicBlock("bb0")
+	ref := NewVarReference("x", UseKindLoad, block, "print(x)", 0)
+	info.AddUse(ref)
+	info.AddUse(nil) // should be ignored
+
+	if info.TotalUses() != 1 {
+		t.Errorf("TotalUses = %d, want 1", info.TotalUses())
+	}
+	if len(info.BlockUses["bb0"]) != 1 {
+		t.Errorf("BlockUses[bb0] = %d, want 1", len(info.BlockUses["bb0"]))
+	}
+}
+
+func TestDFAInfo_AddDef_NilBlock(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	ref := NewVarReference("x", DefKindAssign, nil, "x = 1", 0)
+	info.AddDef(ref)
+
+	if info.TotalDefs() != 1 {
+		t.Errorf("TotalDefs = %d, want 1", info.TotalDefs())
+	}
+	// Should not have any block defs since block is nil
+	if len(info.BlockDefs) != 0 {
+		t.Errorf("Expected no BlockDefs entries, got %d", len(info.BlockDefs))
+	}
+}
+
+func TestDFAInfo_GetChain(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	chain := info.GetChain("x")
+	if chain == nil {
+		t.Fatal("Expected non-nil chain")
+	}
+	if chain.Variable != "x" {
+		t.Errorf("Variable = %q, want %q", chain.Variable, "x")
+	}
+
+	// Getting the same variable returns the same chain
+	chain2 := info.GetChain("x")
+	if chain2 != chain {
+		t.Error("GetChain should return the same chain for the same variable")
+	}
+}
+
+func TestDFAInfo_UniqueVariables(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block := cfg.NewBasicBlock("bb0")
+	info.AddDef(NewVarReference("x", DefKindAssign, block, "x = 1", 0))
+	info.AddDef(NewVarReference("y", DefKindAssign, block, "y = 2", 1))
+	info.AddUse(NewVarReference("x", UseKindLoad, block, "print(x)", 2))
+
+	if info.UniqueVariables() != 2 {
+		t.Errorf("UniqueVariables = %d, want 2", info.UniqueVariables())
+	}
+}
+
+func TestDFAInfo_TotalPairs(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	if info.TotalPairs() != 0 {
+		t.Errorf("Empty TotalPairs = %d, want 0", info.TotalPairs())
+	}
+
+	block := cfg.NewBasicBlock("bb0")
+	def := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block, "print(x)", 1)
+	chain := info.GetChain("x")
+	chain.AddDef(def)
+	chain.AddUse(use)
+	chain.AddPair(NewDefUsePair(def, use))
+
+	if info.TotalPairs() != 1 {
+		t.Errorf("TotalPairs = %d, want 1", info.TotalPairs())
+	}
+}
+
+func TestNewDFAInfo(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	if info.CFG != c {
+		t.Error("CFG mismatch")
+	}
+	if info.TotalDefs() != 0 {
+		t.Errorf("TotalDefs = %d, want 0", info.TotalDefs())
+	}
+	if info.TotalUses() != 0 {
+		t.Errorf("TotalUses = %d, want 0", info.TotalUses())
+	}
+	if info.UniqueVariables() != 0 {
+		t.Errorf("UniqueVariables = %d, want 0", info.UniqueVariables())
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DFAFeatures tests
+// ---------------------------------------------------------------------------
+
+func TestExtractDFAFeatures_Nil(t *testing.T) {
+	features := ExtractDFAFeatures(nil)
+	if features.PairCount != 0 {
+		t.Errorf("PairCount = %d, want 0", features.PairCount)
+	}
+	if features.AvgChainLength != 0 {
+		t.Errorf("AvgChainLength = %f, want 0", features.AvgChainLength)
+	}
+	if features.CrossBlockRatio != 0 {
+		t.Errorf("CrossBlockRatio = %f, want 0", features.CrossBlockRatio)
+	}
+}
+
+func TestExtractDFAFeatures_Empty(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+	features := ExtractDFAFeatures(info)
+
+	if features.PairCount != 0 {
+		t.Errorf("PairCount = %d, want 0", features.PairCount)
+	}
+	if features.AvgChainLength != 0 {
+		t.Errorf("AvgChainLength = %f, want 0", features.AvgChainLength)
+	}
+}
+
+func TestExtractDFAFeatures_IntraBlock(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block := cfg.NewBasicBlock("bb0")
+	def := NewVarReference("x", DefKindAssign, block, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block, "print(x)", 1)
+	info.AddDef(def)
+	info.AddUse(use)
+
+	chain := info.GetChain("x")
+	chain.AddPair(NewDefUsePair(def, use))
+
+	features := ExtractDFAFeatures(info)
+	if features.PairCount != 1 {
+		t.Errorf("PairCount = %d, want 1", features.PairCount)
+	}
+	if features.CrossBlockRatio != 0 {
+		t.Errorf("CrossBlockRatio = %f, want 0 (intra-block pair)", features.CrossBlockRatio)
+	}
+	// chain length: 1 def + 1 use = 2, 1 chain => avg = 2.0
+	if features.AvgChainLength != 2.0 {
+		t.Errorf("AvgChainLength = %f, want 2.0", features.AvgChainLength)
+	}
+	if features.DefKindDist[DefKindAssign] != 1 {
+		t.Errorf("DefKindDist[assign] = %d, want 1", features.DefKindDist[DefKindAssign])
+	}
+	if features.UseKindDist[UseKindLoad] != 1 {
+		t.Errorf("UseKindDist[load] = %d, want 1", features.UseKindDist[UseKindLoad])
+	}
+}
+
+func TestExtractDFAFeatures_CrossBlock(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block1 := cfg.NewBasicBlock("bb0")
+	block2 := cfg.NewBasicBlock("bb1")
+	def := NewVarReference("x", DefKindAssign, block1, "x = 1", 0)
+	use := NewVarReference("x", UseKindLoad, block2, "print(x)", 0)
+	info.AddDef(def)
+	info.AddUse(use)
+
+	chain := info.GetChain("x")
+	chain.AddPair(NewDefUsePair(def, use))
+
+	features := ExtractDFAFeatures(info)
+	if features.CrossBlockRatio != 1.0 {
+		t.Errorf("CrossBlockRatio = %f, want 1.0", features.CrossBlockRatio)
+	}
+}
+
+func TestExtractDFAFeatures_MultipleVariables(t *testing.T) {
+	c := cfg.NewCFG("test")
+	info := NewDFAInfo(c)
+
+	block := cfg.NewBasicBlock("bb0")
+	info.AddDef(NewVarReference("x", DefKindAssign, block, "x = 1", 0))
+	info.AddDef(NewVarReference("y", DefKindParam, block, "y param", 1))
+	info.AddUse(NewVarReference("x", UseKindCall, block, "x()", 2))
+	info.AddUse(NewVarReference("y", UseKindAttribute, block, "y.attr", 3))
+
+	features := ExtractDFAFeatures(info)
+	// 2 variables, each with 1 def + 1 use = 2 refs => avg = 2.0
+	if features.AvgChainLength != 2.0 {
+		t.Errorf("AvgChainLength = %f, want 2.0", features.AvgChainLength)
+	}
+	if features.DefKindDist[DefKindAssign] != 1 {
+		t.Errorf("DefKindDist[assign] = %d, want 1", features.DefKindDist[DefKindAssign])
+	}
+	if features.DefKindDist[DefKindParam] != 1 {
+		t.Errorf("DefKindDist[param] = %d, want 1", features.DefKindDist[DefKindParam])
+	}
+	if features.UseKindDist[UseKindCall] != 1 {
+		t.Errorf("UseKindDist[call] = %d, want 1", features.UseKindDist[UseKindCall])
+	}
+	if features.UseKindDist[UseKindAttribute] != 1 {
+		t.Errorf("UseKindDist[attribute] = %d, want 1", features.UseKindDist[UseKindAttribute])
+	}
+}
+
+func TestNewDFAFeatures(t *testing.T) {
+	f := NewDFAFeatures()
+	if f.PairCount != 0 {
+		t.Errorf("PairCount = %d, want 0", f.PairCount)
+	}
+	if f.DefKindDist == nil {
+		t.Error("DefKindDist should not be nil")
+	}
+	if f.UseKindDist == nil {
+		t.Error("UseKindDist should not be nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// DFABuilder tests
+// ---------------------------------------------------------------------------
+
+// testRefExtractor is a simple RefExtractor for testing.
+// It recognizes string statements:
+//   - "x = 1" => definition of "x" (DefKindAssign)
+//   - "print(x)" => use of "x" (UseKindCall)
+type testRefExtractor struct{}
+
+func (e *testRefExtractor) ExtractDefinitions(stmt any, block *cfg.BasicBlock, pos int) []*VarReference {
+	s, ok := stmt.(string)
+	if !ok {
+		return nil
+	}
+	// Pattern: "varname = value"
+	parts := strings.SplitN(s, " = ", 2)
+	if len(parts) == 2 {
+		varName := strings.TrimSpace(parts[0])
+		return []*VarReference{NewVarReference(varName, DefKindAssign, block, stmt, pos)}
+	}
+	return nil
+}
+
+func (e *testRefExtractor) ExtractUses(stmt any, block *cfg.BasicBlock, pos int) []*VarReference {
+	s, ok := stmt.(string)
+	if !ok {
+		return nil
+	}
+	// Pattern: "print(varname)"
+	if strings.HasPrefix(s, "print(") && strings.HasSuffix(s, ")") {
+		varName := s[6 : len(s)-1]
+		return []*VarReference{NewVarReference(varName, UseKindCall, block, stmt, pos)}
+	}
+	return nil
+}
+
+func TestDFABuilder_Build_NilExtractor(t *testing.T) {
+	builder := NewDFABuilder(nil)
+
+	// nil CFG should still succeed (short-circuit before using extractor)
+	info, err := builder.Build(nil)
+	if err != nil {
+		t.Fatalf("Build(nil CFG) with nil extractor should succeed, got: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Expected non-nil DFAInfo for nil CFG")
+	}
+
+	// non-nil CFG should return an error, not panic
+	c := cfg.NewCFG("test")
+	_, err = builder.Build(c)
+	if err == nil {
+		t.Fatal("Build with nil extractor and non-nil CFG should return an error")
+	}
+}
+
+func TestDFABuilder_Build_NilCFG(t *testing.T) {
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(nil)
+	if err != nil {
+		t.Fatalf("Build(nil) error: %v", err)
+	}
+	if info == nil {
+		t.Fatal("Expected non-nil DFAInfo")
+	}
+	if info.TotalDefs() != 0 {
+		t.Errorf("TotalDefs = %d, want 0", info.TotalDefs())
+	}
+}
+
+func TestDFABuilder_Build_EmptyCFG(t *testing.T) {
+	c := cfg.NewCFG("empty")
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+	if info.TotalDefs() != 0 {
+		t.Errorf("TotalDefs = %d, want 0", info.TotalDefs())
+	}
+	if info.TotalUses() != 0 {
+		t.Errorf("TotalUses = %d, want 0", info.TotalUses())
+	}
+}
+
+func TestDFABuilder_Build_SameBlockDefUse(t *testing.T) {
+	// CFG: entry -> block1 -> exit
+	// block1: "x = 1", "print(x)"
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block1.AddStatement("x = 1")
+	block1.AddStatement("print(x)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalDefs() != 1 {
+		t.Errorf("TotalDefs = %d, want 1", info.TotalDefs())
+	}
+	if info.TotalUses() != 1 {
+		t.Errorf("TotalUses = %d, want 1", info.TotalUses())
+	}
+	if info.UniqueVariables() != 1 {
+		t.Errorf("UniqueVariables = %d, want 1", info.UniqueVariables())
+	}
+	if info.TotalPairs() != 1 {
+		t.Errorf("TotalPairs = %d, want 1", info.TotalPairs())
+	}
+
+	chain := info.GetChain("x")
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("Expected 1 pair for x, got %d", len(chain.Pairs))
+	}
+	pair := chain.Pairs[0]
+	if pair.IsCrossBlock() {
+		t.Error("Same-block pair should not be cross-block")
+	}
+	if pair.Def.Position != 0 {
+		t.Errorf("Def position = %d, want 0", pair.Def.Position)
+	}
+	if pair.Use.Position != 1 {
+		t.Errorf("Use position = %d, want 1", pair.Use.Position)
+	}
+}
+
+func TestDFABuilder_Build_CrossBlockDefUse(t *testing.T) {
+	// CFG: entry -> block1 -> block2 -> exit
+	// block1: "x = 1"
+	// block2: "print(x)"
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block2 := c.CreateBlock("block2")
+	block1.AddStatement("x = 1")
+	block2.AddStatement("print(x)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, block2, cfg.EdgeNormal)
+	c.ConnectBlocks(block2, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalDefs() != 1 {
+		t.Errorf("TotalDefs = %d, want 1", info.TotalDefs())
+	}
+	if info.TotalUses() != 1 {
+		t.Errorf("TotalUses = %d, want 1", info.TotalUses())
+	}
+	if info.TotalPairs() != 1 {
+		t.Errorf("TotalPairs = %d, want 1", info.TotalPairs())
+	}
+
+	chain := info.GetChain("x")
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("Expected 1 pair for x, got %d", len(chain.Pairs))
+	}
+	pair := chain.Pairs[0]
+	if !pair.IsCrossBlock() {
+		t.Error("Cross-block pair should be cross-block")
+	}
+}
+
+func TestDFABuilder_Build_MultipleVariables(t *testing.T) {
+	// CFG: entry -> block1 -> block2 -> exit
+	// block1: "x = 1", "y = 2"
+	// block2: "print(x)", "print(y)"
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block2 := c.CreateBlock("block2")
+	block1.AddStatement("x = 1")
+	block1.AddStatement("y = 2")
+	block2.AddStatement("print(x)")
+	block2.AddStatement("print(y)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, block2, cfg.EdgeNormal)
+	c.ConnectBlocks(block2, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalDefs() != 2 {
+		t.Errorf("TotalDefs = %d, want 2", info.TotalDefs())
+	}
+	if info.TotalUses() != 2 {
+		t.Errorf("TotalUses = %d, want 2", info.TotalUses())
+	}
+	if info.UniqueVariables() != 2 {
+		t.Errorf("UniqueVariables = %d, want 2", info.UniqueVariables())
+	}
+	if info.TotalPairs() != 2 {
+		t.Errorf("TotalPairs = %d, want 2", info.TotalPairs())
+	}
+}
+
+func TestDFABuilder_Build_RedefInBlock(t *testing.T) {
+	// block1: "x = 1", "x = 2", "print(x)"
+	// The use should link to the second (later) definition.
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block1.AddStatement("x = 1")
+	block1.AddStatement("x = 2")
+	block1.AddStatement("print(x)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalDefs() != 2 {
+		t.Errorf("TotalDefs = %d, want 2", info.TotalDefs())
+	}
+
+	chain := info.GetChain("x")
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("Expected 1 pair, got %d", len(chain.Pairs))
+	}
+	// Should link to the second definition (position 1)
+	if chain.Pairs[0].Def.Position != 1 {
+		t.Errorf("Reaching def position = %d, want 1 (latest def before use)", chain.Pairs[0].Def.Position)
+	}
+}
+
+func TestDFABuilder_Build_NoDefForUse(t *testing.T) {
+	// block1: "print(x)" — no definition of x exists
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block1.AddStatement("print(x)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalUses() != 1 {
+		t.Errorf("TotalUses = %d, want 1", info.TotalUses())
+	}
+	if info.TotalPairs() != 0 {
+		t.Errorf("TotalPairs = %d, want 0 (no reaching def)", info.TotalPairs())
+	}
+}
+
+func TestDFABuilder_Build_PredecessorChain(t *testing.T) {
+	// entry -> block1 -> block2 -> block3 -> exit
+	// block1: "x = 1"
+	// block2: (empty)
+	// block3: "print(x)"
+	// The BFS should traverse through block2 to find x's def in block1.
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block2 := c.CreateBlock("block2")
+	block3 := c.CreateBlock("block3")
+	block1.AddStatement("x = 1")
+	block3.AddStatement("print(x)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, block2, cfg.EdgeNormal)
+	c.ConnectBlocks(block2, block3, cfg.EdgeNormal)
+	c.ConnectBlocks(block3, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	if info.TotalPairs() != 1 {
+		t.Errorf("TotalPairs = %d, want 1", info.TotalPairs())
+	}
+
+	chain := info.GetChain("x")
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("Expected 1 pair, got %d", len(chain.Pairs))
+	}
+	if !chain.Pairs[0].IsCrossBlock() {
+		t.Error("Expected cross-block pair")
+	}
+}
+
+func TestDFABuilder_Build_FeatureExtraction(t *testing.T) {
+	// Integration test: build DFA then extract features
+	c := cfg.NewCFG("test")
+	block1 := c.CreateBlock("block1")
+	block2 := c.CreateBlock("block2")
+	block1.AddStatement("x = 1")
+	block1.AddStatement("y = 2")
+	block2.AddStatement("print(x)")
+	block2.AddStatement("print(y)")
+	c.ConnectBlocks(c.Entry, block1, cfg.EdgeNormal)
+	c.ConnectBlocks(block1, block2, cfg.EdgeNormal)
+	c.ConnectBlocks(block2, c.Exit, cfg.EdgeNormal)
+
+	builder := NewDFABuilder(&testRefExtractor{})
+	info, err := builder.Build(c)
+	if err != nil {
+		t.Fatalf("Build error: %v", err)
+	}
+
+	features := ExtractDFAFeatures(info)
+	if features.PairCount != 2 {
+		t.Errorf("PairCount = %d, want 2", features.PairCount)
+	}
+	if features.CrossBlockRatio != 1.0 {
+		t.Errorf("CrossBlockRatio = %f, want 1.0 (all cross-block)", features.CrossBlockRatio)
+	}
+	// 2 variables, each with 1 def + 1 use = 2 => avg = 2.0
+	if features.AvgChainLength != 2.0 {
+		t.Errorf("AvgChainLength = %f, want 2.0", features.AvgChainLength)
+	}
+	if features.DefKindDist[DefKindAssign] != 2 {
+		t.Errorf("DefKindDist[assign] = %d, want 2", features.DefKindDist[DefKindAssign])
+	}
+	if features.UseKindDist[UseKindCall] != 2 {
+		t.Errorf("UseKindDist[call] = %d, want 2", features.UseKindDist[UseKindCall])
+	}
+}

--- a/domain/defaults.go
+++ b/domain/defaults.go
@@ -1,0 +1,68 @@
+package domain
+
+// Clone type thresholds (similarity score 0.0-1.0).
+const (
+	DefaultType1CloneThreshold = 0.85
+	DefaultType2CloneThreshold = 0.80
+	DefaultType3CloneThreshold = 0.70
+	DefaultType4CloneThreshold = 0.65
+)
+
+// DFA feature weights for similarity comparison.
+const (
+	DefaultDFAPairCountWeight   = 0.25
+	DefaultDFAChainLengthWeight = 0.20
+	DefaultDFACrossBlockWeight  = 0.20
+	DefaultDFADefKindWeight     = 0.20
+	DefaultDFAUseKindWeight     = 0.15
+)
+
+// CFG/DFA combined weights for semantic similarity.
+const (
+	DefaultCFGFeatureWeight = 0.60
+	DefaultDFAFeatureWeight = 0.40
+)
+
+// Complexity thresholds for risk assessment.
+const (
+	DefaultComplexityLowThreshold    = 9
+	DefaultComplexityMediumThreshold = 19
+)
+
+// CBO (Coupling Between Objects) thresholds.
+const (
+	DefaultCBOLowThreshold    = 3
+	DefaultCBOMediumThreshold = 7
+)
+
+// LCOM (Lack of Cohesion of Methods) thresholds.
+const (
+	DefaultLCOMLowThreshold    = 2
+	DefaultLCOMMediumThreshold = 5
+)
+
+// Clone detection parameters.
+const (
+	DefaultCloneMinLines             = 10
+	DefaultCloneMinNodes             = 20
+	DefaultCloneMaxEditDistance       = 50.0
+	DefaultCloneSimilarityThreshold  = 0.65
+	DefaultCloneGroupingThreshold    = 0.65
+)
+
+// LSH (Locality-Sensitive Hashing) parameters.
+const (
+	DefaultLSHAutoThreshold       = 500
+	DefaultLSHSimilarityThreshold = 0.50
+	DefaultLSHBands               = 32
+	DefaultLSHRows                = 4
+	DefaultLSHHashes              = 128
+)
+
+// Performance parameters.
+const (
+	DefaultMaxMemoryMB    = 100
+	DefaultBatchSize      = 100
+	DefaultMaxGoroutines  = 4
+	DefaultTimeoutSeconds = 300
+)

--- a/domain/errors.go
+++ b/domain/errors.go
@@ -1,0 +1,104 @@
+package domain
+
+import "fmt"
+
+// Error code constants for domain errors.
+const (
+	ErrCodeInvalidInput      = "INVALID_INPUT"
+	ErrCodeFileNotFound      = "FILE_NOT_FOUND"
+	ErrCodeParseError        = "PARSE_ERROR"
+	ErrCodeAnalysisError     = "ANALYSIS_ERROR"
+	ErrCodeConfigError       = "CONFIG_ERROR"
+	ErrCodeOutputError       = "OUTPUT_ERROR"
+	ErrCodeUnsupportedFormat = "UNSUPPORTED_FORMAT"
+	ErrCodeValidation        = "VALIDATION_ERROR"
+	ErrCodeTimeout           = "TIMEOUT"
+	ErrCodeCancelled         = "CANCELLED"
+	ErrCodeNotImplemented    = "NOT_IMPLEMENTED"
+	ErrCodeInternal          = "INTERNAL_ERROR"
+)
+
+// DomainError represents a structured error with code, message, and optional cause.
+type DomainError struct {
+	Code    string
+	Message string
+	Cause   error
+}
+
+// Error implements the error interface.
+func (e *DomainError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("[%s] %s: %v", e.Code, e.Message, e.Cause)
+	}
+	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+// Unwrap returns the underlying cause for errors.Is/As support.
+func (e *DomainError) Unwrap() error {
+	return e.Cause
+}
+
+// NewDomainError creates a new DomainError with the given code, message, and optional cause.
+func NewDomainError(code, message string, cause error) *DomainError {
+	return &DomainError{Code: code, Message: message, Cause: cause}
+}
+
+// NewInvalidInputError creates an error for invalid input.
+func NewInvalidInputError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeInvalidInput, message, cause)
+}
+
+// NewFileNotFoundError creates an error for missing files.
+func NewFileNotFoundError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeFileNotFound, message, cause)
+}
+
+// NewParseError creates an error for parse failures.
+func NewParseError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeParseError, message, cause)
+}
+
+// NewAnalysisError creates an error for analysis failures.
+func NewAnalysisError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeAnalysisError, message, cause)
+}
+
+// NewConfigError creates an error for configuration issues.
+func NewConfigError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeConfigError, message, cause)
+}
+
+// NewOutputError creates an error for output failures.
+func NewOutputError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeOutputError, message, cause)
+}
+
+// NewUnsupportedFormatError creates an error for unsupported formats.
+func NewUnsupportedFormatError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeUnsupportedFormat, message, cause)
+}
+
+// NewValidationError creates an error for validation failures.
+func NewValidationError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeValidation, message, cause)
+}
+
+// NewTimeoutError creates an error for timeout conditions.
+func NewTimeoutError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeTimeout, message, cause)
+}
+
+// NewCancelledError creates an error for cancelled operations.
+func NewCancelledError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeCancelled, message, cause)
+}
+
+// NewNotImplementedError creates an error for unimplemented features.
+func NewNotImplementedError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeNotImplemented, message, cause)
+}
+
+// NewInternalError creates an error for internal failures.
+func NewInternalError(message string, cause error) *DomainError {
+	return NewDomainError(ErrCodeInternal, message, cause)
+}

--- a/domain/errors_test.go
+++ b/domain/errors_test.go
@@ -1,0 +1,75 @@
+package domain
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+func TestDomainError_Error(t *testing.T) {
+	err := NewDomainError(ErrCodeInvalidInput, "bad input", nil)
+	got := err.Error()
+	if !strings.Contains(got, ErrCodeInvalidInput) {
+		t.Errorf("expected error code %q in %q", ErrCodeInvalidInput, got)
+	}
+	if !strings.Contains(got, "bad input") {
+		t.Errorf("expected message in error string")
+	}
+}
+
+func TestDomainError_ErrorWithCause(t *testing.T) {
+	cause := errors.New("underlying")
+	err := NewDomainError(ErrCodeParseError, "parse failed", cause)
+	got := err.Error()
+	if !strings.Contains(got, "underlying") {
+		t.Errorf("expected cause in error string: %q", got)
+	}
+}
+
+func TestDomainError_Unwrap(t *testing.T) {
+	cause := errors.New("root cause")
+	err := NewDomainError(ErrCodeInternal, "internal", cause)
+	if !errors.Is(err, cause) {
+		t.Errorf("Unwrap should return the cause")
+	}
+}
+
+func TestDomainError_UnwrapNil(t *testing.T) {
+	err := NewDomainError(ErrCodeInternal, "internal", nil)
+	if err.Unwrap() != nil {
+		t.Errorf("Unwrap should return nil when no cause")
+	}
+}
+
+func TestErrorConstructors(t *testing.T) {
+	tests := []struct {
+		name     string
+		fn       func(string, error) *DomainError
+		wantCode string
+	}{
+		{"InvalidInput", NewInvalidInputError, ErrCodeInvalidInput},
+		{"FileNotFound", NewFileNotFoundError, ErrCodeFileNotFound},
+		{"ParseError", NewParseError, ErrCodeParseError},
+		{"AnalysisError", NewAnalysisError, ErrCodeAnalysisError},
+		{"ConfigError", NewConfigError, ErrCodeConfigError},
+		{"OutputError", NewOutputError, ErrCodeOutputError},
+		{"UnsupportedFormat", NewUnsupportedFormatError, ErrCodeUnsupportedFormat},
+		{"Validation", NewValidationError, ErrCodeValidation},
+		{"Timeout", NewTimeoutError, ErrCodeTimeout},
+		{"Cancelled", NewCancelledError, ErrCodeCancelled},
+		{"NotImplemented", NewNotImplementedError, ErrCodeNotImplemented},
+		{"Internal", NewInternalError, ErrCodeInternal},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := tt.fn("test message", nil)
+			if err.Code != tt.wantCode {
+				t.Errorf("got code %q, want %q", err.Code, tt.wantCode)
+			}
+			if err.Message != "test message" {
+				t.Errorf("got message %q, want %q", err.Message, "test message")
+			}
+		})
+	}
+}

--- a/domain/types.go
+++ b/domain/types.go
@@ -1,0 +1,80 @@
+package domain
+
+import "fmt"
+
+// RiskLevel represents the risk level of a metric.
+type RiskLevel string
+
+const (
+	RiskLevelLow    RiskLevel = "low"
+	RiskLevelMedium RiskLevel = "medium"
+	RiskLevelHigh   RiskLevel = "high"
+)
+
+// OutputFormat represents an output format type.
+type OutputFormat string
+
+const (
+	OutputFormatText OutputFormat = "text"
+	OutputFormatJSON OutputFormat = "json"
+	OutputFormatYAML OutputFormat = "yaml"
+	OutputFormatCSV  OutputFormat = "csv"
+	OutputFormatHTML OutputFormat = "html"
+	OutputFormatDOT  OutputFormat = "dot"
+)
+
+// SortCriteria represents a sorting criterion for results.
+type SortCriteria string
+
+const (
+	SortByComplexity SortCriteria = "complexity"
+	SortByName       SortCriteria = "name"
+	SortByRisk       SortCriteria = "risk"
+	SortBySimilarity SortCriteria = "similarity"
+	SortBySize       SortCriteria = "size"
+	SortByLocation   SortCriteria = "location"
+	SortByCoupling   SortCriteria = "coupling"
+	SortByCohesion   SortCriteria = "cohesion"
+)
+
+// CloneType represents the type of code clone (Type-1 through Type-4).
+type CloneType int
+
+const (
+	Type1Clone CloneType = 1 // Exact clones (identical except whitespace/comments)
+	Type2Clone CloneType = 2 // Renamed/parameterized clones
+	Type3Clone CloneType = 3 // Near-miss clones (statements added/removed)
+	Type4Clone CloneType = 4 // Semantic clones (different syntax, same behavior)
+)
+
+// String returns the string representation of a CloneType.
+func (ct CloneType) String() string {
+	switch ct {
+	case Type1Clone:
+		return "Type-1"
+	case Type2Clone:
+		return "Type-2"
+	case Type3Clone:
+		return "Type-3"
+	case Type4Clone:
+		return "Type-4"
+	default:
+		return fmt.Sprintf("Unknown(%d)", int(ct))
+	}
+}
+
+// CloneTypeNames maps clone types to their short names.
+var CloneTypeNames = map[CloneType]string{
+	Type1Clone: "Exact",
+	Type2Clone: "Renamed",
+	Type3Clone: "Near-miss",
+	Type4Clone: "Semantic",
+}
+
+// CloneTypeDescriptions maps clone types to their descriptions.
+var CloneTypeDescriptions = map[CloneType]string{
+	Type1Clone: "Identical code fragments except for whitespace and comments",
+	Type2Clone: "Structurally identical with renamed identifiers or changed literals",
+	Type3Clone: "Near-miss clones with added, removed, or modified statements",
+	Type4Clone: "Semantically similar code with different syntactic structure",
+}

--- a/domain/types_test.go
+++ b/domain/types_test.go
@@ -1,0 +1,78 @@
+package domain
+
+import "testing"
+
+func TestCloneType_String(t *testing.T) {
+	tests := []struct {
+		ct   CloneType
+		want string
+	}{
+		{Type1Clone, "Type-1"},
+		{Type2Clone, "Type-2"},
+		{Type3Clone, "Type-3"},
+		{Type4Clone, "Type-4"},
+		{CloneType(99), "Unknown(99)"},
+	}
+	for _, tt := range tests {
+		got := tt.ct.String()
+		if got != tt.want {
+			t.Errorf("CloneType(%d).String() = %q, want %q", int(tt.ct), got, tt.want)
+		}
+	}
+}
+
+func TestCloneTypeNames(t *testing.T) {
+	if len(CloneTypeNames) != 4 {
+		t.Errorf("expected 4 clone type names, got %d", len(CloneTypeNames))
+	}
+	if CloneTypeNames[Type1Clone] != "Exact" {
+		t.Errorf("Type1Clone name = %q, want %q", CloneTypeNames[Type1Clone], "Exact")
+	}
+}
+
+func TestCloneTypeDescriptions(t *testing.T) {
+	if len(CloneTypeDescriptions) != 4 {
+		t.Errorf("expected 4 clone type descriptions, got %d", len(CloneTypeDescriptions))
+	}
+	for ct, desc := range CloneTypeDescriptions {
+		if desc == "" {
+			t.Errorf("CloneType %d has empty description", int(ct))
+		}
+	}
+}
+
+func TestRiskLevelValues(t *testing.T) {
+	if RiskLevelLow != "low" {
+		t.Errorf("RiskLevelLow = %q", RiskLevelLow)
+	}
+	if RiskLevelMedium != "medium" {
+		t.Errorf("RiskLevelMedium = %q", RiskLevelMedium)
+	}
+	if RiskLevelHigh != "high" {
+		t.Errorf("RiskLevelHigh = %q", RiskLevelHigh)
+	}
+}
+
+func TestOutputFormatValues(t *testing.T) {
+	formats := []OutputFormat{
+		OutputFormatText, OutputFormatJSON, OutputFormatYAML,
+		OutputFormatCSV, OutputFormatHTML, OutputFormatDOT,
+	}
+	for _, f := range formats {
+		if f == "" {
+			t.Errorf("empty output format")
+		}
+	}
+}
+
+func TestSortCriteriaValues(t *testing.T) {
+	criteria := []SortCriteria{
+		SortByComplexity, SortByName, SortByRisk, SortBySimilarity,
+		SortBySize, SortByLocation, SortByCoupling, SortByCohesion,
+	}
+	for _, c := range criteria {
+		if c == "" {
+			t.Errorf("empty sort criteria")
+		}
+	}
+}

--- a/lcom/lcom.go
+++ b/lcom/lcom.go
@@ -1,0 +1,173 @@
+package lcom
+
+import (
+	"sort"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+// MethodAccess describes a method and which instance variables it accesses.
+type MethodAccess struct {
+	MethodName   string
+	InstanceVars map[string]bool
+}
+
+// Result holds the LCOM4 analysis result for a class.
+type Result struct {
+	ClassName         string
+	FilePath          string
+	StartLine         int
+	EndLine           int
+	LCOM4             int
+	TotalMethods      int
+	ExcludedMethods   int
+	InstanceVariables []string
+	MethodGroups      [][]string
+	RiskLevel         domain.RiskLevel
+}
+
+// Config holds configuration for LCOM analysis.
+type Config struct {
+	LowThreshold    int
+	MediumThreshold int
+}
+
+// DefaultConfig returns the default LCOM configuration.
+func DefaultConfig() Config {
+	return Config{
+		LowThreshold:    domain.DefaultLCOMLowThreshold,
+		MediumThreshold: domain.DefaultLCOMMediumThreshold,
+	}
+}
+
+// ComputeLCOM4 computes the LCOM4 metric using the Union-Find algorithm.
+// LCOM4 counts the number of connected components among methods,
+// where two methods are connected if they share at least one instance variable.
+func ComputeLCOM4(methods []MethodAccess, config Config) *Result {
+	result := &Result{
+		MethodGroups: [][]string{},
+	}
+
+	if len(methods) == 0 {
+		result.LCOM4 = 0
+		result.RiskLevel = AssessRisk(0, config)
+		return result
+	}
+
+	// Sort method names for deterministic output
+	sortedMethods := make([]MethodAccess, len(methods))
+	copy(sortedMethods, methods)
+	sort.Slice(sortedMethods, func(i, j int) bool {
+		return sortedMethods[i].MethodName < sortedMethods[j].MethodName
+	})
+
+	result.TotalMethods = len(sortedMethods)
+
+	// Collect all instance variables
+	allVars := make(map[string]bool)
+	for _, m := range sortedMethods {
+		for v := range m.InstanceVars {
+			allVars[v] = true
+		}
+	}
+	varList := make([]string, 0, len(allVars))
+	for v := range allVars {
+		varList = append(varList, v)
+	}
+	sort.Strings(varList)
+	result.InstanceVariables = varList
+
+	// If only one method, LCOM4 = 1
+	if len(sortedMethods) == 1 {
+		result.LCOM4 = 1
+		result.MethodGroups = [][]string{{sortedMethods[0].MethodName}}
+		result.RiskLevel = AssessRisk(1, config)
+		return result
+	}
+
+	// Union-Find
+	n := len(sortedMethods)
+	parent := make([]int, n)
+	rank := make([]int, n)
+	for i := range parent {
+		parent[i] = i
+	}
+
+	var find func(int) int
+	find = func(x int) int {
+		if parent[x] != x {
+			parent[x] = find(parent[x]) // path compression
+		}
+		return parent[x]
+	}
+
+	union := func(x, y int) {
+		rx, ry := find(x), find(y)
+		if rx == ry {
+			return
+		}
+		if rank[rx] < rank[ry] {
+			parent[rx] = ry
+		} else if rank[rx] > rank[ry] {
+			parent[ry] = rx
+		} else {
+			parent[ry] = rx
+			rank[rx]++
+		}
+	}
+
+	// Build variable -> method indices mapping
+	varToMethods := make(map[string][]int)
+	for i, m := range sortedMethods {
+		for v := range m.InstanceVars {
+			varToMethods[v] = append(varToMethods[v], i)
+		}
+	}
+
+	// Union methods that share variables
+	for _, indices := range varToMethods {
+		for k := 1; k < len(indices); k++ {
+			union(indices[0], indices[k])
+		}
+	}
+
+	// Count connected components and build method groups
+	components := make(map[int][]int) // root -> list of method indices
+	for i := range sortedMethods {
+		root := find(i)
+		components[root] = append(components[root], i)
+	}
+
+	// Sort component roots for deterministic output
+	roots := make([]int, 0, len(components))
+	for r := range components {
+		roots = append(roots, r)
+	}
+	sort.Ints(roots)
+
+	result.LCOM4 = len(components)
+	result.MethodGroups = make([][]string, 0, len(components))
+	for _, root := range roots {
+		indices := components[root]
+		group := make([]string, len(indices))
+		for i, idx := range indices {
+			group[i] = sortedMethods[idx].MethodName
+		}
+		sort.Strings(group)
+		result.MethodGroups = append(result.MethodGroups, group)
+	}
+
+	result.RiskLevel = AssessRisk(result.LCOM4, config)
+	return result
+}
+
+// AssessRisk determines the risk level based on LCOM4 and config thresholds.
+func AssessRisk(lcom4 int, config Config) domain.RiskLevel {
+	if lcom4 <= config.LowThreshold {
+		return domain.RiskLevelLow
+	}
+	if lcom4 <= config.MediumThreshold {
+		return domain.RiskLevelMedium
+	}
+	return domain.RiskLevelHigh
+}

--- a/lcom/lcom_test.go
+++ b/lcom/lcom_test.go
@@ -1,0 +1,227 @@
+package lcom
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+func TestComputeLCOM4_EmptyMethods(t *testing.T) {
+	result := ComputeLCOM4(nil, DefaultConfig())
+	if result.LCOM4 != 0 {
+		t.Errorf("LCOM4 = %d, want 0", result.LCOM4)
+	}
+	if result.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("RiskLevel = %q, want %q", result.RiskLevel, domain.RiskLevelLow)
+	}
+	if result.TotalMethods != 0 {
+		t.Errorf("TotalMethods = %d, want 0", result.TotalMethods)
+	}
+	if len(result.MethodGroups) != 0 {
+		t.Errorf("MethodGroups = %v, want empty", result.MethodGroups)
+	}
+}
+
+func TestComputeLCOM4_SingleMethod(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 1 {
+		t.Errorf("LCOM4 = %d, want 1", result.LCOM4)
+	}
+	if result.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("RiskLevel = %q, want %q", result.RiskLevel, domain.RiskLevelLow)
+	}
+	if result.TotalMethods != 1 {
+		t.Errorf("TotalMethods = %d, want 1", result.TotalMethods)
+	}
+	wantGroups := [][]string{{"GetName"}}
+	if !reflect.DeepEqual(result.MethodGroups, wantGroups) {
+		t.Errorf("MethodGroups = %v, want %v", result.MethodGroups, wantGroups)
+	}
+}
+
+func TestComputeLCOM4_TwoMethodsShareVariable(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+		{MethodName: "SetName", InstanceVars: map[string]bool{"name": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 1 {
+		t.Errorf("LCOM4 = %d, want 1", result.LCOM4)
+	}
+	if result.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("RiskLevel = %q, want %q", result.RiskLevel, domain.RiskLevelLow)
+	}
+	wantGroups := [][]string{{"GetName", "SetName"}}
+	if !reflect.DeepEqual(result.MethodGroups, wantGroups) {
+		t.Errorf("MethodGroups = %v, want %v", result.MethodGroups, wantGroups)
+	}
+}
+
+func TestComputeLCOM4_TwoIndependentMethods(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+		{MethodName: "GetAge", InstanceVars: map[string]bool{"age": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 2 {
+		t.Errorf("LCOM4 = %d, want 2", result.LCOM4)
+	}
+	// LCOM4=2 is at the low threshold (<=2), so still low
+	if result.RiskLevel != domain.RiskLevelLow {
+		t.Errorf("RiskLevel = %q, want %q", result.RiskLevel, domain.RiskLevelLow)
+	}
+	if len(result.MethodGroups) != 2 {
+		t.Errorf("len(MethodGroups) = %d, want 2", len(result.MethodGroups))
+	}
+}
+
+func TestComputeLCOM4_ThreeMethodsTwoSharingOneIndependent(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+		{MethodName: "SetName", InstanceVars: map[string]bool{"name": true}},
+		{MethodName: "GetAge", InstanceVars: map[string]bool{"age": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 2 {
+		t.Errorf("LCOM4 = %d, want 2", result.LCOM4)
+	}
+	if result.TotalMethods != 3 {
+		t.Errorf("TotalMethods = %d, want 3", result.TotalMethods)
+	}
+}
+
+func TestComputeLCOM4_MultipleComponents(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+		{MethodName: "GetAge", InstanceVars: map[string]bool{"age": true}},
+		{MethodName: "GetEmail", InstanceVars: map[string]bool{"email": true}},
+		{MethodName: "SetName", InstanceVars: map[string]bool{"name": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	// GetName+SetName share "name" -> 1 component
+	// GetAge alone -> 1 component
+	// GetEmail alone -> 1 component
+	// Total: 3 components
+	if result.LCOM4 != 3 {
+		t.Errorf("LCOM4 = %d, want 3", result.LCOM4)
+	}
+	if result.RiskLevel != domain.RiskLevelMedium {
+		t.Errorf("RiskLevel = %q, want %q", result.RiskLevel, domain.RiskLevelMedium)
+	}
+}
+
+func TestComputeLCOM4_TransitiveConnection(t *testing.T) {
+	// A accesses x,y; B accesses y,z; C accesses z
+	// A-B connected via y, B-C connected via z => all in one component
+	methods := []MethodAccess{
+		{MethodName: "A", InstanceVars: map[string]bool{"x": true, "y": true}},
+		{MethodName: "B", InstanceVars: map[string]bool{"y": true, "z": true}},
+		{MethodName: "C", InstanceVars: map[string]bool{"z": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 1 {
+		t.Errorf("LCOM4 = %d, want 1", result.LCOM4)
+	}
+	wantGroups := [][]string{{"A", "B", "C"}}
+	if !reflect.DeepEqual(result.MethodGroups, wantGroups) {
+		t.Errorf("MethodGroups = %v, want %v", result.MethodGroups, wantGroups)
+	}
+}
+
+func TestAssessRisk_BoundaryValues(t *testing.T) {
+	config := DefaultConfig()
+	tests := []struct {
+		lcom4 int
+		want  domain.RiskLevel
+	}{
+		{0, domain.RiskLevelLow},
+		{1, domain.RiskLevelLow},
+		{2, domain.RiskLevelLow},    // at low threshold
+		{3, domain.RiskLevelMedium}, // just above low threshold
+		{4, domain.RiskLevelMedium},
+		{5, domain.RiskLevelMedium}, // at medium threshold
+		{6, domain.RiskLevelHigh},   // just above medium threshold
+		{10, domain.RiskLevelHigh},
+	}
+	for _, tt := range tests {
+		got := AssessRisk(tt.lcom4, config)
+		if got != tt.want {
+			t.Errorf("AssessRisk(%d) = %q, want %q", tt.lcom4, got, tt.want)
+		}
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+	if config.LowThreshold != domain.DefaultLCOMLowThreshold {
+		t.Errorf("LowThreshold = %d, want %d", config.LowThreshold, domain.DefaultLCOMLowThreshold)
+	}
+	if config.MediumThreshold != domain.DefaultLCOMMediumThreshold {
+		t.Errorf("MediumThreshold = %d, want %d", config.MediumThreshold, domain.DefaultLCOMMediumThreshold)
+	}
+}
+
+func TestComputeLCOM4_MethodGroupsSorted(t *testing.T) {
+	// Supply methods in reverse order to verify sorting
+	methods := []MethodAccess{
+		{MethodName: "Zebra", InstanceVars: map[string]bool{"x": true}},
+		{MethodName: "Alpha", InstanceVars: map[string]bool{"x": true}},
+		{MethodName: "Middle", InstanceVars: map[string]bool{"x": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	if result.LCOM4 != 1 {
+		t.Errorf("LCOM4 = %d, want 1", result.LCOM4)
+	}
+	wantGroups := [][]string{{"Alpha", "Middle", "Zebra"}}
+	if !reflect.DeepEqual(result.MethodGroups, wantGroups) {
+		t.Errorf("MethodGroups = %v, want %v", result.MethodGroups, wantGroups)
+	}
+}
+
+func TestComputeLCOM4_InstanceVariablesCollectedAndSorted(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "A", InstanceVars: map[string]bool{"z": true, "a": true}},
+		{MethodName: "B", InstanceVars: map[string]bool{"m": true, "a": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	wantVars := []string{"a", "m", "z"}
+	if !reflect.DeepEqual(result.InstanceVariables, wantVars) {
+		t.Errorf("InstanceVariables = %v, want %v", result.InstanceVariables, wantVars)
+	}
+}
+
+func TestComputeLCOM4_MethodWithNoVars(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "DoSomething", InstanceVars: map[string]bool{}},
+		{MethodName: "GetName", InstanceVars: map[string]bool{"name": true}},
+	}
+	result := ComputeLCOM4(methods, DefaultConfig())
+	// DoSomething shares no vars with GetName -> 2 components
+	if result.LCOM4 != 2 {
+		t.Errorf("LCOM4 = %d, want 2", result.LCOM4)
+	}
+}
+
+func TestAssessRisk_CustomConfig(t *testing.T) {
+	config := Config{LowThreshold: 1, MediumThreshold: 3}
+	tests := []struct {
+		lcom4 int
+		want  domain.RiskLevel
+	}{
+		{0, domain.RiskLevelLow},
+		{1, domain.RiskLevelLow},
+		{2, domain.RiskLevelMedium},
+		{3, domain.RiskLevelMedium},
+		{4, domain.RiskLevelHigh},
+	}
+	for _, tt := range tests {
+		got := AssessRisk(tt.lcom4, config)
+		if got != tt.want {
+			t.Errorf("AssessRisk(%d, custom) = %q, want %q", tt.lcom4, got, tt.want)
+		}
+	}
+}

--- a/nesting/nesting.go
+++ b/nesting/nesting.go
@@ -1,0 +1,62 @@
+package nesting
+
+// NestingClassifier abstracts the language-specific logic for determining
+// which AST nodes introduce nesting levels. Language adapters implement this
+// to classify their own node types.
+type NestingClassifier interface {
+	// IsNestingNode returns true if the given node introduces a new nesting level
+	// (e.g. if, for, while, with, try blocks).
+	IsNestingNode(node any) bool
+
+	// Children returns the child nodes of the given node.
+	Children(node any) []any
+
+	// Location returns the line number of the given node.
+	Location(node any) int
+}
+
+// Result holds the nesting depth analysis result.
+type Result struct {
+	MaxDepth    int
+	DeepestLine int
+}
+
+// ComputeMaxDepth computes the maximum nesting depth of the given AST tree.
+// It uses the NestingClassifier to determine which nodes increase nesting depth.
+func ComputeMaxDepth(root any, classifier NestingClassifier) *Result {
+	if root == nil || classifier == nil {
+		return &Result{MaxDepth: 0, DeepestLine: 0}
+	}
+
+	result := &Result{MaxDepth: 0, DeepestLine: 0}
+
+	// Start depth at 0 for the root; if root is a nesting node, it starts at 1
+	startDepth := 0
+	if classifier.IsNestingNode(root) {
+		startDepth = 1
+		result.MaxDepth = 1
+		result.DeepestLine = classifier.Location(root)
+	}
+
+	traverseForNesting(root, startDepth, classifier, result)
+	return result
+}
+
+// traverseForNesting recursively traverses the tree to find the maximum nesting depth.
+func traverseForNesting(node any, currentDepth int, classifier NestingClassifier, result *Result) {
+	children := classifier.Children(node)
+	for _, child := range children {
+		if child == nil {
+			continue
+		}
+		childDepth := currentDepth
+		if classifier.IsNestingNode(child) {
+			childDepth++
+		}
+		if childDepth > result.MaxDepth {
+			result.MaxDepth = childDepth
+			result.DeepestLine = classifier.Location(child)
+		}
+		traverseForNesting(child, childDepth, classifier, result)
+	}
+}

--- a/nesting/nesting_test.go
+++ b/nesting/nesting_test.go
@@ -1,0 +1,142 @@
+package nesting
+
+import "testing"
+
+type testNode struct {
+	isNesting bool
+	line      int
+	children  []*testNode
+}
+
+type testClassifier struct{}
+
+func (c *testClassifier) IsNestingNode(node any) bool {
+	if n, ok := node.(*testNode); ok {
+		return n.isNesting
+	}
+	return false
+}
+
+func (c *testClassifier) Children(node any) []any {
+	if n, ok := node.(*testNode); ok {
+		result := make([]any, len(n.children))
+		for i, child := range n.children {
+			result[i] = child
+		}
+		return result
+	}
+	return nil
+}
+
+func (c *testClassifier) Location(node any) int {
+	if n, ok := node.(*testNode); ok {
+		return n.line
+	}
+	return 0
+}
+
+func TestNilRoot(t *testing.T) {
+	cls := &testClassifier{}
+	result := ComputeMaxDepth(nil, cls)
+	if result.MaxDepth != 0 {
+		t.Errorf("expected MaxDepth 0, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 0 {
+		t.Errorf("expected DeepestLine 0, got %d", result.DeepestLine)
+	}
+}
+
+func TestNilClassifier(t *testing.T) {
+	root := &testNode{isNesting: false, line: 1}
+	result := ComputeMaxDepth(root, nil)
+	if result.MaxDepth != 0 {
+		t.Errorf("expected MaxDepth 0, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 0 {
+		t.Errorf("expected DeepestLine 0, got %d", result.DeepestLine)
+	}
+}
+
+func TestSingleNonNestingNode(t *testing.T) {
+	cls := &testClassifier{}
+	root := &testNode{isNesting: false, line: 1}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 0 {
+		t.Errorf("expected MaxDepth 0, got %d", result.MaxDepth)
+	}
+}
+
+func TestSingleNestingNode(t *testing.T) {
+	cls := &testClassifier{}
+	root := &testNode{isNesting: true, line: 5}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 1 {
+		t.Errorf("expected MaxDepth 1, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 5 {
+		t.Errorf("expected DeepestLine 5, got %d", result.DeepestLine)
+	}
+}
+
+func TestDepthTwo(t *testing.T) {
+	cls := &testClassifier{}
+	inner := &testNode{isNesting: true, line: 10}
+	root := &testNode{isNesting: true, line: 5, children: []*testNode{inner}}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 2 {
+		t.Errorf("expected MaxDepth 2, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 10 {
+		t.Errorf("expected DeepestLine 10, got %d", result.DeepestLine)
+	}
+}
+
+func TestDepthThree(t *testing.T) {
+	cls := &testClassifier{}
+	innermost := &testNode{isNesting: true, line: 15}
+	middle := &testNode{isNesting: true, line: 10, children: []*testNode{innermost}}
+	root := &testNode{isNesting: true, line: 5, children: []*testNode{middle}}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 3 {
+		t.Errorf("expected MaxDepth 3, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 15 {
+		t.Errorf("expected DeepestLine 15, got %d", result.DeepestLine)
+	}
+}
+
+func TestNonNestingChildrenDontIncrease(t *testing.T) {
+	cls := &testClassifier{}
+	child1 := &testNode{isNesting: false, line: 10}
+	child2 := &testNode{isNesting: false, line: 15}
+	root := &testNode{isNesting: true, line: 5, children: []*testNode{child1, child2}}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 1 {
+		t.Errorf("expected MaxDepth 1, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 5 {
+		t.Errorf("expected DeepestLine 5, got %d", result.DeepestLine)
+	}
+}
+
+func TestMixedNestingAndNonNesting(t *testing.T) {
+	cls := &testClassifier{}
+	// Build a tree:
+	//   root (nesting, line 1)
+	//     ├── child1 (non-nesting, line 2)
+	//     │     └── grandchild1 (nesting, line 3)  -> depth 2
+	//     └── child2 (nesting, line 4)              -> depth 2
+	//           └── grandchild2 (nesting, line 5)   -> depth 3
+	grandchild1 := &testNode{isNesting: true, line: 3}
+	grandchild2 := &testNode{isNesting: true, line: 5}
+	child1 := &testNode{isNesting: false, line: 2, children: []*testNode{grandchild1}}
+	child2 := &testNode{isNesting: true, line: 4, children: []*testNode{grandchild2}}
+	root := &testNode{isNesting: true, line: 1, children: []*testNode{child1, child2}}
+	result := ComputeMaxDepth(root, cls)
+	if result.MaxDepth != 3 {
+		t.Errorf("expected MaxDepth 3, got %d", result.MaxDepth)
+	}
+	if result.DeepestLine != 5 {
+		t.Errorf("expected DeepestLine 5, got %d", result.DeepestLine)
+	}
+}

--- a/semantic/semantic.go
+++ b/semantic/semantic.go
@@ -1,0 +1,243 @@
+package semantic
+
+import (
+	"math"
+	"slices"
+
+	"github.com/ludo-technologies/codescan-core/cfg"
+	"github.com/ludo-technologies/codescan-core/dfa"
+	"github.com/ludo-technologies/codescan-core/domain"
+)
+
+// CFGFeatures holds structural features extracted from a CFG.
+type CFGFeatures struct {
+	BlockCount      int
+	EdgeCount       int
+	EdgeTypeCounts  map[cfg.EdgeType]int
+	CyclomaticNumber int
+	BranchingFactor float64
+	LoopEdgeCount   int
+	ConditionalCount int
+}
+
+// ExtractCFGFeatures extracts structural features from a CFG.
+func ExtractCFGFeatures(c *cfg.CFG) *CFGFeatures {
+	if c == nil {
+		return &CFGFeatures{EdgeTypeCounts: make(map[cfg.EdgeType]int)}
+	}
+
+	f := &CFGFeatures{
+		BlockCount:     len(c.Blocks),
+		EdgeTypeCounts: make(map[cfg.EdgeType]int),
+	}
+
+	totalSuccessors := 0
+	branchingBlocks := 0
+
+	for _, block := range c.Blocks {
+		for _, edge := range block.Successors {
+			f.EdgeCount++
+			f.EdgeTypeCounts[edge.Type]++
+
+			switch edge.Type {
+			case cfg.EdgeLoop:
+				f.LoopEdgeCount++
+			case cfg.EdgeCondTrue, cfg.EdgeCondFalse:
+				f.ConditionalCount++
+			}
+		}
+
+		if len(block.Successors) > 1 {
+			totalSuccessors += len(block.Successors)
+			branchingBlocks++
+		}
+	}
+
+	// Cyclomatic complexity: V(G) = E - N + 2P (P=1 for single component)
+	f.CyclomaticNumber = f.EdgeCount - f.BlockCount + 2
+
+	// Average branching factor among blocks with >1 successor
+	if branchingBlocks > 0 {
+		f.BranchingFactor = float64(totalSuccessors) / float64(branchingBlocks)
+	}
+
+	return f
+}
+
+// Config holds configuration for semantic similarity computation.
+type Config struct {
+	EnableDFA        bool
+	CFGFeatureWeight float64
+	DFAFeatureWeight float64
+}
+
+// DefaultConfig returns the default semantic similarity configuration.
+func DefaultConfig() Config {
+	return Config{
+		EnableDFA:        true,
+		CFGFeatureWeight: domain.DefaultCFGFeatureWeight,
+		DFAFeatureWeight: domain.DefaultDFAFeatureWeight,
+	}
+}
+
+// CompareCFGFeatures computes similarity between two CFG feature sets.
+// Returns a value between 0.0 (completely different) and 1.0 (identical).
+func CompareCFGFeatures(f1, f2 *CFGFeatures) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+
+	// Weighted similarity across multiple dimensions
+	blockSim := computeCountSimilarity(f1.BlockCount, f2.BlockCount)
+	edgeSim := computeCountSimilarity(f1.EdgeCount, f2.EdgeCount)
+	ccSim := computeCountSimilarity(f1.CyclomaticNumber, f2.CyclomaticNumber)
+	edgeDistSim := compareEdgeDistributions(f1.EdgeTypeCounts, f2.EdgeTypeCounts)
+	branchSim := computeFloatSimilarity(f1.BranchingFactor, f2.BranchingFactor)
+	loopCondSim := computeCountSimilarity(
+		f1.LoopEdgeCount+f1.ConditionalCount,
+		f2.LoopEdgeCount+f2.ConditionalCount,
+	)
+
+	return blockSim*0.20 + edgeSim*0.15 + ccSim*0.25 + edgeDistSim*0.25 + branchSim*0.10 + loopCondSim*0.05
+}
+
+// CompareDFAFeatures computes similarity between two DFA feature sets.
+// Returns a value between 0.0 (completely different) and 1.0 (identical).
+func CompareDFAFeatures(f1, f2 *dfa.DFAFeatures) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+
+	pairSim := computeCountSimilarity(f1.PairCount, f2.PairCount)
+	chainSim := computeFloatSimilarity(f1.AvgChainLength, f2.AvgChainLength)
+	crossSim := computeFloatSimilarity(f1.CrossBlockRatio, f2.CrossBlockRatio)
+	defKindSim := compareDefUseKindDistributions(f1.DefKindDist, f2.DefKindDist)
+	useKindSim := compareDefUseKindDistributions(f1.UseKindDist, f2.UseKindDist)
+
+	return pairSim*domain.DefaultDFAPairCountWeight +
+		chainSim*domain.DefaultDFAChainLengthWeight +
+		crossSim*domain.DefaultDFACrossBlockWeight +
+		defKindSim*domain.DefaultDFADefKindWeight +
+		useKindSim*domain.DefaultDFAUseKindWeight
+}
+
+// ComputeSimilarity computes the combined CFG+DFA semantic similarity.
+// Returns 0.0 when either CFG is nil (e.g. parse/build failures) to avoid
+// false-positive matches on absent semantic data.
+func ComputeSimilarity(cfg1, cfg2 *cfg.CFG, dfa1, dfa2 *dfa.DFAInfo, config Config) float64 {
+	if cfg1 == nil || cfg2 == nil {
+		return 0.0
+	}
+
+	cfgFeatures1 := ExtractCFGFeatures(cfg1)
+	cfgFeatures2 := ExtractCFGFeatures(cfg2)
+	cfgSim := CompareCFGFeatures(cfgFeatures1, cfgFeatures2)
+
+	if !config.EnableDFA || dfa1 == nil || dfa2 == nil {
+		return cfgSim
+	}
+
+	dfaFeatures1 := dfa.ExtractDFAFeatures(dfa1)
+	dfaFeatures2 := dfa.ExtractDFAFeatures(dfa2)
+	dfaSim := CompareDFAFeatures(dfaFeatures1, dfaFeatures2)
+
+	return cfgSim*config.CFGFeatureWeight + dfaSim*config.DFAFeatureWeight
+}
+
+// computeCountSimilarity computes similarity between two integer counts.
+// Returns 1.0 for identical, decreasing toward 0.0 for larger differences.
+func computeCountSimilarity(a, b int) float64 {
+	if a == 0 && b == 0 {
+		return 1.0
+	}
+	maxVal := math.Max(float64(a), float64(b))
+	if maxVal == 0 {
+		return 1.0
+	}
+	diff := math.Abs(float64(a) - float64(b))
+	return 1.0 - diff/maxVal
+}
+
+// computeFloatSimilarity computes similarity between two float values.
+func computeFloatSimilarity(a, b float64) float64 {
+	if a == 0 && b == 0 {
+		return 1.0
+	}
+	maxVal := math.Max(math.Abs(a), math.Abs(b))
+	if maxVal == 0 {
+		return 1.0
+	}
+	diff := math.Abs(a - b)
+	return 1.0 - diff/maxVal
+}
+
+// compareEdgeDistributions computes cosine similarity between two edge type distributions.
+func compareEdgeDistributions(d1, d2 map[cfg.EdgeType]int) float64 {
+	// Collect all edge types
+	allTypes := make(map[cfg.EdgeType]bool)
+	for k := range d1 {
+		allTypes[k] = true
+	}
+	for k := range d2 {
+		allTypes[k] = true
+	}
+	if len(allTypes) == 0 {
+		return 1.0
+	}
+
+	// Sort for deterministic iteration
+	types := make([]cfg.EdgeType, 0, len(allTypes))
+	for t := range allTypes {
+		types = append(types, t)
+	}
+	slices.Sort(types)
+
+	// Cosine similarity
+	var dotProduct, norm1, norm2 float64
+	for _, t := range types {
+		v1 := float64(d1[t])
+		v2 := float64(d2[t])
+		dotProduct += v1 * v2
+		norm1 += v1 * v1
+		norm2 += v2 * v2
+	}
+
+	if norm1 == 0 || norm2 == 0 {
+		return 0.0
+	}
+	return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
+}
+
+// compareDefUseKindDistributions computes cosine similarity between two DefUseKind distributions.
+func compareDefUseKindDistributions(d1, d2 map[dfa.DefUseKind]int) float64 {
+	allKinds := make(map[dfa.DefUseKind]bool)
+	for k := range d1 {
+		allKinds[k] = true
+	}
+	for k := range d2 {
+		allKinds[k] = true
+	}
+	if len(allKinds) == 0 {
+		return 1.0
+	}
+
+	kinds := make([]dfa.DefUseKind, 0, len(allKinds))
+	for k := range allKinds {
+		kinds = append(kinds, k)
+	}
+	slices.Sort(kinds)
+
+	var dotProduct, norm1, norm2 float64
+	for _, k := range kinds {
+		v1 := float64(d1[k])
+		v2 := float64(d2[k])
+		dotProduct += v1 * v2
+		norm1 += v1 * v1
+		norm2 += v2 * v2
+	}
+
+	if norm1 == 0 || norm2 == 0 {
+		return 0.0
+	}
+	return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
+}

--- a/semantic/semantic_test.go
+++ b/semantic/semantic_test.go
@@ -1,0 +1,271 @@
+package semantic
+
+import (
+	"math"
+	"testing"
+
+	"github.com/ludo-technologies/codescan-core/cfg"
+	"github.com/ludo-technologies/codescan-core/dfa"
+)
+
+func TestExtractCFGFeatures_Nil(t *testing.T) {
+	f := ExtractCFGFeatures(nil)
+	if f.BlockCount != 0 || f.EdgeCount != 0 {
+		t.Errorf("nil CFG should produce zero features")
+	}
+}
+
+func TestExtractCFGFeatures_Simple(t *testing.T) {
+	c := cfg.NewCFG("test")
+	block := c.CreateBlock("body")
+	c.ConnectBlocks(c.Entry, block, cfg.EdgeNormal)
+	c.ConnectBlocks(block, c.Exit, cfg.EdgeNormal)
+
+	f := ExtractCFGFeatures(c)
+	if f.BlockCount != 3 { // entry, body, exit
+		t.Errorf("BlockCount = %d, want 3", f.BlockCount)
+	}
+	if f.EdgeCount != 2 {
+		t.Errorf("EdgeCount = %d, want 2", f.EdgeCount)
+	}
+	if f.CyclomaticNumber != 1 { // 2 - 3 + 2 = 1
+		t.Errorf("CyclomaticNumber = %d, want 1", f.CyclomaticNumber)
+	}
+}
+
+func TestExtractCFGFeatures_WithBranching(t *testing.T) {
+	c := cfg.NewCFG("branch")
+	cond := c.CreateBlock("cond")
+	thenB := c.CreateBlock("then")
+	elseB := c.CreateBlock("else")
+	merge := c.CreateBlock("merge")
+
+	c.ConnectBlocks(c.Entry, cond, cfg.EdgeNormal)
+	c.ConnectBlocks(cond, thenB, cfg.EdgeCondTrue)
+	c.ConnectBlocks(cond, elseB, cfg.EdgeCondFalse)
+	c.ConnectBlocks(thenB, merge, cfg.EdgeNormal)
+	c.ConnectBlocks(elseB, merge, cfg.EdgeNormal)
+	c.ConnectBlocks(merge, c.Exit, cfg.EdgeNormal)
+
+	f := ExtractCFGFeatures(c)
+	if f.BlockCount != 6 {
+		t.Errorf("BlockCount = %d, want 6", f.BlockCount)
+	}
+	if f.EdgeCount != 6 {
+		t.Errorf("EdgeCount = %d, want 6", f.EdgeCount)
+	}
+	if f.ConditionalCount != 2 { // true + false
+		t.Errorf("ConditionalCount = %d, want 2", f.ConditionalCount)
+	}
+	if f.BranchingFactor == 0 {
+		t.Error("BranchingFactor should be > 0 for branching CFG")
+	}
+}
+
+func TestExtractCFGFeatures_WithLoop(t *testing.T) {
+	c := cfg.NewCFG("loop")
+	loopHead := c.CreateBlock("loop_head")
+	body := c.CreateBlock("body")
+
+	c.ConnectBlocks(c.Entry, loopHead, cfg.EdgeNormal)
+	c.ConnectBlocks(loopHead, body, cfg.EdgeCondTrue)
+	c.ConnectBlocks(loopHead, c.Exit, cfg.EdgeCondFalse)
+	c.ConnectBlocks(body, loopHead, cfg.EdgeLoop)
+
+	f := ExtractCFGFeatures(c)
+	if f.LoopEdgeCount != 1 {
+		t.Errorf("LoopEdgeCount = %d, want 1", f.LoopEdgeCount)
+	}
+}
+
+func TestCompareCFGFeatures_Identical(t *testing.T) {
+	f := &CFGFeatures{
+		BlockCount:       5,
+		EdgeCount:        6,
+		CyclomaticNumber: 3,
+		EdgeTypeCounts:   map[cfg.EdgeType]int{cfg.EdgeNormal: 4, cfg.EdgeCondTrue: 1, cfg.EdgeCondFalse: 1},
+		BranchingFactor:  2.0,
+		LoopEdgeCount:    0,
+		ConditionalCount: 2,
+	}
+	sim := CompareCFGFeatures(f, f)
+	if math.Abs(sim-1.0) > 0.001 {
+		t.Errorf("identical features should have sim ~1.0, got %f", sim)
+	}
+}
+
+func TestCompareCFGFeatures_Different(t *testing.T) {
+	f1 := &CFGFeatures{
+		BlockCount:       3,
+		EdgeCount:        2,
+		CyclomaticNumber: 1,
+		EdgeTypeCounts:   map[cfg.EdgeType]int{cfg.EdgeNormal: 2},
+		BranchingFactor:  0,
+		LoopEdgeCount:    0,
+		ConditionalCount: 0,
+	}
+	f2 := &CFGFeatures{
+		BlockCount:       10,
+		EdgeCount:        15,
+		CyclomaticNumber: 7,
+		EdgeTypeCounts:   map[cfg.EdgeType]int{cfg.EdgeNormal: 8, cfg.EdgeCondTrue: 3, cfg.EdgeCondFalse: 3, cfg.EdgeLoop: 1},
+		BranchingFactor:  3.0,
+		LoopEdgeCount:    1,
+		ConditionalCount: 6,
+	}
+	sim := CompareCFGFeatures(f1, f2)
+	if sim >= 0.8 {
+		t.Errorf("very different features should have low similarity, got %f", sim)
+	}
+	if sim < 0 || sim > 1.0 {
+		t.Errorf("similarity should be in [0,1], got %f", sim)
+	}
+}
+
+func TestCompareCFGFeatures_Nil(t *testing.T) {
+	f := &CFGFeatures{EdgeTypeCounts: make(map[cfg.EdgeType]int)}
+	if sim := CompareCFGFeatures(nil, f); sim != 0.0 {
+		t.Errorf("nil should return 0, got %f", sim)
+	}
+	if sim := CompareCFGFeatures(f, nil); sim != 0.0 {
+		t.Errorf("nil should return 0, got %f", sim)
+	}
+}
+
+func TestCompareDFAFeatures_Identical(t *testing.T) {
+	f := &dfa.DFAFeatures{
+		PairCount:       5,
+		AvgChainLength:  3.0,
+		CrossBlockRatio: 0.4,
+		DefKindDist:     map[dfa.DefUseKind]int{dfa.DefKindAssign: 3, dfa.DefKindParam: 2},
+		UseKindDist:     map[dfa.DefUseKind]int{dfa.UseKindLoad: 5},
+	}
+	sim := CompareDFAFeatures(f, f)
+	if math.Abs(sim-1.0) > 0.001 {
+		t.Errorf("identical DFA features should have sim ~1.0, got %f", sim)
+	}
+}
+
+func TestCompareDFAFeatures_Nil(t *testing.T) {
+	f := dfa.NewDFAFeatures()
+	if sim := CompareDFAFeatures(nil, f); sim != 0.0 {
+		t.Errorf("nil should return 0, got %f", sim)
+	}
+}
+
+func TestComputeSimilarity_CFGOnly(t *testing.T) {
+	c := cfg.NewCFG("test")
+	block := c.CreateBlock("body")
+	c.ConnectBlocks(c.Entry, block, cfg.EdgeNormal)
+	c.ConnectBlocks(block, c.Exit, cfg.EdgeNormal)
+
+	config := DefaultConfig()
+	config.EnableDFA = false
+
+	sim := ComputeSimilarity(c, c, nil, nil, config)
+	if math.Abs(sim-1.0) > 0.001 {
+		t.Errorf("same CFG should have sim ~1.0, got %f", sim)
+	}
+}
+
+func TestComputeSimilarity_WithDFA(t *testing.T) {
+	c := cfg.NewCFG("test")
+	block := c.CreateBlock("body")
+	c.ConnectBlocks(c.Entry, block, cfg.EdgeNormal)
+	c.ConnectBlocks(block, c.Exit, cfg.EdgeNormal)
+
+	dfaInfo := dfa.NewDFAInfo(c)
+	ref := dfa.NewVarReference("x", dfa.DefKindAssign, block, nil, 0)
+	dfaInfo.AddDef(ref)
+
+	config := DefaultConfig()
+	sim := ComputeSimilarity(c, c, dfaInfo, dfaInfo, config)
+	if sim < 0.5 || sim > 1.0 {
+		t.Errorf("same CFG+DFA should have high similarity, got %f", sim)
+	}
+}
+
+func TestComputeSimilarity_NilDFA(t *testing.T) {
+	c := cfg.NewCFG("test")
+	config := DefaultConfig()
+
+	// With DFA enabled but nil DFA info, should fall back to CFG only
+	sim := ComputeSimilarity(c, c, nil, nil, config)
+	if sim < 0 || sim > 1.0 {
+		t.Errorf("similarity should be in [0,1], got %f", sim)
+	}
+}
+
+func TestComputeSimilarity_NilCFG(t *testing.T) {
+	config := DefaultConfig()
+
+	// Both nil: absent data should not look like a perfect match
+	if sim := ComputeSimilarity(nil, nil, nil, nil, config); sim != 0.0 {
+		t.Errorf("both nil CFGs should return 0.0, got %f", sim)
+	}
+
+	c := cfg.NewCFG("test")
+
+	// One nil: still absent, should return 0
+	if sim := ComputeSimilarity(nil, c, nil, nil, config); sim != 0.0 {
+		t.Errorf("first nil CFG should return 0.0, got %f", sim)
+	}
+	if sim := ComputeSimilarity(c, nil, nil, nil, config); sim != 0.0 {
+		t.Errorf("second nil CFG should return 0.0, got %f", sim)
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+	if !config.EnableDFA {
+		t.Error("EnableDFA should be true by default")
+	}
+	if config.CFGFeatureWeight != 0.60 {
+		t.Errorf("CFGFeatureWeight = %f, want 0.60", config.CFGFeatureWeight)
+	}
+	if config.DFAFeatureWeight != 0.40 {
+		t.Errorf("DFAFeatureWeight = %f, want 0.40", config.DFAFeatureWeight)
+	}
+}
+
+func TestComputeCountSimilarity(t *testing.T) {
+	tests := []struct {
+		a, b int
+		want float64
+	}{
+		{0, 0, 1.0},
+		{5, 5, 1.0},
+		{10, 0, 0.0},
+		{10, 5, 0.5},
+	}
+	for _, tt := range tests {
+		got := computeCountSimilarity(tt.a, tt.b)
+		if math.Abs(got-tt.want) > 0.001 {
+			t.Errorf("computeCountSimilarity(%d, %d) = %f, want %f", tt.a, tt.b, got, tt.want)
+		}
+	}
+}
+
+func TestCompareEdgeDistributions_Empty(t *testing.T) {
+	sim := compareEdgeDistributions(map[cfg.EdgeType]int{}, map[cfg.EdgeType]int{})
+	if math.Abs(sim-1.0) > 0.001 {
+		t.Errorf("empty distributions should have sim 1.0, got %f", sim)
+	}
+}
+
+func TestCompareEdgeDistributions_Identical(t *testing.T) {
+	d := map[cfg.EdgeType]int{cfg.EdgeNormal: 3, cfg.EdgeCondTrue: 1}
+	sim := compareEdgeDistributions(d, d)
+	if math.Abs(sim-1.0) > 0.001 {
+		t.Errorf("identical distributions should have sim 1.0, got %f", sim)
+	}
+}
+
+func TestCompareEdgeDistributions_Orthogonal(t *testing.T) {
+	d1 := map[cfg.EdgeType]int{cfg.EdgeNormal: 5}
+	d2 := map[cfg.EdgeType]int{cfg.EdgeLoop: 5}
+	sim := compareEdgeDistributions(d1, d2)
+	if sim != 0.0 {
+		t.Errorf("orthogonal distributions should have sim 0.0, got %f", sim)
+	}
+}

--- a/source/collector.go
+++ b/source/collector.go
@@ -1,0 +1,117 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// FileFilter configures which files to include or exclude during collection.
+type FileFilter struct {
+	IncludePatterns []string // Glob patterns to include (e.g. "*.py", "*.js")
+	ExcludePatterns []string // Glob patterns to exclude (e.g. "*.pyc", "*_test.go")
+	Recursive       bool     // Whether to recurse into subdirectories
+}
+
+// CollectFiles walks the given paths and returns matching files based on the filter.
+// Each path can be a file or directory. Directories are walked according to filter settings.
+func CollectFiles(paths []string, filter FileFilter) ([]string, error) {
+	seen := make(map[string]bool)
+	var result []string
+
+	for _, p := range paths {
+		abs, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+
+		info, err := os.Stat(abs)
+		if err != nil {
+			return nil, err
+		}
+
+		if !info.IsDir() {
+			// Single file: check patterns
+			if matchesFilter(filepath.Base(abs), filter) && !seen[abs] {
+				seen[abs] = true
+				result = append(result, abs)
+			}
+			continue
+		}
+
+		// Directory: walk
+		if filter.Recursive {
+			err = filepath.WalkDir(abs, func(path string, d os.DirEntry, err error) error {
+				if err != nil {
+					return err
+				}
+				if d.IsDir() {
+					return nil
+				}
+				if matchesFilter(d.Name(), filter) && !seen[path] {
+					seen[path] = true
+					result = append(result, path)
+				}
+				return nil
+			})
+		} else {
+			entries, err2 := os.ReadDir(abs)
+			if err2 != nil {
+				return nil, err2
+			}
+			for _, entry := range entries {
+				if entry.IsDir() {
+					continue
+				}
+				full := filepath.Join(abs, entry.Name())
+				if matchesFilter(entry.Name(), filter) && !seen[full] {
+					seen[full] = true
+					result = append(result, full)
+				}
+			}
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	sort.Strings(result)
+	return result, nil
+}
+
+// matchesFilter checks whether a filename passes the include/exclude patterns.
+func matchesFilter(name string, filter FileFilter) bool {
+	// If include patterns are specified, file must match at least one
+	if len(filter.IncludePatterns) > 0 {
+		if !MatchesAnyPattern(name, filter.IncludePatterns) {
+			return false
+		}
+	}
+	// If exclude patterns are specified, file must not match any
+	if len(filter.ExcludePatterns) > 0 {
+		if MatchesAnyPattern(name, filter.ExcludePatterns) {
+			return false
+		}
+	}
+	return true
+}
+
+// MatchesAnyPattern returns true if the name matches any of the given glob patterns.
+func MatchesAnyPattern(name string, patterns []string) bool {
+	for _, pattern := range patterns {
+		matched, err := filepath.Match(pattern, name)
+		if err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
+
+// IsDirectory returns true if the given path is a directory.
+func IsDirectory(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return info.IsDir()
+}

--- a/source/collector_test.go
+++ b/source/collector_test.go
@@ -1,0 +1,230 @@
+package source
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupTestDir creates a temporary directory structure:
+//
+//	testdir/
+//	├── a.go
+//	├── b.py
+//	├── c.txt
+//	└── sub/
+//	    ├── d.go
+//	    └── e.py
+func setupTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+
+	for _, name := range []string{"a.go", "b.py", "c.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("// "+name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	sub := filepath.Join(dir, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	for _, name := range []string{"d.go", "e.py"} {
+		if err := os.WriteFile(filepath.Join(sub, name), []byte("// "+name), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return dir
+}
+
+// ---------- MatchesAnyPattern ----------
+
+func TestMatchesAnyPattern_Match(t *testing.T) {
+	if !MatchesAnyPattern("foo.go", []string{"*.go", "*.py"}) {
+		t.Error("expected match for foo.go against *.go")
+	}
+}
+
+func TestMatchesAnyPattern_NoMatch(t *testing.T) {
+	if MatchesAnyPattern("foo.txt", []string{"*.go", "*.py"}) {
+		t.Error("did not expect match for foo.txt")
+	}
+}
+
+func TestMatchesAnyPattern_EmptyPatterns(t *testing.T) {
+	if MatchesAnyPattern("foo.go", nil) {
+		t.Error("empty patterns should never match")
+	}
+}
+
+// ---------- IsDirectory ----------
+
+func TestIsDirectory_Dir(t *testing.T) {
+	dir := t.TempDir()
+	if !IsDirectory(dir) {
+		t.Error("expected true for a directory")
+	}
+}
+
+func TestIsDirectory_File(t *testing.T) {
+	dir := t.TempDir()
+	f := filepath.Join(dir, "file.txt")
+	if err := os.WriteFile(f, []byte("hi"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if IsDirectory(f) {
+		t.Error("expected false for a regular file")
+	}
+}
+
+func TestIsDirectory_Nonexistent(t *testing.T) {
+	if IsDirectory("/nonexistent/path/abc123") {
+		t.Error("expected false for nonexistent path")
+	}
+}
+
+// ---------- CollectFiles ----------
+
+func TestCollectFiles_SingleFile(t *testing.T) {
+	dir := setupTestDir(t)
+	file := filepath.Join(dir, "a.go")
+
+	files, err := CollectFiles([]string{file}, FileFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0] != file {
+		t.Errorf("expected %s, got %s", file, files[0])
+	}
+}
+
+func TestCollectFiles_DirectoryNonRecursive(t *testing.T) {
+	dir := setupTestDir(t)
+
+	files, err := CollectFiles([]string{dir}, FileFilter{Recursive: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should only contain a.go, b.py, c.txt (not sub/ contents)
+	if len(files) != 3 {
+		t.Fatalf("expected 3 files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Dir(f) != dir {
+			t.Errorf("file %s should be directly in %s", f, dir)
+		}
+	}
+}
+
+func TestCollectFiles_DirectoryRecursive(t *testing.T) {
+	dir := setupTestDir(t)
+
+	files, err := CollectFiles([]string{dir}, FileFilter{Recursive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Should contain all 5 files
+	if len(files) != 5 {
+		t.Fatalf("expected 5 files, got %d: %v", len(files), files)
+	}
+}
+
+func TestCollectFiles_IncludePatterns(t *testing.T) {
+	dir := setupTestDir(t)
+
+	files, err := CollectFiles([]string{dir}, FileFilter{
+		IncludePatterns: []string{"*.go"},
+		Recursive:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// a.go and sub/d.go
+	if len(files) != 2 {
+		t.Fatalf("expected 2 .go files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Ext(f) != ".go" {
+			t.Errorf("unexpected non-.go file: %s", f)
+		}
+	}
+}
+
+func TestCollectFiles_ExcludePatterns(t *testing.T) {
+	dir := setupTestDir(t)
+
+	files, err := CollectFiles([]string{dir}, FileFilter{
+		ExcludePatterns: []string{"*.txt"},
+		Recursive:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// All except c.txt → 4 files
+	if len(files) != 4 {
+		t.Fatalf("expected 4 files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Ext(f) == ".txt" {
+			t.Errorf("should have excluded .txt file: %s", f)
+		}
+	}
+}
+
+func TestCollectFiles_IncludeAndExclude(t *testing.T) {
+	dir := setupTestDir(t)
+
+	files, err := CollectFiles([]string{dir}, FileFilter{
+		IncludePatterns: []string{"*.go", "*.py"},
+		ExcludePatterns: []string{"*.py"},
+		Recursive:       true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Include *.go and *.py, then exclude *.py → only *.go files: a.go, sub/d.go
+	if len(files) != 2 {
+		t.Fatalf("expected 2 files, got %d: %v", len(files), files)
+	}
+	for _, f := range files {
+		if filepath.Ext(f) != ".go" {
+			t.Errorf("unexpected file: %s", f)
+		}
+	}
+}
+
+func TestCollectFiles_EmptyPaths(t *testing.T) {
+	files, err := CollectFiles(nil, FileFilter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(files) != 0 {
+		t.Fatalf("expected 0 files, got %d", len(files))
+	}
+}
+
+func TestCollectFiles_Deduplication(t *testing.T) {
+	dir := setupTestDir(t)
+	file := filepath.Join(dir, "a.go")
+
+	// Pass the same file twice, and also pass the directory containing it
+	files, err := CollectFiles([]string{file, file, dir}, FileFilter{Recursive: false})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Count how many times a.go appears
+	count := 0
+	for _, f := range files {
+		if filepath.Base(f) == "a.go" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected a.go exactly once, got %d times in %v", count, files)
+	}
+}


### PR DESCRIPTION
## Summary

- Add 7 new packages (`domain/`, `dfa/`, `semantic/`, `cbo/`, `lcom/`, `nesting/`, `source/`) and extend `clone/` with 3 new files to extract all language-independent analysis logic from pyscn into codescan-core
- This enables pyscn to replace its internal copies with direct imports from codescan-core, reducing duplication and centralizing the shared algorithms
- All new code follows the existing adapter pattern (interfaces + `any` typed fields) so language-specific logic remains in pyscn/jscan

### New packages

| Package | Description |
|---------|-------------|
| `domain/` | Shared error types (`DomainError`), `RiskLevel`, `CloneType`, `OutputFormat`, `SortCriteria`, and all default threshold constants |
| `dfa/` | Data flow analysis: `DefUseKind`, `VarReference`, `DefUsePair`, `DefUseChain`, `DFAInfo`, `DFAFeatures`, and `DFABuilder` with `RefExtractor` interface for language adapters |
| `semantic/` | CFG+DFA semantic similarity: `ExtractCFGFeatures`, `CompareCFGFeatures`, `CompareDFAFeatures`, `ComputeSimilarity` with configurable weights |
| `cbo/` | Coupling Between Objects: `ComputeCBO` with dependency kind breakdown and risk assessment |
| `lcom/` | Lack of Cohesion of Methods (LCOM4): Union-Find algorithm with connected component grouping |
| `nesting/` | Nesting depth analysis via `NestingClassifier` interface for language-agnostic tree traversal |
| `source/` | File collection with glob-based include/exclude filtering and recursive directory walking |

### Extended `clone/` package

| File | Description |
|------|-------------|
| `fragment.go` | `CodeFragment` (implements `GroupableItem`), `ClonePair`, `CloneGroup`, `CloneStatistics` |
| `similarity.go` | `SimilarityAnalyzer` interface + `StructuralAnalyzer` wrapping APTED |
| `classifier.go` | Cascade clone classifier (Type-1 → Type-4) with configurable thresholds |

### Key design decisions

- `dfa.RefExtractor` and `nesting.NestingClassifier` are interfaces so language-specific AST logic stays in pyscn/jscan
- `semantic.ComputeSimilarity` returns 0.0 for nil CFGs to prevent false-positive matches on parse failures
- `dfa.DFABuilder.Build` validates the extractor is non-nil before use, returning an error instead of panicking
- No existing files were modified — only new files added

## Test plan

- [x] `go test ./... -count=1` — all 13 packages pass (24 new files, 4261 lines added)
- [x] `go vet ./...` — clean
- [x] `go build ./...` — clean
- [x] Nil-input edge cases covered (nil CFG, nil extractor, nil classifier, empty inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)