### PR TITLE
core/clone: refresh grouping to current jscan/pyscn parity

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -9,7 +9,7 @@ Shared Go module that provides language-agnostic code analysis algorithms for th
 | `apted/` | APTED tree edit distance algorithm with configurable cost models and normalization |
 | `cbo/` | Coupling Between Objects (CBO) metric over language-provided dependency references |
 | `cfg/` | Control Flow Graph data structures, reachability analysis, McCabe cyclomatic complexity, dead code detection |
-| `clone/` | AST feature extraction, clone classification, and 5 clone grouping strategies (Connected, KCore, StarMedoid, CompleteLinkage, Centroid) |
+| `clone/` | AST feature extraction, clone classification, 5 clone grouping strategies (Connected, KCore, StarMedoid, CompleteLinkage, Centroid), and group dedup post-passes |
 | `dfa/` | Data-flow analysis framework over CFGs with language-injected variable reference extraction |
 | `domain/` | Shared type definitions, thresholds, and error taxonomy |
 | `graph/` | Directed graph abstraction, Tarjan SCC cycle detection, Robert Martin coupling metrics |

--- a/core/clone/fragment.go
+++ b/core/clone/fragment.go
@@ -27,7 +27,18 @@ func (f *CodeFragment) ItemID() int {
 	return f.ID
 }
 
-// ItemKey returns the sorting key for GroupableItem.
+// ItemLocation returns the fragment's source location for GroupableItem.
+func (f *CodeFragment) ItemLocation() ItemLocation {
+	return ItemLocation{
+		FilePath:  f.FilePath,
+		StartLine: f.StartLine,
+		EndLine:   f.EndLine,
+		StartCol:  f.StartCol,
+		EndCol:    f.EndCol,
+	}
+}
+
+// ItemKey returns a stable location-based key for the fragment.
 func (f *CodeFragment) ItemKey() string {
 	return fmt.Sprintf("%s|%d|%d|%d|%d", f.FilePath, f.StartLine, f.EndLine, f.StartCol, f.EndCol)
 }

--- a/core/clone/group_dedup_test.go
+++ b/core/clone/group_dedup_test.go
@@ -1,0 +1,299 @@
+package clone
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
+)
+
+var nextTestItemID = 1000
+
+func gi(file string, start, end int) *testItem {
+	nextTestItemID++
+	return &testItem{
+		id:  nextTestItemID,
+		loc: ItemLocation{FilePath: file, StartLine: start, EndLine: end},
+	}
+}
+
+func mkGroup(id int, items ...*testItem) *ItemGroup[*testItem] {
+	return &ItemGroup[*testItem]{ID: id, Items: items}
+}
+
+func keysOf(g *ItemGroup[*testItem]) []string {
+	out := make([]string, 0, len(g.Items))
+	for _, item := range g.Items {
+		out = append(out, ItemKey(item))
+	}
+	return out
+}
+
+// TestCoveredGroups_Repro reproduces the case where the same duplication is
+// emitted as two near-identical groups whose member windows differ by
+// exactly one enclosing line. The group with the smaller windows must be
+// suppressed.
+func TestCoveredGroups_Repro(t *testing.T) {
+	inner := mkGroup(6, gi("smoke.js", 299, 315), gi("smoke.js", 318, 334))
+	inner.Similarity = 0.9692
+	outer := mkGroup(14, gi("smoke.js", 298, 315), gi("smoke.js", 317, 334))
+	outer.Similarity = 0.9613
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{inner, outer})
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected 1 group after covered-group dedup, got %d", len(out.Groups))
+	}
+	if out.Groups[0] != outer {
+		t.Fatalf("expected the larger-window group to survive, got %v", keysOf(out.Groups[0]))
+	}
+	if len(out.SuppressedPairs) != 1 {
+		t.Fatalf("expected the covered group's pair suppressed, got %d", len(out.SuppressedPairs))
+	}
+}
+
+// TestCoveredGroups_IdenticalGroupsKeepFirst verifies the deterministic
+// tiebreak for mutual coverage: groups with identical member ranges collapse
+// to the earlier one in the slice.
+func TestCoveredGroups_IdenticalGroupsKeepFirst(t *testing.T) {
+	g1 := mkGroup(1, gi("x.js", 1, 10), gi("y.js", 1, 10))
+	g2 := mkGroup(2, gi("x.js", 1, 10), gi("y.js", 1, 10))
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{g1, g2})
+
+	if len(out.Groups) != 1 || out.Groups[0] != g1 {
+		t.Fatalf("expected only the first of two identical groups to survive, got %+v", out.Groups)
+	}
+}
+
+// TestCoveredGroups_ChainCollapsesToOutermost verifies transitivity: with
+// g1 ⊂ g2 ⊂ g3 member-wise, only the outermost group survives even though g2
+// is itself suppressed.
+func TestCoveredGroups_ChainCollapsesToOutermost(t *testing.T) {
+	g1 := mkGroup(1, gi("x.js", 3, 8), gi("y.js", 3, 8))
+	g2 := mkGroup(2, gi("x.js", 2, 9), gi("y.js", 2, 9))
+	g3 := mkGroup(3, gi("x.js", 1, 10), gi("y.js", 1, 10))
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{g1, g2, g3})
+
+	if len(out.Groups) != 1 || out.Groups[0] != g3 {
+		t.Fatalf("expected only outermost group to survive, got %+v", out.Groups)
+	}
+}
+
+// TestCoveredGroups_PartialCoverageKeptBoth verifies a group is kept when any
+// member falls outside the other group's windows: it carries information the
+// covering group does not.
+func TestCoveredGroups_PartialCoverageKeptBoth(t *testing.T) {
+	g1 := mkGroup(1, gi("x.js", 2, 9), gi("z.js", 1, 8))
+	g2 := mkGroup(2, gi("x.js", 1, 10), gi("y.js", 1, 10))
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{g1, g2})
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("expected both groups kept, got %d", len(out.Groups))
+	}
+	if len(out.SuppressedPairs) != 0 {
+		t.Fatalf("expected no suppressed pairs, got %d", len(out.SuppressedPairs))
+	}
+}
+
+// TestCoveredGroups_DistinctMembersRequired verifies the injective-matching
+// constraint: two disjoint blocks inside ONE member of another group describe
+// duplication within that member, which the outer group does not report, so
+// the inner group must be kept.
+func TestCoveredGroups_DistinctMembersRequired(t *testing.T) {
+	inner := mkGroup(1, gi("x.js", 10, 20), gi("x.js", 30, 40))
+	outer := mkGroup(2, gi("x.js", 1, 100), gi("y.js", 1, 100))
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{inner, outer})
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("expected both groups kept (no injective cover), got %d", len(out.Groups))
+	}
+}
+
+// TestCoveredGroups_NestedDistinctFilesSuppressed verifies the general nested
+// case: a group of inner blocks each inside a distinct cloned member of a
+// larger group, with comparable similarity, is redundant with it.
+func TestCoveredGroups_NestedDistinctFilesSuppressed(t *testing.T) {
+	inner := mkGroup(1, gi("x.js", 20, 30), gi("y.js", 20, 30))
+	inner.Similarity = 0.93
+	outer := mkGroup(2, gi("x.js", 1, 100), gi("y.js", 1, 100))
+	outer.Similarity = 0.91
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{inner, outer})
+
+	if len(out.Groups) != 1 || out.Groups[0] != outer {
+		t.Fatalf("expected nested group suppressed in favor of covering group, got %+v", out.Groups)
+	}
+}
+
+// TestCoveredGroups_StrongerInnerFindingKept verifies the similarity guard:
+// an inner group that matches much more strongly than its covering group
+// (e.g., a near-identical block inside loosely similar functions) is a
+// distinct finding and must survive.
+func TestCoveredGroups_StrongerInnerFindingKept(t *testing.T) {
+	inner := mkGroup(1, gi("x.js", 2, 5), gi("y.js", 2, 5))
+	inner.Similarity = 0.95
+	outer := mkGroup(2, gi("x.js", 1, 6), gi("y.js", 1, 6))
+	outer.Similarity = 0.65
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{inner, outer})
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("expected both groups kept when inner is the stronger finding, got %d", len(out.Groups))
+	}
+	if len(out.SuppressedPairs) != 0 {
+		t.Fatalf("expected no suppressed pairs, got %d", len(out.SuppressedPairs))
+	}
+}
+
+// TestCoveredGroups_SharedItemKeepsPairs verifies that a pair needed by a
+// surviving group is not suppressed.
+func TestCoveredGroups_SharedItemKeepsPairs(t *testing.T) {
+	shared := gi("x.js", 5, 9)
+	covered := mkGroup(1, shared, gi("y.js", 5, 9))
+	covering := mkGroup(2, gi("x.js", 1, 10), gi("y.js", 1, 10))
+	keeper := mkGroup(3, shared, gi("z.js", 50, 90))
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{covered, covering, keeper})
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("expected covering+keeper groups to survive, got %d", len(out.Groups))
+	}
+	if _, ok := out.SuppressedPairs[PairKey(shared, keeper.Items[1])]; ok {
+		t.Fatalf("pair used by a surviving group must not be suppressed")
+	}
+	if len(out.SuppressedPairs) != 1 {
+		t.Fatalf("expected only the covered group's pair suppressed, got %d", len(out.SuppressedPairs))
+	}
+}
+
+func TestCoveredGroups_SameLinesDifferentColumnsKept(t *testing.T) {
+	leftX := gi("x.js", 1, 1)
+	leftX.loc.StartCol, leftX.loc.EndCol = 1, 10
+	leftY := gi("y.js", 1, 1)
+	leftY.loc.StartCol, leftY.loc.EndCol = 1, 10
+	rightX := gi("x.js", 1, 1)
+	rightX.loc.StartCol, rightX.loc.EndCol = 20, 30
+	rightY := gi("y.js", 1, 1)
+	rightY.loc.StartCol, rightY.loc.EndCol = 20, 30
+
+	out := DedupeCoveredGroups([]*ItemGroup[*testItem]{
+		mkGroup(1, leftX, leftY),
+		mkGroup(2, rightX, rightY),
+	})
+
+	if len(out.Groups) != 2 {
+		t.Fatalf("expected groups at different columns to remain distinct, got %d", len(out.Groups))
+	}
+}
+
+func TestFilterMaximalPerFile_SameLinesDifferentColumnsKept(t *testing.T) {
+	left := gi("x.js", 1, 1)
+	left.loc.StartCol, left.loc.EndCol = 1, 10
+	right := gi("x.js", 1, 1)
+	right.loc.StartCol, right.loc.EndCol = 20, 30
+
+	kept, suppressed := filterMaximalPerFile([]*testItem{left, right})
+	if len(kept) != 2 || len(suppressed) != 0 {
+		t.Fatalf("expected fragments at different columns to remain distinct, got %d kept", len(kept))
+	}
+}
+
+func TestFilterMaximalPerFile_StrictSubsetSuppressed(t *testing.T) {
+	outer := gi("x.js", 1, 20)
+	inner := gi("x.js", 5, 10)
+
+	kept, suppressed := filterMaximalPerFile([]*testItem{inner, outer})
+	if len(kept) != 1 || kept[0] != outer {
+		t.Fatalf("expected only the covering fragment to survive, got %d kept", len(kept))
+	}
+	if _, ok := suppressed[ItemKey(inner)]; !ok {
+		t.Fatalf("expected the covered fragment to be reported as suppressed")
+	}
+}
+
+func TestDedupeStrictSubsetGroupMembers_CollapsesOverlappingWindows(t *testing.T) {
+	// A group whose same-file members overlap (one strictly covers the other)
+	// collapses to the maximal window; a group reduced below 2 members drops.
+	a := gi("x.js", 512, 542)
+	b := gi("x.js", 515, 542)
+	c := gi("y.js", 1, 30)
+	g := mkGroup(1, a, b, c)
+
+	pairs := []*ItemPair[*testItem]{
+		pair(a, c, 0.9, domain.Type3Clone),
+		pair(b, c, 0.9, domain.Type3Clone),
+	}
+
+	out := DedupeStrictSubsetGroupMembers([]*ItemGroup[*testItem]{g}, pairs)
+
+	if len(out.Groups) != 1 {
+		t.Fatalf("expected 1 group, got %d", len(out.Groups))
+	}
+	if len(out.Groups[0].Items) != 2 {
+		t.Fatalf("expected 2 members after collapsing overlap, got %d", len(out.Groups[0].Items))
+	}
+	if _, ok := out.Suppressed[ItemKey(b)]; !ok {
+		t.Fatalf("expected the covered member to be reported as suppressed")
+	}
+}
+
+func TestFilterSuppressedPairs_KeepsUnrelatedPair(t *testing.T) {
+	a := gi("x.js", 10, 20)
+	b := gi("y.js", 10, 20)
+	c := gi("z.js", 10, 20)
+	coveredPair := &ItemPair[*testItem]{Item1: a, Item2: b}
+	unrelatedPair := &ItemPair[*testItem]{Item1: a, Item2: c}
+
+	out := FilterSuppressedPairs(
+		[]*ItemPair[*testItem]{coveredPair, unrelatedPair},
+		map[string]struct{}{PairKey(a, b): {}},
+	)
+
+	if len(out) != 1 || out[0] != unrelatedPair {
+		t.Fatalf("expected unrelated pair sharing one member to survive, got %+v", out)
+	}
+}
+
+func TestFilterPairsWithSuppressedMembers(t *testing.T) {
+	a := gi("x.js", 10, 20)
+	b := gi("y.js", 10, 20)
+	c := gi("z.js", 10, 20)
+	suppressedPair := &ItemPair[*testItem]{Item1: a, Item2: b}
+	keptPair := &ItemPair[*testItem]{Item1: b, Item2: c}
+
+	out := FilterPairsWithSuppressedMembers(
+		[]*ItemPair[*testItem]{suppressedPair, keptPair},
+		map[string]struct{}{ItemKey(a): {}},
+	)
+
+	if len(out) != 1 || out[0] != keptPair {
+		t.Fatalf("expected only the pair without suppressed members to survive, got %+v", out)
+	}
+}
+
+// TestFilterGroupsWithoutBackingPairs_DropsUnbackedGroup verifies that a
+// group whose members have no positive-similarity backing pair is dropped,
+// while a backed group has its metadata refreshed.
+func TestFilterGroupsWithoutBackingPairs_DropsUnbackedGroup(t *testing.T) {
+	a := gi("x.js", 1, 10)
+	b := gi("x.js", 20, 30)
+	c := gi("y.js", 1, 10)
+	unbacked := mkGroup(1, a, b)
+	backed := mkGroup(2, a, c)
+	pairs := []*ItemPair[*testItem]{pair(a, c, 0.92, domain.Type4Clone)}
+
+	out := FilterGroupsWithoutBackingPairs([]*ItemGroup[*testItem]{unbacked, backed}, pairs)
+
+	if len(out) != 1 {
+		t.Fatalf("expected only the backed group to remain, got %d groups", len(out))
+	}
+	if out[0] != backed {
+		t.Fatalf("expected backed group to remain")
+	}
+	if !almostEqual(out[0].Similarity, 0.92) {
+		t.Fatalf("expected refreshed similarity 0.92, got %.3f", out[0].Similarity)
+	}
+}

--- a/core/clone/grouping.go
+++ b/core/clone/grouping.go
@@ -1,14 +1,29 @@
 package clone
 
 import (
-	"math"
+	"container/heap"
+	"container/list"
+	"fmt"
 	"sort"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
 )
 
-// GroupableItem represents an item that can be grouped (e.g. CodeFragment or domain.Clone).
+// ItemLocation is the source location of a groupable item. The zero value is
+// valid; items with equal locations fall back to ItemID ordering.
+type ItemLocation struct {
+	FilePath  string
+	StartLine int
+	EndLine   int
+	StartCol  int
+	EndCol    int
+}
+
+// GroupableItem represents an item that can be grouped (e.g. a code fragment
+// or clone). Items passed to this package must be non-nil.
 type GroupableItem interface {
 	ItemID() int
-	ItemKey() string // Sorting key: "filepath|startLine|endLine|startCol|endCol"
+	ItemLocation() ItemLocation
 }
 
 // ItemPair represents a pair of items with similarity information.
@@ -16,14 +31,14 @@ type ItemPair[T GroupableItem] struct {
 	Item1      T
 	Item2      T
 	Similarity float64
-	PairType   int // Clone type (1-4)
+	PairType   domain.CloneType
 }
 
 // ItemGroup represents a grouping result.
 type ItemGroup[T GroupableItem] struct {
 	ID         int
 	Items      []T
-	GroupType  int
+	GroupType  domain.CloneType
 	Similarity float64
 }
 
@@ -48,6 +63,12 @@ const (
 	ModeCentroid        GroupingMode = "centroid"
 )
 
+// Algorithm-specific constants.
+const (
+	starMedoidMaxIterations    = 10
+	starMedoidConvergenceRatio = 0.01
+)
+
 // GroupingConfig holds configuration for the grouping strategy.
 type GroupingConfig struct {
 	Mode      GroupingMode
@@ -59,136 +80,163 @@ type GroupingConfig struct {
 func NewGroupingStrategy[T GroupableItem](config GroupingConfig) GroupingStrategy[T] {
 	switch config.Mode {
 	case ModeKCore:
-		k := config.KCoreK
-		if k <= 0 {
-			k = 2
-		}
-		return &KCoreGrouping[T]{threshold: config.Threshold, k: k}
+		return NewKCoreGrouping[T](config.Threshold, config.KCoreK)
 	case ModeStarMedoid:
-		return &StarMedoidGrouping[T]{threshold: config.Threshold}
+		return NewStarMedoidGrouping[T](config.Threshold)
 	case ModeCompleteLinkage:
-		return &CompleteLinkageGrouping[T]{threshold: config.Threshold}
+		return NewCompleteLinkageGrouping[T](config.Threshold)
 	case ModeCentroid:
-		return &CentroidGrouping[T]{threshold: config.Threshold}
+		return NewCentroidGrouping[T](config.Threshold)
 	default:
-		return &ConnectedGrouping[T]{threshold: config.Threshold}
+		return NewConnectedGrouping[T](config.Threshold)
 	}
 }
 
 // ---------------------------------------------------------------------------
-// Helper functions (unexported)
+// Keys, ordering, and shared metadata helpers
 // ---------------------------------------------------------------------------
 
-// pairKey returns a normalized key for a pair of items, smaller key first.
-func pairKey[T GroupableItem](a, b T) string {
-	ka, kb := a.ItemKey(), b.ItemKey()
-	if ka > kb {
-		ka, kb = kb, ka
-	}
-	return ka + "|" + kb
+// ItemKey returns a stable identifier for an item based on its location.
+func ItemKey[T GroupableItem](item T) string {
+	loc := item.ItemLocation()
+	return fmt.Sprintf("%s|%d|%d|%d|%d", loc.FilePath, loc.StartLine, loc.EndLine, loc.StartCol, loc.EndCol)
 }
 
-// itemLess compares two items by their ItemKey for stable sorting.
+// PairKey returns a canonical key for a pair of items, independent of order.
+func PairKey[T GroupableItem](a, b T) string {
+	ka := ItemKey(a)
+	kb := ItemKey(b)
+	if ka <= kb {
+		return ka + "||" + kb
+	}
+	return kb + "||" + ka
+}
+
+// itemLess provides deterministic ordering between two items by location.
 func itemLess[T GroupableItem](a, b T) bool {
-	return a.ItemKey() < b.ItemKey()
+	al, bl := a.ItemLocation(), b.ItemLocation()
+	if al == bl {
+		return a.ItemID() < b.ItemID()
+	}
+	if al.FilePath != bl.FilePath {
+		return al.FilePath < bl.FilePath
+	}
+	if al.StartLine != bl.StartLine {
+		return al.StartLine < bl.StartLine
+	}
+	if al.StartCol != bl.StartCol {
+		return al.StartCol < bl.StartCol
+	}
+	if al.EndLine != bl.EndLine {
+		return al.EndLine < bl.EndLine
+	}
+	return al.EndCol < bl.EndCol
 }
 
-// averageGroupSimilarity computes the average similarity of all pairs whose
-// both endpoints are in the members set.
-func averageGroupSimilarity[T GroupableItem](pairs []*ItemPair[T], members map[int]bool) float64 {
+// itemSimilarity returns cached similarity, or 0 if not present.
+func itemSimilarity[T GroupableItem](sims map[string]float64, a, b T) float64 {
+	if a.ItemID() == b.ItemID() {
+		return 1.0
+	}
+	if s, ok := sims[PairKey(a, b)]; ok {
+		return s
+	}
+	return 0.0
+}
+
+// averageGroupSimilarity computes average pairwise similarity among members using cache.
+// Only pairs that exist in the similarity map are counted (missing pairs are skipped, not treated as 0).
+func averageGroupSimilarity[T GroupableItem](sims map[string]float64, members []T) float64 {
+	if len(members) < 2 {
+		return 1.0
+	}
 	sum := 0.0
-	count := 0
-	for _, p := range pairs {
-		if members[p.Item1.ItemID()] && members[p.Item2.ItemID()] {
-			sum += p.Similarity
-			count++
+	cnt := 0
+	for i := 0; i < len(members); i++ {
+		for j := i + 1; j < len(members); j++ {
+			key := PairKey(members[i], members[j])
+			if sim, ok := sims[key]; ok {
+				sum += sim
+				cnt++
+			}
 		}
 	}
-	if count == 0 {
+	if cnt == 0 {
 		return 0.0
 	}
-	return sum / float64(count)
+	return sum / float64(cnt)
 }
 
-// majorityType returns the most common PairType among pairs whose both
-// endpoints are in the members set.
-func majorityType[T GroupableItem](pairs []*ItemPair[T], members map[int]bool) int {
-	counts := make(map[int]int)
-	for _, p := range pairs {
-		if members[p.Item1.ItemID()] && members[p.Item2.ItemID()] {
-			counts[p.PairType]++
+// majorityType chooses the CloneType of the highest-similarity pair edge in
+// members. When several pairs share the maximum similarity, the most strict
+// (lowest enum) type wins. This prevents a high-similarity Type-2/Type-4 pair
+// from being hidden when lower-similarity Type-3 transitive edges outnumber it
+// in the same connected component.
+func majorityType[T GroupableItem](typeMap map[string]domain.CloneType, simMap map[string]float64, members []T) domain.CloneType {
+	maxSim := -1.0
+	var best domain.CloneType
+	found := false
+	for i := 0; i < len(members); i++ {
+		for j := i + 1; j < len(members); j++ {
+			key := PairKey(members[i], members[j])
+			t, tok := typeMap[key]
+			s, sok := simMap[key]
+			if !tok || !sok || t == 0 {
+				continue
+			}
+			found = true
+			if s > maxSim || (almostEqual(s, maxSim) && t < best) {
+				maxSim = s
+				best = t
+			}
 		}
 	}
-	bestType, bestCount := 0, -1
-	// Iterate in sorted order for determinism when counts are equal.
-	keys := make([]int, 0, len(counts))
-	for k := range counts {
-		keys = append(keys, k)
+	if !found {
+		return domain.Type4Clone // conservative fallback: never report unknown as Type-1
 	}
-	sort.Ints(keys)
-	for _, k := range keys {
-		if counts[k] > bestCount {
-			bestCount = counts[k]
-			bestType = k
+	return best
+}
+
+// pairMetadata reduces raw pairs to per-pair-key similarity and type maps,
+// keeping the highest-similarity record for duplicate keys.
+func pairMetadata[T GroupableItem](pairs []*ItemPair[T]) (map[string]float64, map[string]domain.CloneType) {
+	similarities := make(map[string]float64, len(pairs))
+	types := make(map[string]domain.CloneType, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil {
+			continue
+		}
+		key := PairKey(pair.Item1, pair.Item2)
+		if old, ok := similarities[key]; !ok || pair.Similarity > old {
+			similarities[key] = pair.Similarity
+			types[key] = pair.PairType
 		}
 	}
-	return bestType
+	return similarities, types
 }
 
-// almostEqual returns true if |a - b| < 1e-9.
-func almostEqual(a, b float64) bool {
-	return math.Abs(a-b) < 1e-9
-}
-
-// sortGroupItems sorts the items within a group by ItemKey for deterministic output.
-func sortGroupItems[T GroupableItem](items []T) {
-	sort.Slice(items, func(i, j int) bool {
-		return itemLess(items[i], items[j])
+func sortItemGroups[T GroupableItem](groups []*ItemGroup[T]) {
+	sort.Slice(groups, func(i, j int) bool {
+		if !almostEqual(groups[i].Similarity, groups[j].Similarity) {
+			return groups[i].Similarity > groups[j].Similarity
+		}
+		if len(groups[i].Items) != len(groups[j].Items) {
+			return len(groups[i].Items) > len(groups[j].Items)
+		}
+		if len(groups[i].Items) == 0 || len(groups[j].Items) == 0 {
+			return false
+		}
+		return itemLess(groups[i].Items[0], groups[j].Items[0])
 	})
 }
 
-// ---------------------------------------------------------------------------
-// adjacency builds an adjacency list and collects all unique items from pairs
-// that meet the similarity threshold.
-// ---------------------------------------------------------------------------
-
-type adjacency[T GroupableItem] struct {
-	items map[int]T            // id -> item
-	adj   map[int]map[int]bool // id -> set of neighbor ids
-}
-
-func buildAdjacency[T GroupableItem](pairs []*ItemPair[T], threshold float64) adjacency[T] {
-	a := adjacency[T]{
-		items: make(map[int]T),
-		adj:   make(map[int]map[int]bool),
+func almostEqual(a, b float64) bool {
+	const eps = 1e-9
+	d := a - b
+	if d < 0 {
+		d = -d
 	}
-	for _, p := range pairs {
-		if p.Similarity < threshold && !almostEqual(p.Similarity, threshold) {
-			continue
-		}
-		id1, id2 := p.Item1.ItemID(), p.Item2.ItemID()
-		a.items[id1] = p.Item1
-		a.items[id2] = p.Item2
-		if a.adj[id1] == nil {
-			a.adj[id1] = make(map[int]bool)
-		}
-		if a.adj[id2] == nil {
-			a.adj[id2] = make(map[int]bool)
-		}
-		a.adj[id1][id2] = true
-		a.adj[id2][id1] = true
-	}
-	return a
-}
-
-// sortedIDs returns all item IDs sorted for deterministic iteration.
-func (a *adjacency[T]) sortedIDs() []int {
-	ids := make([]int, 0, len(a.items))
-	for id := range a.items {
-		ids = append(ids, id)
-	}
-	sort.Ints(ids)
-	return ids
+	return d <= eps
 }
 
 // ---------------------------------------------------------------------------
@@ -237,6 +285,34 @@ func (u *unionFind) union(x, y int) {
 	}
 }
 
+// collectItems gathers unique items from pairs (insertion order) and reduces
+// pair metadata to per-key maps.
+func collectItems[T GroupableItem](pairs []*ItemPair[T]) ([]T, map[string]float64, map[string]domain.CloneType) {
+	items := make([]T, 0)
+	seen := make(map[int]struct{})
+	simMap := make(map[string]float64)
+	typeMap := make(map[string]domain.CloneType)
+	for _, p := range pairs {
+		if p == nil {
+			continue
+		}
+		if _, ok := seen[p.Item1.ItemID()]; !ok {
+			seen[p.Item1.ItemID()] = struct{}{}
+			items = append(items, p.Item1)
+		}
+		if _, ok := seen[p.Item2.ItemID()]; !ok {
+			seen[p.Item2.ItemID()] = struct{}{}
+			items = append(items, p.Item2)
+		}
+		key := PairKey(p.Item1, p.Item2)
+		if old, ok := simMap[key]; !ok || p.Similarity > old {
+			simMap[key] = p.Similarity
+			typeMap[key] = p.PairType
+		}
+	}
+	return items, simMap, typeMap
+}
+
 // ---------------------------------------------------------------------------
 // 1. ConnectedGrouping — Union-Find based connected components
 // ---------------------------------------------------------------------------
@@ -246,62 +322,70 @@ type ConnectedGrouping[T GroupableItem] struct {
 	threshold float64
 }
 
-func (c *ConnectedGrouping[T]) Name() string { return "connected" }
+func NewConnectedGrouping[T GroupableItem](threshold float64) *ConnectedGrouping[T] {
+	return &ConnectedGrouping[T]{threshold: threshold}
+}
+
+func (c *ConnectedGrouping[T]) Name() string { return string(ModeConnected) }
 
 func (c *ConnectedGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
 	if len(pairs) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	graph := buildAdjacency[T](pairs, c.threshold)
-	if len(graph.items) == 0 {
+	items, simMap, typeMap := collectItems(pairs)
+	if len(items) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
+	// Union-Find across edges with similarity >= threshold
 	uf := newUnionFind()
-	for id := range graph.items {
-		uf.makeSet(id)
+	for _, item := range items {
+		uf.makeSet(item.ItemID())
 	}
-	for id, neighbors := range graph.adj {
-		for nid := range neighbors {
-			uf.union(id, nid)
+	for _, p := range pairs {
+		if p == nil {
+			continue
+		}
+		if p.Similarity >= c.threshold {
+			uf.union(p.Item1.ItemID(), p.Item2.ItemID())
 		}
 	}
 
-	// Collect components.
-	components := make(map[int][]int) // root -> list of item ids
-	for _, id := range graph.sortedIDs() {
-		root := uf.find(id)
-		components[root] = append(components[root], id)
+	// Build components
+	comp := make(map[int][]T)
+	for _, item := range items {
+		r := uf.find(item.ItemID())
+		comp[r] = append(comp[r], item)
 	}
 
-	// Sort component roots for deterministic ordering.
-	roots := make([]int, 0, len(components))
-	for r := range components {
+	// Iterate components in sorted root order for deterministic group IDs.
+	roots := make([]int, 0, len(comp))
+	for r := range comp {
 		roots = append(roots, r)
 	}
 	sort.Ints(roots)
 
-	groups := make([]*ItemGroup[T], 0, len(components))
-	groupID := 1
+	// Convert to groups, exclude singletons
+	groups := make([]*ItemGroup[T], 0, len(comp))
+	groupID := 0
 	for _, root := range roots {
-		memberIDs := components[root]
-		members := make(map[int]bool, len(memberIDs))
-		items := make([]T, 0, len(memberIDs))
-		for _, id := range memberIDs {
-			members[id] = true
-			items = append(items, graph.items[id])
+		members := comp[root]
+		if len(members) < 2 {
+			continue
 		}
-		sortGroupItems(items)
-
+		sort.Slice(members, func(i, j int) bool { return itemLess(members[i], members[j]) })
 		groups = append(groups, &ItemGroup[T]{
 			ID:         groupID,
-			Items:      items,
-			GroupType:  majorityType(pairs, members),
-			Similarity: averageGroupSimilarity(pairs, members),
+			Items:      members,
+			GroupType:  majorityType(typeMap, simMap, members),
+			Similarity: averageGroupSimilarity(simMap, members),
 		})
 		groupID++
 	}
+
+	sortItemGroups(groups)
+
 	return groups
 }
 
@@ -309,540 +393,1220 @@ func (c *ConnectedGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] 
 // 2. KCoreGrouping — k-core subgraph decomposition
 // ---------------------------------------------------------------------------
 
-// KCoreGrouping finds k-core subgraphs and groups their connected components.
+// KCoreGrouping ensures each item has at least k similar neighbors.
 type KCoreGrouping[T GroupableItem] struct {
 	threshold float64
 	k         int
 }
 
-func (kc *KCoreGrouping[T]) Name() string { return "k_core" }
+func NewKCoreGrouping[T GroupableItem](threshold float64, k int) *KCoreGrouping[T] {
+	if k < 2 {
+		k = 2 // Minimum meaningful value
+	}
+	return &KCoreGrouping[T]{threshold: threshold, k: k}
+}
 
-func (kc *KCoreGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
+func (kg *KCoreGrouping[T]) Name() string { return string(ModeKCore) }
+
+func (kg *KCoreGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
 	if len(pairs) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	graph := buildAdjacency[T](pairs, kc.threshold)
-	if len(graph.items) == 0 {
+	items, simMap, typeMap := collectItems(pairs)
+	if len(items) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	// Copy adjacency so we can mutate it during peeling.
-	adj := make(map[int]map[int]bool, len(graph.adj))
-	for id, nbrs := range graph.adj {
-		cp := make(map[int]bool, len(nbrs))
-		for n := range nbrs {
-			cp[n] = true
-		}
-		adj[id] = cp
+	// Build adjacency with edges meeting threshold
+	adj := make(map[int]map[int]float64, len(items))
+	for _, item := range items {
+		adj[item.ItemID()] = make(map[int]float64)
 	}
-
-	// Iteratively remove nodes with degree < k.
-	changed := true
-	for changed {
-		changed = false
-		for id := range adj {
-			if len(adj[id]) < kc.k {
-				// Remove this node.
-				for nid := range adj[id] {
-					delete(adj[nid], id)
-				}
-				delete(adj, id)
-				changed = true
-			}
-		}
-	}
-
-	if len(adj) == 0 {
-		return []*ItemGroup[T]{}
-	}
-
-	// Find connected components among remaining nodes via BFS.
-	visited := make(map[int]bool)
-	var components [][]int
-
-	// Sort remaining IDs for determinism.
-	remaining := make([]int, 0, len(adj))
-	for id := range adj {
-		remaining = append(remaining, id)
-	}
-	sort.Ints(remaining)
-
-	for _, id := range remaining {
-		if visited[id] {
+	for _, p := range pairs {
+		if p == nil {
 			continue
 		}
-		// BFS
-		queue := []int{id}
-		visited[id] = true
-		var comp []int
-		for len(queue) > 0 {
-			cur := queue[0]
-			queue = queue[1:]
-			comp = append(comp, cur)
-			for nid := range adj[cur] {
-				if !visited[nid] {
-					visited[nid] = true
-					queue = append(queue, nid)
+		if p.Similarity >= kg.threshold {
+			adj[p.Item1.ItemID()][p.Item2.ItemID()] = p.Similarity
+			adj[p.Item2.ItemID()][p.Item1.ItemID()] = p.Similarity
+		}
+	}
+
+	// Build item ID to item map
+	itemByID := make(map[int]T)
+	for _, item := range items {
+		itemByID[item.ItemID()] = item
+	}
+
+	// Compute initial degrees
+	degree := make(map[int]int, len(items))
+	for id, nbrs := range adj {
+		degree[id] = len(nbrs)
+	}
+
+	// Queue for items with degree < k
+	q := list.New()
+	inQueue := make(map[int]bool)
+	for id, d := range degree {
+		if d < kg.k {
+			q.PushBack(id)
+			inQueue[id] = true
+		}
+	}
+
+	// Iteratively remove low-degree items
+	removed := make(map[int]bool)
+	for q.Len() > 0 {
+		e := q.Front()
+		q.Remove(e)
+		v := e.Value.(int)
+		if removed[v] {
+			continue
+		}
+		removed[v] = true
+		// Decrease degree of neighbors
+		for u := range adj[v] {
+			if removed[u] {
+				continue
+			}
+			degree[u]--
+			delete(adj[u], v)
+			if degree[u] < kg.k && !inQueue[u] {
+				q.PushBack(u)
+				inQueue[u] = true
+			}
+		}
+		// Clear v's adjacency
+		delete(adj, v)
+	}
+
+	// Remaining items form the k-core subgraph
+	// Now find connected components among remaining items
+	groups := make([]*ItemGroup[T], 0)
+	visited := make(map[int]bool)
+	groupID := 0
+
+	// Build deterministic order
+	sort.Slice(items, func(i, j int) bool { return itemLess(items[i], items[j]) })
+
+	for _, start := range items {
+		if removed[start.ItemID()] || visited[start.ItemID()] || adj[start.ItemID()] == nil {
+			continue
+		}
+		// BFS/DFS to collect component
+		stack := []int{start.ItemID()}
+		component := make([]T, 0)
+		visited[start.ItemID()] = true
+		for len(stack) > 0 {
+			v := stack[len(stack)-1]
+			stack = stack[:len(stack)-1]
+			component = append(component, itemByID[v])
+			for u := range adj[v] {
+				if !removed[u] && !visited[u] {
+					visited[u] = true
+					stack = append(stack, u)
 				}
 			}
 		}
-		components = append(components, comp)
-	}
-
-	groups := make([]*ItemGroup[T], 0, len(components))
-	groupID := 1
-	for _, comp := range components {
-		members := make(map[int]bool, len(comp))
-		items := make([]T, 0, len(comp))
-		for _, id := range comp {
-			members[id] = true
-			items = append(items, graph.items[id])
+		if len(component) < 2 {
+			continue
 		}
-		sortGroupItems(items)
-
+		sort.Slice(component, func(i, j int) bool { return itemLess(component[i], component[j]) })
 		groups = append(groups, &ItemGroup[T]{
 			ID:         groupID,
-			Items:      items,
-			GroupType:  majorityType(pairs, members),
-			Similarity: averageGroupSimilarity(pairs, members),
+			Items:      component,
+			GroupType:  majorityType(typeMap, simMap, component),
+			Similarity: averageGroupSimilarity(simMap, component),
 		})
 		groupID++
 	}
+
+	sortItemGroups(groups)
+
 	return groups
 }
 
 // ---------------------------------------------------------------------------
-// 3. StarMedoidGrouping — greedy medoid star expansion
+// 3. StarMedoidGrouping — iterative medoid refinement
 // ---------------------------------------------------------------------------
 
-// StarMedoidGrouping builds groups by iteratively selecting the item with the
-// highest average similarity to its neighbors (the medoid), grouping it with
-// its neighbors, and repeating.
+// StarMedoidGrouping uses iterative medoid optimization for balanced precision/recall.
 type StarMedoidGrouping[T GroupableItem] struct {
 	threshold float64
 }
 
-func (s *StarMedoidGrouping[T]) Name() string { return "star_medoid" }
+func NewStarMedoidGrouping[T GroupableItem](threshold float64) *StarMedoidGrouping[T] {
+	return &StarMedoidGrouping[T]{threshold: threshold}
+}
+
+func (s *StarMedoidGrouping[T]) Name() string { return string(ModeStarMedoid) }
 
 func (s *StarMedoidGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
 	if len(pairs) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	graph := buildAdjacency[T](pairs, s.threshold)
-	if len(graph.items) == 0 {
+	items, simMap, typeMap := collectItems(pairs)
+	if len(items) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	// Build a similarity lookup: (id1, id2) -> similarity.
-	simMap := make(map[[2]int]float64)
+	// Build item ID to item map
+	itemByID := make(map[int]T)
+	for _, item := range items {
+		itemByID[item.ItemID()] = item
+	}
+
+	// Phase 1: Initial clustering using Union-Find (same as ConnectedGrouping)
+	uf := newUnionFind()
+	for _, item := range items {
+		uf.makeSet(item.ItemID())
+	}
 	for _, p := range pairs {
-		if p.Similarity < s.threshold && !almostEqual(p.Similarity, s.threshold) {
+		if p == nil {
 			continue
 		}
-		id1, id2 := p.Item1.ItemID(), p.Item2.ItemID()
-		simMap[[2]int{id1, id2}] = p.Similarity
-		simMap[[2]int{id2, id1}] = p.Similarity
-	}
-
-	remaining := make(map[int]bool, len(graph.items))
-	for id := range graph.items {
-		remaining[id] = true
-	}
-
-	groups := make([]*ItemGroup[T], 0)
-	groupID := 1
-
-	for len(remaining) > 0 {
-		// Compute average similarity for each remaining item to its remaining neighbors.
-		bestID := -1
-		bestAvg := -1.0
-
-		// Sort remaining IDs for deterministic tie-breaking (lowest ID wins).
-		remIDs := make([]int, 0, len(remaining))
-		for id := range remaining {
-			remIDs = append(remIDs, id)
+		if p.Similarity >= s.threshold {
+			uf.union(p.Item1.ItemID(), p.Item2.ItemID())
 		}
-		sort.Ints(remIDs)
+	}
 
-		for _, id := range remIDs {
-			nbrs := graph.adj[id]
-			sum := 0.0
-			count := 0
-			for nid := range nbrs {
-				if remaining[nid] {
-					sum += simMap[[2]int{id, nid}]
-					count++
+	// Build initial components
+	comp := make(map[int][]T)
+	for _, item := range items {
+		r := uf.find(item.ItemID())
+		comp[r] = append(comp[r], item)
+	}
+
+	// Convert to groups (singletons excluded)
+	type groupData struct {
+		members   []T
+		medoid    T
+		hasMedoid bool
+	}
+	groups := make([]*groupData, 0)
+	for _, members := range comp {
+		if len(members) < 2 {
+			continue
+		}
+		groups = append(groups, &groupData{members: members})
+	}
+
+	if len(groups) == 0 {
+		return []*ItemGroup[T]{}
+	}
+
+	// Phase 2: Iterative medoid refinement
+	for iter := 0; iter < starMedoidMaxIterations; iter++ {
+		// Find medoid for each group
+		for _, g := range groups {
+			g.medoid, g.hasMedoid = s.findMedoid(g.members, simMap)
+		}
+
+		// Build item-to-group map for O(1) lookup
+		itemToGroup := make(map[int]int)
+		for gi, g := range groups {
+			for _, m := range g.members {
+				itemToGroup[m.ItemID()] = gi
+			}
+		}
+
+		// Reassign items to closest medoid
+		newAssignment := make(map[int]int) // item ID -> group index
+		changed := 0
+
+		for _, item := range items {
+			bestGroup := -1
+			bestSim := -1.0
+
+			for gi, g := range groups {
+				if !g.hasMedoid {
+					continue
+				}
+				sim := itemSimilarity(simMap, item, g.medoid)
+				if sim >= s.threshold && sim > bestSim {
+					bestSim = sim
+					bestGroup = gi
 				}
 			}
-			if count == 0 {
-				continue
-			}
-			avg := sum / float64(count)
-			if avg > bestAvg || (almostEqual(avg, bestAvg) && (bestID == -1 || id < bestID)) {
-				bestAvg = avg
-				bestID = id
+
+			// Find current group using O(1) lookup
+			currentGroup, inGroup := itemToGroup[item.ItemID()]
+
+			if bestGroup >= 0 {
+				newAssignment[item.ItemID()] = bestGroup
+				if bestGroup != currentGroup {
+					changed++
+				}
+			} else if inGroup {
+				// Item doesn't match any medoid above threshold, keep in current group
+				newAssignment[item.ItemID()] = currentGroup
 			}
 		}
 
-		if bestID == -1 {
-			// Remaining items have no neighbors among remaining items. Add each as singleton.
-			for _, id := range remIDs {
-				items := []T{graph.items[id]}
-				members := map[int]bool{id: true}
-				groups = append(groups, &ItemGroup[T]{
-					ID:         groupID,
-					Items:      items,
-					GroupType:  majorityType(pairs, members),
-					Similarity: 0.0,
-				})
-				groupID++
-				delete(remaining, id)
+		// Rebuild groups from new assignments
+		newGroups := make([]*groupData, len(groups))
+		for i := range newGroups {
+			newGroups[i] = &groupData{members: make([]T, 0)}
+		}
+		for itemID, gi := range newAssignment {
+			newGroups[gi].members = append(newGroups[gi].members, itemByID[itemID])
+		}
+
+		// Filter empty groups
+		filteredGroups := make([]*groupData, 0)
+		for _, g := range newGroups {
+			if len(g.members) >= 2 {
+				filteredGroups = append(filteredGroups, g)
 			}
+		}
+		groups = filteredGroups
+
+		if len(groups) == 0 {
+			return []*ItemGroup[T]{}
+		}
+
+		// Check convergence
+		if float64(changed)/float64(len(items)) < starMedoidConvergenceRatio {
 			break
 		}
+	}
 
-		// Collect the medoid and its remaining neighbors into a group.
-		memberIDs := []int{bestID}
-		for nid := range graph.adj[bestID] {
-			if remaining[nid] {
-				memberIDs = append(memberIDs, nid)
-			}
+	// Phase 3: Finalize groups
+	result := make([]*ItemGroup[T], 0, len(groups))
+	groupID := 0
+	for _, g := range groups {
+		if len(g.members) < 2 {
+			continue
 		}
-
-		members := make(map[int]bool, len(memberIDs))
-		items := make([]T, 0, len(memberIDs))
-		for _, id := range memberIDs {
-			members[id] = true
-			items = append(items, graph.items[id])
-			delete(remaining, id)
-		}
-		sortGroupItems(items)
-
-		groups = append(groups, &ItemGroup[T]{
+		sort.Slice(g.members, func(i, j int) bool { return itemLess(g.members[i], g.members[j]) })
+		result = append(result, &ItemGroup[T]{
 			ID:         groupID,
-			Items:      items,
-			GroupType:  majorityType(pairs, members),
-			Similarity: averageGroupSimilarity(pairs, members),
+			Items:      g.members,
+			GroupType:  majorityType(typeMap, simMap, g.members),
+			Similarity: averageGroupSimilarity(simMap, g.members),
 		})
 		groupID++
 	}
 
-	return groups
+	sortItemGroups(result)
+
+	return result
+}
+
+// findMedoid returns the item with highest average similarity to all other members.
+func (s *StarMedoidGrouping[T]) findMedoid(members []T, simMap map[string]float64) (T, bool) {
+	var zero T
+	if len(members) == 0 {
+		return zero, false
+	}
+	if len(members) == 1 {
+		return members[0], true
+	}
+
+	bestMedoid := zero
+	found := false
+	bestAvgSim := -1.0
+
+	for _, candidate := range members {
+		sumSim := 0.0
+		for _, other := range members {
+			if candidate.ItemID() != other.ItemID() {
+				sumSim += itemSimilarity(simMap, candidate, other)
+			}
+		}
+		avgSim := sumSim / float64(len(members)-1)
+		if avgSim > bestAvgSim {
+			bestAvgSim = avgSim
+			bestMedoid = candidate
+			found = true
+		}
+	}
+
+	return bestMedoid, found
 }
 
 // ---------------------------------------------------------------------------
-// 4. CompleteLinkageGrouping — Bron-Kerbosch maximal cliques
+// 4. CompleteLinkageGrouping — agglomerative complete-linkage clustering
 // ---------------------------------------------------------------------------
 
-// CompleteLinkageGrouping finds maximal cliques using the Bron-Kerbosch
-// algorithm with pivoting. Each clique becomes a group. If an item appears
-// in multiple cliques, it is assigned to the largest one.
+// CompleteLinkageGrouping ensures all pairs within a group have similarity above threshold.
 type CompleteLinkageGrouping[T GroupableItem] struct {
 	threshold float64
 }
 
-func (cl *CompleteLinkageGrouping[T]) Name() string { return "complete_linkage" }
+func NewCompleteLinkageGrouping[T GroupableItem](threshold float64) *CompleteLinkageGrouping[T] {
+	return &CompleteLinkageGrouping[T]{threshold: threshold}
+}
 
-func (cl *CompleteLinkageGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
-	if len(pairs) == 0 {
+func (c *CompleteLinkageGrouping[T]) Name() string { return string(ModeCompleteLinkage) }
+
+func (c *CompleteLinkageGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
+	input := c.collectInput(pairs)
+	if len(input.items) < 2 {
 		return []*ItemGroup[T]{}
 	}
 
-	graph := buildAdjacency[T](pairs, cl.threshold)
-	if len(graph.items) == 0 {
-		return []*ItemGroup[T]{}
+	clusterer := newCompleteLinkageClusterer(input.items, input.edges)
+	clusterer.mergeUntilStable()
+
+	return c.buildGroups(clusterer.activeClusters(), input.similarities, input.types)
+}
+
+type completeLinkageInput[T GroupableItem] struct {
+	items        []T
+	similarities map[string]float64
+	types        map[string]domain.CloneType
+	edges        []completeLinkageEdge
+}
+
+type completeLinkagePairRecord[T GroupableItem] struct {
+	left       T
+	right      T
+	similarity float64
+	cloneType  domain.CloneType
+}
+
+type completeLinkageEdge struct {
+	leftID  int
+	rightID int
+	score   float64
+}
+
+func (c *CompleteLinkageGrouping[T]) collectInput(pairs []*ItemPair[T]) completeLinkageInput[T] {
+	input := completeLinkageInput[T]{
+		items:        make([]T, 0),
+		similarities: make(map[string]float64),
+		types:        make(map[string]domain.CloneType),
 	}
 
-	// Find all maximal cliques using Bron-Kerbosch with pivot.
-	var cliques [][]int
-	allIDs := graph.sortedIDs()
-
-	pSet := make(map[int]bool, len(allIDs))
-	for _, id := range allIDs {
-		pSet[id] = true
-	}
-
-	var bronKerbosch func(r, p, x map[int]bool)
-	bronKerbosch = func(r, p, x map[int]bool) {
-		if len(p) == 0 && len(x) == 0 {
-			// R is a maximal clique.
-			clique := make([]int, 0, len(r))
-			for id := range r {
-				clique = append(clique, id)
-			}
-			sort.Ints(clique)
-			cliques = append(cliques, clique)
-			return
-		}
-
-		// Choose pivot: node in P ∪ X with the most neighbors in P.
-		pivot := -1
-		pivotDeg := -1
-		union := make([]int, 0, len(p)+len(x))
-		for id := range p {
-			union = append(union, id)
-		}
-		for id := range x {
-			union = append(union, id)
-		}
-		sort.Ints(union)
-		for _, u := range union {
-			deg := 0
-			for nid := range graph.adj[u] {
-				if p[nid] {
-					deg++
-				}
-			}
-			if deg > pivotDeg || (deg == pivotDeg && (pivot == -1 || u < pivot)) {
-				pivotDeg = deg
-				pivot = u
-			}
-		}
-
-		// Iterate over P \ N(pivot) in sorted order.
-		candidates := make([]int, 0, len(p))
-		for id := range p {
-			if !graph.adj[pivot][id] {
-				candidates = append(candidates, id)
-			}
-		}
-		sort.Ints(candidates)
-
-		for _, v := range candidates {
-			newR := make(map[int]bool, len(r)+1)
-			for id := range r {
-				newR[id] = true
-			}
-			newR[v] = true
-
-			newP := make(map[int]bool)
-			for id := range p {
-				if graph.adj[v][id] {
-					newP[id] = true
-				}
-			}
-
-			newX := make(map[int]bool)
-			for id := range x {
-				if graph.adj[v][id] {
-					newX[id] = true
-				}
-			}
-
-			bronKerbosch(newR, newP, newX)
-
-			delete(p, v)
-			x[v] = true
-		}
-	}
-
-	bronKerbosch(
-		make(map[int]bool),
-		pSet,
-		make(map[int]bool),
-	)
-
-	if len(cliques) == 0 {
-		return []*ItemGroup[T]{}
-	}
-
-	// Sort cliques: largest first, then by first element for determinism.
-	sort.Slice(cliques, func(i, j int) bool {
-		if len(cliques[i]) != len(cliques[j]) {
-			return len(cliques[i]) > len(cliques[j])
-		}
-		// Same size: compare element by element.
-		for k := 0; k < len(cliques[i]) && k < len(cliques[j]); k++ {
-			if cliques[i][k] != cliques[j][k] {
-				return cliques[i][k] < cliques[j][k]
-			}
-		}
-		return false
-	})
-
-	// Assign each item to the largest clique it belongs to.
-	assigned := make(map[int]bool)
-	groups := make([]*ItemGroup[T], 0)
-	groupID := 1
-
-	for _, clique := range cliques {
-		// Filter out already-assigned items.
-		var memberIDs []int
-		for _, id := range clique {
-			if !assigned[id] {
-				memberIDs = append(memberIDs, id)
-			}
-		}
-		if len(memberIDs) == 0 {
+	seen := make(map[int]struct{})
+	pairRecords := make(map[string]completeLinkagePairRecord[T])
+	for _, pair := range pairs {
+		if pair == nil {
 			continue
 		}
 
-		members := make(map[int]bool, len(memberIDs))
-		items := make([]T, 0, len(memberIDs))
-		for _, id := range memberIDs {
-			members[id] = true
-			assigned[id] = true
-			items = append(items, graph.items[id])
+		if _, ok := seen[pair.Item1.ItemID()]; !ok {
+			seen[pair.Item1.ItemID()] = struct{}{}
+			input.items = append(input.items, pair.Item1)
 		}
-		sortGroupItems(items)
+		if _, ok := seen[pair.Item2.ItemID()]; !ok {
+			seen[pair.Item2.ItemID()] = struct{}{}
+			input.items = append(input.items, pair.Item2)
+		}
+
+		key := PairKey(pair.Item1, pair.Item2)
+		record, ok := pairRecords[key]
+		if !ok || pair.Similarity > record.similarity {
+			pairRecords[key] = completeLinkagePairRecord[T]{
+				left:       pair.Item1,
+				right:      pair.Item2,
+				similarity: pair.Similarity,
+				cloneType:  pair.PairType,
+			}
+			input.similarities[key] = pair.Similarity
+			input.types[key] = pair.PairType
+		}
+	}
+
+	itemIndexes := make(map[int]int, len(input.items))
+	for index, item := range input.items {
+		itemIndexes[item.ItemID()] = index
+	}
+
+	input.edges = make([]completeLinkageEdge, 0, len(pairRecords))
+	for _, record := range pairRecords {
+		if record.similarity < c.threshold {
+			continue
+		}
+
+		leftID, rightID := orderClusterIDs(itemIndexes[record.left.ItemID()], itemIndexes[record.right.ItemID()])
+		input.edges = append(input.edges, completeLinkageEdge{
+			leftID:  leftID,
+			rightID: rightID,
+			score:   record.similarity,
+		})
+	}
+
+	return input
+}
+
+func (c *CompleteLinkageGrouping[T]) buildGroups(activeClusters []*completeLinkageCluster[T], similarities map[string]float64, types map[string]domain.CloneType) []*ItemGroup[T] {
+	groups := make([]*ItemGroup[T], 0, len(activeClusters))
+	groupID := 0
+	for _, cluster := range activeClusters {
+		members := cluster.members
+		if len(members) < 2 {
+			continue
+		}
+
+		// Keep a final safety check so the optimized clusterer cannot return a
+		// non-clique even if an internal update regresses later.
+		valid := true
+		for i := 0; i < len(members) && valid; i++ {
+			for j := i + 1; j < len(members); j++ {
+				if itemSimilarity(similarities, members[i], members[j]) < c.threshold {
+					valid = false
+					break
+				}
+			}
+		}
+		if !valid {
+			continue
+		}
+
+		sortedMembers := append([]T(nil), members...)
+		sort.Slice(sortedMembers, func(i, j int) bool { return itemLess(sortedMembers[i], sortedMembers[j]) })
 
 		groups = append(groups, &ItemGroup[T]{
 			ID:         groupID,
-			Items:      items,
-			GroupType:  majorityType(pairs, members),
-			Similarity: averageGroupSimilarity(pairs, members),
+			Items:      sortedMembers,
+			GroupType:  majorityType(types, similarities, sortedMembers),
+			Similarity: averageGroupSimilarity(similarities, sortedMembers),
 		})
 		groupID++
 	}
 
+	sortItemGroups(groups)
+
 	return groups
 }
 
+// completeLinkageClusterer stores only threshold-qualified inter-cluster edges.
+// That keeps sparse workloads sparse while still supporting exact complete-linkage
+// merges, since a merged cluster can stay adjacent to C only if both source
+// clusters already had qualifying edges to C.
+type completeLinkageClusterer[T GroupableItem] struct {
+	clusters      []completeLinkageCluster[T]
+	bestNeighbors *completeLinkageBestNeighborHeap
+}
+
+type completeLinkageCluster[T GroupableItem] struct {
+	members   []T
+	neighbors map[int]float64
+	active    bool
+}
+
+func newCompleteLinkageClusterer[T GroupableItem](items []T, edges []completeLinkageEdge) *completeLinkageClusterer[T] {
+	clusterer := &completeLinkageClusterer[T]{
+		clusters:      make([]completeLinkageCluster[T], len(items)),
+		bestNeighbors: newCompleteLinkageBestNeighborHeap(len(items)),
+	}
+
+	for clusterID, item := range items {
+		clusterer.clusters[clusterID] = completeLinkageCluster[T]{
+			members:   []T{item},
+			neighbors: make(map[int]float64),
+			active:    true,
+		}
+	}
+
+	for _, edge := range edges {
+		clusterer.clusters[edge.leftID].neighbors[edge.rightID] = edge.score
+		clusterer.clusters[edge.rightID].neighbors[edge.leftID] = edge.score
+	}
+
+	for clusterID := range clusterer.clusters {
+		clusterer.recomputeBestNeighbor(clusterID)
+	}
+
+	return clusterer
+}
+
+func (c *completeLinkageClusterer[T]) mergeUntilStable() {
+	for {
+		bestNeighbor, ok := c.bestNeighbors.popBest()
+		if !ok {
+			return
+		}
+
+		targetID, sourceID := orderClusterIDs(bestNeighbor.clusterID, bestNeighbor.neighborID)
+		if !c.clusters[targetID].active || !c.clusters[sourceID].active {
+			continue
+		}
+
+		c.mergeClusters(targetID, sourceID)
+	}
+}
+
+func (c *completeLinkageClusterer[T]) mergeClusters(targetID, sourceID int) {
+	target := &c.clusters[targetID]
+	source := &c.clusters[sourceID]
+	target.members = append(target.members, source.members...)
+
+	affected := make(map[int]struct{}, len(target.neighbors)+len(source.neighbors))
+	for neighborID := range target.neighbors {
+		affected[neighborID] = struct{}{}
+	}
+	for neighborID := range source.neighbors {
+		affected[neighborID] = struct{}{}
+	}
+	delete(affected, targetID)
+	delete(affected, sourceID)
+
+	newTargetNeighbors := make(map[int]float64)
+	for neighborID := range affected {
+		if !c.clusters[neighborID].active {
+			continue
+		}
+
+		neighbor := &c.clusters[neighborID]
+		delete(neighbor.neighbors, sourceID)
+
+		targetScore, targetOK := target.neighbors[neighborID]
+		sourceScore, sourceOK := source.neighbors[neighborID]
+		if !targetOK || !sourceOK {
+			delete(neighbor.neighbors, targetID)
+			continue
+		}
+
+		mergedScore := targetScore
+		if sourceScore < mergedScore {
+			mergedScore = sourceScore
+		}
+		newTargetNeighbors[neighborID] = mergedScore
+		neighbor.neighbors[targetID] = mergedScore
+	}
+
+	target.neighbors = newTargetNeighbors
+	source.active = false
+	source.members = nil
+	source.neighbors = nil
+
+	c.bestNeighbors.remove(sourceID)
+	for neighborID := range affected {
+		if c.clusters[neighborID].active {
+			c.recomputeBestNeighbor(neighborID)
+		}
+	}
+	c.recomputeBestNeighbor(targetID)
+}
+
+func (c *completeLinkageClusterer[T]) recomputeBestNeighbor(clusterID int) {
+	cluster := &c.clusters[clusterID]
+	if !cluster.active {
+		c.bestNeighbors.remove(clusterID)
+		return
+	}
+
+	bestNeighborID, bestScore, ok := c.findBestNeighbor(clusterID)
+	if !ok {
+		c.bestNeighbors.remove(clusterID)
+		return
+	}
+
+	c.bestNeighbors.set(clusterID, bestNeighborID, bestScore)
+}
+
+func (c *completeLinkageClusterer[T]) findBestNeighbor(clusterID int) (int, float64, bool) {
+	cluster := &c.clusters[clusterID]
+	bestNeighborID := -1
+	bestScore := 0.0
+	for neighborID, score := range cluster.neighbors {
+		if !c.clusters[neighborID].active {
+			continue
+		}
+		if bestNeighborID == -1 || betterCompleteLinkageNeighbor(clusterID, neighborID, score, bestNeighborID, bestScore) {
+			bestNeighborID = neighborID
+			bestScore = score
+		}
+	}
+	if bestNeighborID == -1 {
+		return 0, 0.0, false
+	}
+
+	return bestNeighborID, bestScore, true
+}
+
+func betterCompleteLinkageNeighbor(clusterID, candidateNeighborID int, candidateScore float64, bestNeighborID int, bestScore float64) bool {
+	if !almostEqual(candidateScore, bestScore) {
+		return candidateScore > bestScore
+	}
+
+	candidateLeft, candidateRight := orderClusterIDs(clusterID, candidateNeighborID)
+	bestLeft, bestRight := orderClusterIDs(clusterID, bestNeighborID)
+	if candidateLeft != bestLeft {
+		return candidateLeft < bestLeft
+	}
+	return candidateRight < bestRight
+}
+
+func (c *completeLinkageClusterer[T]) activeClusters() []*completeLinkageCluster[T] {
+	activeClusters := make([]*completeLinkageCluster[T], 0)
+	for clusterID := range c.clusters {
+		if c.clusters[clusterID].active {
+			activeClusters = append(activeClusters, &c.clusters[clusterID])
+		}
+	}
+	return activeClusters
+}
+
+type completeLinkageBestNeighbor struct {
+	clusterID  int
+	neighborID int
+	score      float64
+}
+
+type completeLinkageBestNeighborHeap struct {
+	entries   []completeLinkageBestNeighbor
+	positions []int
+}
+
+func newCompleteLinkageBestNeighborHeap(clusterCount int) *completeLinkageBestNeighborHeap {
+	positions := make([]int, clusterCount)
+	for i := range positions {
+		positions[i] = -1
+	}
+	return &completeLinkageBestNeighborHeap{positions: positions}
+}
+
+func (h *completeLinkageBestNeighborHeap) Len() int { return len(h.entries) }
+
+func (h *completeLinkageBestNeighborHeap) Less(i, j int) bool {
+	if !almostEqual(h.entries[i].score, h.entries[j].score) {
+		return h.entries[i].score > h.entries[j].score
+	}
+
+	leftI, rightI := orderClusterIDs(h.entries[i].clusterID, h.entries[i].neighborID)
+	leftJ, rightJ := orderClusterIDs(h.entries[j].clusterID, h.entries[j].neighborID)
+	if leftI != leftJ {
+		return leftI < leftJ
+	}
+	if rightI != rightJ {
+		return rightI < rightJ
+	}
+	return h.entries[i].clusterID < h.entries[j].clusterID
+}
+
+func (h *completeLinkageBestNeighborHeap) Swap(i, j int) {
+	h.entries[i], h.entries[j] = h.entries[j], h.entries[i]
+	h.positions[h.entries[i].clusterID] = i
+	h.positions[h.entries[j].clusterID] = j
+}
+
+func (h *completeLinkageBestNeighborHeap) Push(x any) {
+	entry := x.(completeLinkageBestNeighbor)
+	h.positions[entry.clusterID] = len(h.entries)
+	h.entries = append(h.entries, entry)
+}
+
+func (h *completeLinkageBestNeighborHeap) Pop() any {
+	last := len(h.entries) - 1
+	entry := h.entries[last]
+	h.entries = h.entries[:last]
+	h.positions[entry.clusterID] = -1
+	return entry
+}
+
+func (h *completeLinkageBestNeighborHeap) set(clusterID, neighborID int, score float64) {
+	if position := h.positions[clusterID]; position >= 0 {
+		h.entries[position].neighborID = neighborID
+		h.entries[position].score = score
+		heap.Fix(h, position)
+		return
+	}
+
+	heap.Push(h, completeLinkageBestNeighbor{
+		clusterID:  clusterID,
+		neighborID: neighborID,
+		score:      score,
+	})
+}
+
+func (h *completeLinkageBestNeighborHeap) remove(clusterID int) {
+	position := h.positions[clusterID]
+	if position < 0 {
+		return
+	}
+	heap.Remove(h, position)
+}
+
+func (h *completeLinkageBestNeighborHeap) popBest() (completeLinkageBestNeighbor, bool) {
+	if h.Len() == 0 {
+		return completeLinkageBestNeighbor{}, false
+	}
+	return heap.Pop(h).(completeLinkageBestNeighbor), true
+}
+
+func orderClusterIDs(firstID, secondID int) (int, int) {
+	if firstID < secondID {
+		return firstID, secondID
+	}
+	return secondID, firstID
+}
+
 // ---------------------------------------------------------------------------
-// 5. CentroidGrouping — greedy BFS expansion from highest-similarity pairs
+// 5. CentroidGrouping — BFS expansion with strict similarity to all members
 // ---------------------------------------------------------------------------
 
-// CentroidGrouping starts with the highest-similarity pair, forms a group,
-// then expands by adding items that have similarity >= threshold to ALL
-// existing group members.
+// CentroidGrouping uses BFS expansion with strict similarity to all existing members.
 type CentroidGrouping[T GroupableItem] struct {
 	threshold float64
 }
 
-func (cg *CentroidGrouping[T]) Name() string { return "centroid" }
+func NewCentroidGrouping[T GroupableItem](threshold float64) *CentroidGrouping[T] {
+	return &CentroidGrouping[T]{threshold: threshold}
+}
+
+func (cg *CentroidGrouping[T]) Name() string { return string(ModeCentroid) }
 
 func (cg *CentroidGrouping[T]) GroupItems(pairs []*ItemPair[T]) []*ItemGroup[T] {
 	if len(pairs) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	// Build similarity lookup.
-	type idPair struct{ a, b int }
-	simMap := make(map[idPair]float64)
-	itemMap := make(map[int]T)
-
-	// Collect qualifying pairs.
-	qualifying := make([]*ItemPair[T], 0, len(pairs))
-	for _, p := range pairs {
-		if p.Similarity < cg.threshold && !almostEqual(p.Similarity, cg.threshold) {
-			continue
-		}
-		qualifying = append(qualifying, p)
-		id1, id2 := p.Item1.ItemID(), p.Item2.ItemID()
-		simMap[idPair{id1, id2}] = p.Similarity
-		simMap[idPair{id2, id1}] = p.Similarity
-		itemMap[id1] = p.Item1
-		itemMap[id2] = p.Item2
-	}
-
-	if len(qualifying) == 0 {
+	items, simMap, typeMap := collectItems(pairs)
+	if len(items) == 0 {
 		return []*ItemGroup[T]{}
 	}
 
-	// Sort pairs by similarity descending, then by pairKey for determinism.
-	sorted := make([]*ItemPair[T], len(qualifying))
-	copy(sorted, qualifying)
-	sort.Slice(sorted, func(i, j int) bool {
-		if !almostEqual(sorted[i].Similarity, sorted[j].Similarity) {
-			return sorted[i].Similarity > sorted[j].Similarity
+	// Build adjacency with edges meeting threshold
+	neighbors := make(map[int][]int, len(items)) // item ID -> neighbor IDs above threshold
+	for _, item := range items {
+		neighbors[item.ItemID()] = make([]int, 0)
+	}
+	for _, p := range pairs {
+		if p == nil {
+			continue
 		}
-		return pairKey(sorted[i].Item1, sorted[i].Item2) < pairKey(sorted[j].Item1, sorted[j].Item2)
-	})
-
-	remaining := make(map[int]bool, len(itemMap))
-	for id := range itemMap {
-		remaining[id] = true
+		if p.Similarity >= cg.threshold {
+			neighbors[p.Item1.ItemID()] = append(neighbors[p.Item1.ItemID()], p.Item2.ItemID())
+			neighbors[p.Item2.ItemID()] = append(neighbors[p.Item2.ItemID()], p.Item1.ItemID())
+		}
 	}
 
+	// Sort items for deterministic processing
+	sort.Slice(items, func(i, j int) bool { return itemLess(items[i], items[j]) })
+
+	// Build item ID to item map
+	itemByID := make(map[int]T)
+	for _, item := range items {
+		itemByID[item.ItemID()] = item
+	}
+
+	// Sort neighbors for deterministic BFS traversal
+	for id := range neighbors {
+		sort.Ints(neighbors[id])
+	}
+
+	// BFS expansion from each unassigned item
+	assigned := make(map[int]bool)
 	groups := make([]*ItemGroup[T], 0)
-	groupID := 1
+	groupID := 0
 
-	for len(remaining) > 0 {
-		// Find the highest-similarity pair among remaining items.
-		var seedPair *ItemPair[T]
-		for _, p := range sorted {
-			id1, id2 := p.Item1.ItemID(), p.Item2.ItemID()
-			if remaining[id1] && remaining[id2] {
-				seedPair = p
-				break
+	for _, seed := range items {
+		if assigned[seed.ItemID()] {
+			continue
+		}
+
+		// Start new group with seed
+		members := []T{seed}
+		assigned[seed.ItemID()] = true
+
+		// BFS queue: neighbor IDs to consider
+		queue := list.New()
+		visited := make(map[int]bool)
+		visited[seed.ItemID()] = true
+
+		// Add seed's neighbors to queue
+		for _, nid := range neighbors[seed.ItemID()] {
+			if !visited[nid] && !assigned[nid] {
+				queue.PushBack(nid)
+				visited[nid] = true
 			}
 		}
 
-		if seedPair == nil {
-			// No more pairs among remaining items. Each remaining item is isolated.
-			remIDs := make([]int, 0, len(remaining))
-			for id := range remaining {
-				remIDs = append(remIDs, id)
-			}
-			sort.Ints(remIDs)
-			for _, id := range remIDs {
-				items := []T{itemMap[id]}
-				members := map[int]bool{id: true}
-				groups = append(groups, &ItemGroup[T]{
-					ID:         groupID,
-					Items:      items,
-					GroupType:  majorityType(pairs, members),
-					Similarity: 0.0,
-				})
-				groupID++
-				delete(remaining, id)
-			}
-			break
-		}
+		// BFS expansion
+		for queue.Len() > 0 {
+			e := queue.Front()
+			queue.Remove(e)
+			candidateID := e.Value.(int)
 
-		// Start group with the seed pair.
-		groupMembers := map[int]bool{
-			seedPair.Item1.ItemID(): true,
-			seedPair.Item2.ItemID(): true,
-		}
-
-		// Try to expand: check each remaining item (not in group) for compatibility.
-		// An item is compatible if it has similarity >= threshold to ALL group members.
-		changed := true
-		for changed {
-			changed = false
-			candidates := make([]int, 0)
-			for id := range remaining {
-				if groupMembers[id] {
-					continue
-				}
-				candidates = append(candidates, id)
+			if assigned[candidateID] {
+				continue
 			}
-			sort.Ints(candidates)
 
-			for _, cid := range candidates {
-				compatible := true
-				for mid := range groupMembers {
-					sim, exists := simMap[idPair{cid, mid}]
-					if !exists || (sim < cg.threshold && !almostEqual(sim, cg.threshold)) {
-						compatible = false
-						break
+			candidate, ok := itemByID[candidateID]
+			if !ok {
+				continue
+			}
+
+			// Check if candidate is similar to ALL current members
+			if cg.isSimilarToAll(candidate, members, simMap) {
+				members = append(members, candidate)
+				assigned[candidateID] = true
+
+				// Add candidate's neighbors to queue
+				for _, nid := range neighbors[candidateID] {
+					if !visited[nid] && !assigned[nid] {
+						queue.PushBack(nid)
+						visited[nid] = true
 					}
 				}
-				if compatible {
-					groupMembers[cid] = true
-					changed = true
-				}
 			}
 		}
 
-		items := make([]T, 0, len(groupMembers))
-		for id := range groupMembers {
-			items = append(items, itemMap[id])
-			delete(remaining, id)
+		// Only keep groups with at least 2 members
+		if len(members) >= 2 {
+			sort.Slice(members, func(i, j int) bool { return itemLess(members[i], members[j]) })
+			groups = append(groups, &ItemGroup[T]{
+				ID:         groupID,
+				Items:      members,
+				GroupType:  majorityType(typeMap, simMap, members),
+				Similarity: averageGroupSimilarity(simMap, members),
+			})
+			groupID++
 		}
-		sortGroupItems(items)
-
-		groups = append(groups, &ItemGroup[T]{
-			ID:         groupID,
-			Items:      items,
-			GroupType:  majorityType(pairs, groupMembers),
-			Similarity: averageGroupSimilarity(pairs, groupMembers),
-		})
-		groupID++
 	}
 
+	sortItemGroups(groups)
+
 	return groups
+}
+
+// isSimilarToAll checks if candidate is similar to all members above threshold.
+func (cg *CentroidGrouping[T]) isSimilarToAll(candidate T, members []T, simMap map[string]float64) bool {
+	for _, member := range members {
+		if itemSimilarity(simMap, candidate, member) < cg.threshold {
+			return false
+		}
+	}
+	return true
+}
+
+// ---------------------------------------------------------------------------
+// Group deduplication post-passes
+// ---------------------------------------------------------------------------
+
+// GroupDedupeResult carries the surviving groups plus the keys of suppressed
+// members (by ItemKey) and suppressed pairs (by PairKey).
+type GroupDedupeResult[T GroupableItem] struct {
+	Groups          []*ItemGroup[T]
+	Suppressed      map[string]struct{} // keyed by ItemKey
+	SuppressedPairs map[string]struct{} // keyed by PairKey
+}
+
+// DedupeStrictSubsetGroupMembers removes group members whose source range is a
+// strict subset of (or identical to) another member's range in the same file.
+// Groups reduced to fewer than two members are dropped.
+//
+// Why this exists: pair-detection paths typically reject *direct* pairs
+// between overlapping same-file fragments, so pairs cannot contain a same-file
+// `(A, B)` where one strictly covers the other. Union-Find grouping, however,
+// still merges such fragments into one group via a shared distinct-file
+// neighbor — e.g., pairs `(A=x.ts:512-542, C=y.ts:1-30)` and
+// `(B=x.ts:515-542, C=y.ts:1-30)` are both legal yet transitively connect A
+// and B. This post-pass collapses those overlapping windows back to the
+// maximal one per file.
+//
+// For exactly-equal ranges (which UF can produce in the same way), the first
+// occurrence is kept; later duplicates are suppressed for deterministic output.
+func DedupeStrictSubsetGroupMembers[T GroupableItem](groups []*ItemGroup[T], pairs []*ItemPair[T]) GroupDedupeResult[T] {
+	result := GroupDedupeResult[T]{
+		Groups:     groups,
+		Suppressed: make(map[string]struct{}),
+	}
+	if len(groups) == 0 {
+		return result
+	}
+
+	out := make([]*ItemGroup[T], 0, len(groups))
+	var similarities map[string]float64
+	var types map[string]domain.CloneType
+	metadataReady := false
+	anyChanged := false
+	for _, g := range groups {
+		if g == nil {
+			continue
+		}
+		kept, suppressed := filterMaximalPerFile(g.Items)
+		for key := range suppressed {
+			result.Suppressed[key] = struct{}{}
+		}
+		groupChanged := len(suppressed) > 0
+		anyChanged = anyChanged || groupChanged
+		if len(kept) < 2 {
+			continue
+		}
+		g.Items = kept
+		if groupChanged {
+			if !metadataReady {
+				similarities, types = pairMetadata(pairs)
+				metadataReady = true
+			}
+			g.Similarity = averageGroupSimilarity(similarities, g.Items)
+			g.GroupType = majorityType(types, similarities, g.Items)
+		}
+		out = append(out, g)
+	}
+	if anyChanged {
+		sortItemGroups(out)
+	}
+	result.Groups = out
+	return result
+}
+
+// coveredGroupSimilarityTolerance bounds how much weaker (in average
+// similarity) a covering group may be while still subsuming a covered group.
+// Overlapping windows of the same duplication shift similarity only slightly;
+// a covered group that matches much more strongly than its covering group is
+// a distinct, sharper finding (e.g., a near-identical inner block inside
+// loosely similar functions) and is kept.
+const coveredGroupSimilarityTolerance = 0.05
+
+// DedupeCoveredGroups suppresses whole groups that are covered by another
+// group: every member of the covered group fits inside a distinct member of
+// the covering group (same file, containing line range), and the covering
+// group's similarity is comparable or better. Such groups describe the same
+// duplication relationship through slightly smaller windows and double-count
+// it.
+//
+// Why DedupeStrictSubsetGroupMembers does not catch this: that pass compares
+// members *within* one group. Here the overlapping windows sit in *different*
+// groups, which stay disconnected when detection forbids the direct same-file
+// pair that would have linked them.
+//
+// The group with the larger (covering) windows is kept, mirroring the
+// maximal-window policy of filterMaximalPerFile. When two groups cover each
+// other (identical member ranges), the earlier one in the slice wins.
+func DedupeCoveredGroups[T GroupableItem](groups []*ItemGroup[T]) GroupDedupeResult[T] {
+	result := GroupDedupeResult[T]{
+		Groups:          groups,
+		Suppressed:      make(map[string]struct{}),
+		SuppressedPairs: make(map[string]struct{}),
+	}
+	if len(groups) < 2 {
+		return result
+	}
+
+	suppressed := make([]bool, len(groups))
+	for i, gi := range groups {
+		if gi == nil {
+			continue
+		}
+		// Compare against every other group, including already-suppressed
+		// ones: coverage is transitive, so a chain g1 ⊂ g2 ⊂ g3 still
+		// resolves to keeping only g3.
+		for j, gj := range groups {
+			if i == j || gj == nil {
+				continue
+			}
+			if !groupCoveredBy(gi, gj) {
+				continue
+			}
+			if groupCoveredBy(gj, gi) {
+				if j > i {
+					continue // mutual coverage: the earlier group survives
+				}
+			} else if gi.Similarity > gj.Similarity+coveredGroupSimilarityTolerance {
+				continue // gi is a distinctly stronger match than its cover
+			}
+			suppressed[i] = true
+			break
+		}
+	}
+
+	out := make([]*ItemGroup[T], 0, len(groups))
+	keptPairs := make(map[string]struct{})
+	for i, g := range groups {
+		if g == nil || suppressed[i] {
+			continue
+		}
+		out = append(out, g)
+		for first := 0; first < len(g.Items); first++ {
+			for second := first + 1; second < len(g.Items); second++ {
+				keptPairs[PairKey(g.Items[first], g.Items[second])] = struct{}{}
+			}
+		}
+	}
+	for i, g := range groups {
+		if g == nil || !suppressed[i] {
+			continue
+		}
+		for first := 0; first < len(g.Items); first++ {
+			for second := first + 1; second < len(g.Items); second++ {
+				key := PairKey(g.Items[first], g.Items[second])
+				if _, needed := keptPairs[key]; !needed {
+					result.SuppressedPairs[key] = struct{}{}
+				}
+			}
+		}
+	}
+	result.Groups = out
+	return result
+}
+
+// groupCoveredBy reports whether every member of inner can be matched to a
+// distinct member of outer that covers it (same file, containing range,
+// equality included). Distinctness matters: two disjoint inner blocks inside
+// one outer member describe duplication *within* that member, which the outer
+// group does not report.
+func groupCoveredBy[T GroupableItem](inner, outer *ItemGroup[T]) bool {
+	n := len(inner.Items)
+	if n == 0 || n > len(outer.Items) {
+		return false
+	}
+	candidates := make([][]int, n)
+	for i, c := range inner.Items {
+		for j, oc := range outer.Items {
+			if locationCovers(oc.ItemLocation(), c.ItemLocation()) {
+				candidates[i] = append(candidates[i], j)
+			}
+		}
+		if len(candidates[i]) == 0 {
+			return false
+		}
+	}
+	// Bipartite matching via augmenting paths; group sizes are small.
+	matchedInner := make([]int, len(outer.Items))
+	for j := range matchedInner {
+		matchedInner[j] = -1
+	}
+	var assign func(i int, visited []bool) bool
+	assign = func(i int, visited []bool) bool {
+		for _, j := range candidates[i] {
+			if visited[j] {
+				continue
+			}
+			visited[j] = true
+			if matchedInner[j] == -1 || assign(matchedInner[j], visited) {
+				matchedInner[j] = i
+				return true
+			}
+		}
+		return false
+	}
+	for i := 0; i < n; i++ {
+		if !assign(i, make([]bool, len(outer.Items))) {
+			return false
+		}
+	}
+	return true
+}
+
+// locationCovers reports whether outer contains inner (same file, inclusive
+// line and column ranges; equal ranges count as covered).
+func locationCovers(outer, inner ItemLocation) bool {
+	if outer.FilePath != inner.FilePath {
+		return false
+	}
+	startsBefore := outer.StartLine < inner.StartLine ||
+		(outer.StartLine == inner.StartLine && outer.StartCol <= inner.StartCol)
+	endsAfter := outer.EndLine > inner.EndLine ||
+		(outer.EndLine == inner.EndLine && outer.EndCol >= inner.EndCol)
+	return startsBefore && endsAfter
+}
+
+// FilterGroupsWithoutBackingPairs drops groups whose refreshed metadata shows
+// no positive-similarity pair actually backs them (e.g. every member pair was
+// filtered out upstream), which would otherwise surface a group with zero
+// similarity.
+func FilterGroupsWithoutBackingPairs[T GroupableItem](groups []*ItemGroup[T], pairs []*ItemPair[T]) []*ItemGroup[T] {
+	if len(groups) == 0 {
+		return groups
+	}
+	similarities, types := pairMetadata(pairs)
+	out := make([]*ItemGroup[T], 0, len(groups))
+	for _, group := range groups {
+		if group == nil || len(group.Items) < 2 {
+			continue
+		}
+		group.Similarity = averageGroupSimilarity(similarities, group.Items)
+		group.GroupType = majorityType(types, similarities, group.Items)
+		if group.Similarity <= 0 {
+			continue
+		}
+		out = append(out, group)
+	}
+	return out
+}
+
+// filterMaximalPerFile returns the subset of items that are maximal under the
+// same-file containment order. An item is suppressed if any other kept item in
+// the same file strictly covers it, or if it duplicates an earlier item's
+// range exactly.
+func filterMaximalPerFile[T GroupableItem](items []T) ([]T, map[string]struct{}) {
+	suppressedItems := make(map[string]struct{})
+	n := len(items)
+	if n <= 1 {
+		return items, suppressedItems
+	}
+	suppressed := make([]bool, n)
+	for i := 0; i < n; i++ {
+		if suppressed[i] {
+			continue
+		}
+		for j := 0; j < n; j++ {
+			if i == j || suppressed[j] {
+				continue
+			}
+			if covers(items[i].ItemLocation(), items[j].ItemLocation(), i, j) {
+				suppressed[j] = true
+			}
+		}
+	}
+	out := make([]T, 0, n)
+	for i, item := range items {
+		if suppressed[i] {
+			suppressedItems[ItemKey(item)] = struct{}{}
+			continue
+		}
+		out = append(out, item)
+	}
+	return out, suppressedItems
+}
+
+// covers reports whether outer (at index iOuter) covers inner (at index
+// iInner) in the same file. Strict coverage suppresses inner outright;
+// identical ranges suppress only the later index so that exactly one survives.
+func covers(outer, inner ItemLocation, iOuter, iInner int) bool {
+	if !locationCovers(outer, inner) {
+		return false
+	}
+	if outer == inner {
+		return iOuter < iInner
+	}
+	return true
+}
+
+// FilterPairsWithSuppressedMembers removes pairs that reference a suppressed
+// member (keyed by ItemKey).
+func FilterPairsWithSuppressedMembers[T GroupableItem](pairs []*ItemPair[T], suppressed map[string]struct{}) []*ItemPair[T] {
+	if len(pairs) == 0 || len(suppressed) == 0 {
+		return pairs
+	}
+	out := make([]*ItemPair[T], 0, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil {
+			continue
+		}
+		if _, ok := suppressed[ItemKey(pair.Item1)]; ok {
+			continue
+		}
+		if _, ok := suppressed[ItemKey(pair.Item2)]; ok {
+			continue
+		}
+		out = append(out, pair)
+	}
+	return out
+}
+
+// FilterSuppressedPairs removes pairs whose PairKey is in the suppressed set.
+func FilterSuppressedPairs[T GroupableItem](pairs []*ItemPair[T], suppressed map[string]struct{}) []*ItemPair[T] {
+	if len(pairs) == 0 || len(suppressed) == 0 {
+		return pairs
+	}
+	out := make([]*ItemPair[T], 0, len(pairs))
+	for _, pair := range pairs {
+		if pair == nil {
+			continue
+		}
+		if _, ok := suppressed[PairKey(pair.Item1, pair.Item2)]; ok {
+			continue
+		}
+		out = append(out, pair)
+	}
+	return out
 }

--- a/core/clone/grouping_test.go
+++ b/core/clone/grouping_test.go
@@ -1,439 +1,593 @@
 package clone
 
 import (
-	"fmt"
 	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
 )
 
-// testItem implements GroupableItem for testing.
+// testItem is a minimal GroupableItem implementation for tests.
 type testItem struct {
 	id  int
-	key string
+	loc ItemLocation
 }
 
-func (t *testItem) ItemID() int    { return t.id }
-func (t *testItem) ItemKey() string { return t.key }
+func (t *testItem) ItemID() int                { return t.id }
+func (t *testItem) ItemLocation() ItemLocation { return t.loc }
 
-func newItem(id int) *testItem {
-	return &testItem{id: id, key: fmt.Sprintf("file%d|%d|%d|0|0", id, id, id+10)}
+func ti(id int, file string, startLine, endLine int) *testItem {
+	return &testItem{id: id, loc: ItemLocation{FilePath: file, StartLine: startLine, EndLine: endLine}}
 }
 
-func makePair(a, b *testItem, sim float64, pairType int) *ItemPair[*testItem] {
-	return &ItemPair[*testItem]{
-		Item1:      a,
-		Item2:      b,
-		Similarity: sim,
-		PairType:   pairType,
-	}
+func pair(id1, id2 *testItem, sim float64, t domain.CloneType) *ItemPair[*testItem] {
+	return &ItemPair[*testItem]{Item1: id1, Item2: id2, Similarity: sim, PairType: t}
 }
-
-// --- GroupableItem interface test ---
-
-func TestGroupableItemInterface(t *testing.T) {
-	var _ GroupableItem = &testItem{id: 1, key: "a"}
-}
-
-// --- Factory test ---
 
 func TestNewGroupingStrategy(t *testing.T) {
-	tests := []struct {
-		mode GroupingMode
-		name string
+	testCases := []struct {
+		mode     GroupingMode
+		expected string
 	}{
 		{ModeConnected, "connected"},
 		{ModeKCore, "k_core"},
 		{ModeStarMedoid, "star_medoid"},
 		{ModeCompleteLinkage, "complete_linkage"},
 		{ModeCentroid, "centroid"},
-		{"", "connected"}, // default
+		{"unknown", "connected"}, // Default fallback
 	}
 
-	for _, tt := range tests {
-		s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: tt.mode})
-		if s.Name() != tt.name {
-			t.Errorf("mode %q: expected name %q, got %q", tt.mode, tt.name, s.Name())
-		}
-	}
-}
-
-// --- Empty input test ---
-
-func TestAllStrategiesEmptyInput(t *testing.T) {
-	modes := []GroupingMode{ModeConnected, ModeKCore, ModeStarMedoid, ModeCompleteLinkage, ModeCentroid}
-	for _, mode := range modes {
-		s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: mode, Threshold: 0.5})
-		result := s.GroupItems(nil)
-		if len(result) != 0 {
-			t.Errorf("%s: expected 0 groups for nil input, got %d", mode, len(result))
-		}
-		result = s.GroupItems([]*ItemPair[*testItem]{})
-		if len(result) != 0 {
-			t.Errorf("%s: expected 0 groups for empty input, got %d", mode, len(result))
-		}
+	for _, tc := range testCases {
+		t.Run(string(tc.mode), func(t *testing.T) {
+			config := GroupingConfig{
+				Mode:      tc.mode,
+				Threshold: 0.8,
+				KCoreK:    2,
+			}
+			strategy := NewGroupingStrategy[*testItem](config)
+			if strategy.Name() != tc.expected {
+				t.Errorf("Expected strategy name %s, got %s", tc.expected, strategy.Name())
+			}
+		})
 	}
 }
 
-// --- ConnectedGrouping tests ---
+func TestConnectedGroupingEmpty(t *testing.T) {
+	grouping := NewConnectedGrouping[*testItem](0.8)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups for empty input, got %d", len(groups))
+	}
+}
 
 func TestConnectedGroupingSinglePair(t *testing.T) {
-	a, b := newItem(1), newItem(2)
-	pairs := []*ItemPair[*testItem]{makePair(a, b, 0.8, 1)}
+	grouping := NewConnectedGrouping[*testItem](0.8)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+	})
 
 	if len(groups) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(groups))
+		t.Fatalf("Expected 1 group, got %d", len(groups))
 	}
 	if len(groups[0].Items) != 2 {
-		t.Fatalf("expected 2 items in group, got %d", len(groups[0].Items))
-	}
-	if groups[0].ID != 1 {
-		t.Fatalf("expected group ID 1, got %d", groups[0].ID)
+		t.Errorf("Expected group size 2, got %d", len(groups[0].Items))
 	}
 }
 
-func TestConnectedGroupingTwoComponents(t *testing.T) {
-	a, b, c, d := newItem(1), newItem(2), newItem(3), newItem(4)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(c, d, 0.8, 2),
-	}
+func TestConnectedGroupingBelowThreshold(t *testing.T) {
+	grouping := NewConnectedGrouping[*testItem](0.9)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.8, domain.Type2Clone), // Below threshold
+	})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups (below threshold), got %d", len(groups))
+	}
+}
+
+func TestConnectedGroupingMultipleComponents(t *testing.T) {
+	grouping := NewConnectedGrouping[*testItem](0.8)
+
+	// First component: items 1 and 2. Second component: items 3 and 4.
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "a.js", 20, 30)
+	item3 := ti(3, "b.js", 1, 10)
+	item4 := ti(4, "b.js", 20, 30)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item3, item4, 0.85, domain.Type2Clone),
+	})
 
 	if len(groups) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(groups))
+		t.Errorf("Expected 2 groups, got %d", len(groups))
 	}
 }
 
-func TestConnectedGroupingThreshold(t *testing.T) {
-	a, b := newItem(1), newItem(2)
-	pairs := []*ItemPair[*testItem]{makePair(a, b, 0.3, 1)}
+func TestConnectedGroupingSortsMembersDeterministically(t *testing.T) {
+	grouping := NewConnectedGrouping[*testItem](0.8)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	item1 := ti(1, "b.js", 1, 10)
+	item2 := ti(2, "a.js", 1, 10)
 
-	// Pair below threshold, so no groups
-	if len(groups) != 0 {
-		t.Fatalf("expected 0 groups (below threshold), got %d", len(groups))
-	}
-}
-
-func TestConnectedGroupingChain(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.8, 1),
-		makePair(b, c, 0.7, 1),
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+	})
 
 	if len(groups) != 1 {
-		t.Fatalf("expected 1 connected group, got %d", len(groups))
+		t.Fatalf("Expected 1 group, got %d", len(groups))
 	}
-	if len(groups[0].Items) != 3 {
-		t.Fatalf("expected 3 items in chain group, got %d", len(groups[0].Items))
+	if groups[0].Items[0] != item2 {
+		t.Error("expected members sorted by location (a.js before b.js)")
 	}
 }
 
-// --- KCoreGrouping tests ---
+func TestNewKCoreGroupingMinK(t *testing.T) {
+	grouping := NewKCoreGrouping[*testItem](0.8, 1) // k=1 should be bumped to 2
+
+	if grouping.k != 2 {
+		t.Errorf("Expected k=2 (minimum), got %d", grouping.k)
+	}
+}
+
+func TestKCoreGroupingEmpty(t *testing.T) {
+	grouping := NewKCoreGrouping[*testItem](0.8, 2)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups for empty input, got %d", len(groups))
+	}
+}
 
 func TestKCoreGroupingTriangle(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(b, c, 0.8, 1),
-		makePair(a, c, 0.7, 1),
-	}
+	grouping := NewKCoreGrouping[*testItem](0.8, 2)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeKCore, Threshold: 0.5, KCoreK: 2})
-	groups := s.GroupItems(pairs)
+	// Three items forming a triangle (each connected to 2 others)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
 
-	// Triangle: every node has degree 2, so all survive k=2 peeling.
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		pair(item1, item3, 0.9, domain.Type1Clone),
+	})
+
 	if len(groups) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(groups))
+		t.Fatalf("Expected 1 group (triangle is 2-core), got %d", len(groups))
 	}
 	if len(groups[0].Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(groups[0].Items))
+		t.Errorf("Expected group size 3, got %d", len(groups[0].Items))
 	}
 }
 
-func TestKCoreGroupingChainPeeled(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	// Chain: a-b-c, degrees: a=1, b=2, c=1 → peeling removes a and c, then b
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(b, c, 0.8, 1),
-	}
+func TestKCoreGroupingRemovesLowDegree(t *testing.T) {
+	grouping := NewKCoreGrouping[*testItem](0.8, 2)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeKCore, Threshold: 0.5, KCoreK: 2})
-	groups := s.GroupItems(pairs)
+	// Item 1 only connected to item 2 (degree 1, will be removed).
+	// After removing item 1, we have a triangle: 2-3-4.
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+	item4 := ti(4, "d.js", 1, 10)
 
-	// No 2-core in a chain
-	if len(groups) != 0 {
-		t.Fatalf("expected 0 groups (no 2-core in chain), got %d", len(groups))
-	}
-}
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		pair(item2, item4, 0.9, domain.Type1Clone),
+		pair(item3, item4, 0.9, domain.Type1Clone),
+	})
 
-func TestKCoreGroupingDefaultK(t *testing.T) {
-	// Config with KCoreK=0 should default to 2.
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeKCore, Threshold: 0.5, KCoreK: 0})
-	if s.Name() != "k_core" {
-		t.Fatalf("expected k_core, got %s", s.Name())
-	}
-}
-
-// --- StarMedoidGrouping tests ---
-
-func TestStarMedoidGrouping(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(a, c, 0.8, 1),
-		makePair(b, c, 0.7, 1), // fully connected star
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeStarMedoid, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
-
-	// a has avg sim (0.9+0.8)/2=0.85, b has (0.9+0.7)/2=0.8, c has (0.8+0.7)/2=0.75
-	// Medoid is a (or b depending on tie-break). All connected → 1 star group.
 	if len(groups) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(groups))
+		t.Fatalf("Expected 1 group, got %d", len(groups))
 	}
 	if len(groups[0].Items) != 3 {
-		t.Fatalf("expected 3 items in star, got %d", len(groups[0].Items))
+		t.Errorf("Expected group size 3 (item 1 should be removed), got %d", len(groups[0].Items))
 	}
 }
 
-func TestStarMedoidGroupingPartial(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(a, c, 0.8, 1),
-		// b and c not directly connected
-	}
+func TestPairKeyCanonical(t *testing.T) {
+	item1 := &testItem{id: 1, loc: ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 10, EndCol: 50}}
+	item2 := &testItem{id: 2, loc: ItemLocation{FilePath: "b.js", StartLine: 1, EndLine: 10, EndCol: 50}}
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeStarMedoid, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	key1 := PairKey(item1, item2)
+	key2 := PairKey(item2, item1)
 
-	// b has avg 0.9 (best medoid), star = {b, a}. Then c is singleton.
-	if len(groups) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(groups))
+	// Key should be canonical (same regardless of order)
+	if key1 != key2 {
+		t.Errorf("Keys should be identical regardless of order: %s vs %s", key1, key2)
 	}
 }
 
-func TestStarMedoidSingleton(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	// All below threshold — singletons
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.1, 1),
-		makePair(b, c, 0.2, 1),
-	}
+func TestItemKey(t *testing.T) {
+	item := &testItem{id: 1, loc: ItemLocation{FilePath: "test.js", StartLine: 1, EndLine: 10, StartCol: 0, EndCol: 50}}
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeStarMedoid, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	key := ItemKey(item)
 
-	if len(groups) != 0 {
-		t.Fatalf("expected 0 groups (all below threshold), got %d", len(groups))
-	}
-}
-
-// --- CompleteLinkageGrouping tests ---
-
-func TestCompleteLinkageTriangle(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(b, c, 0.8, 1),
-		makePair(a, c, 0.7, 1),
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeCompleteLinkage, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
-
-	// Complete triangle is one maximal clique.
-	if len(groups) != 1 {
-		t.Fatalf("expected 1 group (triangle clique), got %d", len(groups))
-	}
-	if len(groups[0].Items) != 3 {
-		t.Fatalf("expected 3 items in clique, got %d", len(groups[0].Items))
-	}
-}
-
-func TestCompleteLinkageMissingEdge(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	// a-b and a-c connected, but b-c not → no triangle clique
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(a, c, 0.8, 1),
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeCompleteLinkage, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
-
-	// Maximal cliques: {a,b} and {a,c}. a assigned to largest (or first).
-	// Both have size 2, so a goes to the first one.
-	if len(groups) < 1 {
-		t.Fatal("expected at least 1 group")
-	}
-}
-
-// --- CentroidGrouping tests ---
-
-func TestCentroidGroupingTriangle(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(b, c, 0.8, 1),
-		makePair(a, c, 0.7, 1),
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeCentroid, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
-
-	// All pairs above threshold, all can be expanded into one group.
-	if len(groups) != 1 {
-		t.Fatalf("expected 1 group, got %d", len(groups))
-	}
-	if len(groups[0].Items) != 3 {
-		t.Fatalf("expected 3 items, got %d", len(groups[0].Items))
-	}
-}
-
-func TestCentroidGroupingNoExpansion(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	// a-b high sim, a-c above threshold but b-c below → c can't expand into {a,b}
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.9, 1),
-		makePair(a, c, 0.6, 1), // above threshold
-		makePair(b, c, 0.3, 1), // below threshold
-	}
-
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeCentroid, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
-
-	// Seed pair = {a,b} (sim 0.9). c has sim 0.6 to a (ok) but 0.3 to b (below threshold).
-	// c can't join {a,b}, becomes separate group. {a,b} + {c} = 2 groups.
-	if len(groups) != 2 {
-		t.Fatalf("expected 2 groups, got %d", len(groups))
-	}
-}
-
-// --- Helper function tests ---
-
-func TestAlmostEqual(t *testing.T) {
-	if !almostEqual(1.0, 1.0) {
-		t.Fatal("expected 1.0 == 1.0")
-	}
-	if !almostEqual(0.1+0.2, 0.3) {
-		t.Fatal("expected 0.1+0.2 ≈ 0.3")
-	}
-	if almostEqual(1.0, 2.0) {
-		t.Fatal("expected 1.0 != 2.0")
-	}
-}
-
-func TestPairKey(t *testing.T) {
-	a := &testItem{id: 1, key: "b"}
-	b := &testItem{id: 2, key: "a"}
-
-	// Should normalize: smaller key first
-	k := pairKey(a, b)
-	if k != "a|b" {
-		t.Fatalf("expected 'a|b', got %s", k)
-	}
-	k2 := pairKey(b, a)
-	if k != k2 {
-		t.Fatal("pairKey should be symmetric")
+	expected := "test.js|1|10|0|50"
+	if key != expected {
+		t.Errorf("Expected key %s, got %s", expected, key)
 	}
 }
 
 func TestItemLess(t *testing.T) {
-	a := &testItem{id: 1, key: "alpha"}
-	b := &testItem{id: 2, key: "beta"}
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "a.js", 20, 30)
 
-	if !itemLess(a, b) {
-		t.Fatal("expected alpha < beta")
+	// a.js < b.js
+	if !itemLess(item1, item2) {
+		t.Error("item1 should be less than item2 (file path)")
 	}
-	if itemLess(b, a) {
-		t.Fatal("expected beta > alpha")
+
+	// Same file, different start line
+	if !itemLess(item1, item3) {
+		t.Error("item1 should be less than item3 (start line)")
+	}
+
+	// Same element
+	if itemLess(item1, item1) {
+		t.Error("item should not be less than itself")
+	}
+
+	// Equal locations fall back to ItemID
+	item4 := ti(4, "a.js", 1, 10)
+	if !itemLess(item1, item4) {
+		t.Error("equal locations should order by ItemID")
 	}
 }
 
-func TestGroupSimilarity(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.8, 1),
-		makePair(b, c, 0.6, 1),
-		makePair(a, c, 0.7, 1),
+func TestAlmostEqual(t *testing.T) {
+	if !almostEqual(1.0, 1.0) {
+		t.Error("1.0 should equal 1.0")
 	}
-	members := map[int]bool{1: true, 2: true, 3: true}
-	avg := averageGroupSimilarity(pairs, members)
-	expected := (0.8 + 0.6 + 0.7) / 3.0
+	if !almostEqual(1.0, 1.0+1e-10) {
+		t.Error("1.0 should be almost equal to 1.0+1e-10")
+	}
+	if almostEqual(1.0, 1.1) {
+		t.Error("1.0 should not be almost equal to 1.1")
+	}
+}
+
+func TestAverageGroupSimilarity(t *testing.T) {
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+
+	sims := map[string]float64{
+		PairKey(item1, item2): 0.9,
+		PairKey(item2, item3): 0.8,
+		PairKey(item1, item3): 0.85,
+	}
+
+	avg := averageGroupSimilarity(sims, []*testItem{item1, item2, item3})
+
+	expected := (0.9 + 0.8 + 0.85) / 3.0
 	if !almostEqual(avg, expected) {
-		t.Fatalf("expected avg %.4f, got %.4f", expected, avg)
+		t.Errorf("Expected average %f, got %f", expected, avg)
 	}
 }
 
-func TestMajorityType(t *testing.T) {
-	a, b, c := newItem(1), newItem(2), newItem(3)
-	pairs := []*ItemPair[*testItem]{
-		makePair(a, b, 0.8, 1),
-		makePair(b, c, 0.7, 2),
-		makePair(a, c, 0.6, 1),
-	}
-	members := map[int]bool{1: true, 2: true, 3: true}
-	mt := majorityType(pairs, members)
-	if mt != 1 {
-		t.Fatalf("expected majority type 1, got %d", mt)
+func TestAverageGroupSimilarityEmpty(t *testing.T) {
+	avg := averageGroupSimilarity(nil, []*testItem{})
+	if avg != 1.0 {
+		t.Errorf("Expected 1.0 for empty/single member, got %f", avg)
 	}
 }
 
-// --- Group ordering test ---
+func TestAverageGroupSimilaritySkipsMissingPairs(t *testing.T) {
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
 
-func TestGroupIDsSequential(t *testing.T) {
-	items := make([]*testItem, 6)
-	for i := range items {
-		items[i] = newItem(i + 1)
+	// Only one of three member pairs has a cached similarity; missing pairs
+	// must be skipped rather than counted as 0.
+	sims := map[string]float64{
+		PairKey(item1, item2): 0.9,
 	}
 
-	pairs := []*ItemPair[*testItem]{
-		makePair(items[0], items[1], 0.9, 1),
-		makePair(items[2], items[3], 0.8, 1),
-		makePair(items[4], items[5], 0.7, 1),
+	avg := averageGroupSimilarity(sims, []*testItem{item1, item2, item3})
+	if !almostEqual(avg, 0.9) {
+		t.Errorf("Expected 0.9 (missing pairs skipped), got %f", avg)
+	}
+}
+
+func TestMajorityType_TieBreaksDeterministically(t *testing.T) {
+	item1 := ti(1, "a.js", 0, 0)
+	item2 := ti(2, "b.js", 0, 0)
+	item3 := ti(3, "c.js", 0, 0)
+
+	typeMap := map[string]domain.CloneType{
+		PairKey(item1, item2): domain.Type2Clone,
+		PairKey(item2, item3): domain.Type2Clone,
+		PairKey(item1, item3): domain.Type1Clone,
+	}
+	simMap := map[string]float64{
+		PairKey(item1, item2): 0.9,
+		PairKey(item2, item3): 0.9,
+		PairKey(item1, item3): 0.9,
 	}
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected, Threshold: 0.5})
-	groups := s.GroupItems(pairs)
+	majority := majorityType(typeMap, simMap, []*testItem{item1, item2, item3})
 
-	if len(groups) != 3 {
-		t.Fatalf("expected 3 groups, got %d", len(groups))
+	// All pairs tie on similarity, so the strictest (lowest) type wins deterministically.
+	if majority != domain.Type1Clone {
+		t.Errorf("Expected Type1Clone deterministic tie break, got %v", majority)
 	}
-	for i, g := range groups {
-		if g.ID != i+1 {
-			t.Errorf("expected group ID %d, got %d", i+1, g.ID)
+}
+
+// TestMajorityType_PrefersHighSimilarityPair ensures a connected component
+// whose strongest edge is a high-similarity Type-2 pair is reported as Type-2
+// even when weaker Type-3 transitive edges outnumber it.
+func TestMajorityType_PrefersHighSimilarityPair(t *testing.T) {
+	item1 := ti(1, "a.js", 0, 0)
+	item2 := ti(2, "b.js", 0, 0)
+	item3 := ti(3, "c.js", 0, 0)
+	item4 := ti(4, "d.js", 0, 0)
+
+	members := []*testItem{item1, item2, item3, item4}
+	typeMap := map[string]domain.CloneType{
+		PairKey(item1, item2): domain.Type2Clone,
+		PairKey(item1, item3): domain.Type3Clone,
+		PairKey(item1, item4): domain.Type3Clone,
+		PairKey(item2, item3): domain.Type3Clone,
+		PairKey(item2, item4): domain.Type3Clone,
+		PairKey(item3, item4): domain.Type3Clone,
+	}
+	simMap := map[string]float64{
+		PairKey(item1, item2): 0.96, // high-sim Type-2 pair
+		PairKey(item1, item3): 0.85,
+		PairKey(item1, item4): 0.85,
+		PairKey(item2, item3): 0.85,
+		PairKey(item2, item4): 0.85,
+		PairKey(item3, item4): 0.85,
+	}
+
+	majority := majorityType(typeMap, simMap, members)
+	if majority != domain.Type2Clone {
+		t.Errorf("Expected Type2Clone from the highest-similarity edge, got %v", majority)
+	}
+}
+
+func TestMajorityTypeEmpty(t *testing.T) {
+	majority := majorityType(nil, nil, []*testItem{})
+
+	// Conservative default fallback: never report unknown as Type-1
+	if majority != domain.Type4Clone {
+		t.Errorf("Expected Type4Clone as fallback, got %v", majority)
+	}
+}
+
+// StarMedoidGrouping tests
+
+func TestStarMedoidGroupingEmpty(t *testing.T) {
+	grouping := NewStarMedoidGrouping[*testItem](0.8)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups for empty input, got %d", len(groups))
+	}
+}
+
+func TestStarMedoidGroupingSinglePair(t *testing.T) {
+	grouping := NewStarMedoidGrouping[*testItem](0.8)
+
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+	})
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("Expected group size 2, got %d", len(groups[0].Items))
+	}
+}
+
+func TestStarMedoidGroupingMedoidSelection(t *testing.T) {
+	grouping := NewStarMedoidGrouping[*testItem](0.7)
+
+	// Item 2 should be medoid as it has highest average similarity to others
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.95, domain.Type1Clone),
+		pair(item1, item3, 0.75, domain.Type2Clone),
+	})
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Items) != 3 {
+		t.Errorf("Expected group size 3, got %d", len(groups[0].Items))
+	}
+}
+
+func TestStarMedoidGroupingBelowThreshold(t *testing.T) {
+	grouping := NewStarMedoidGrouping[*testItem](0.9)
+
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.8, domain.Type2Clone),
+	})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups (below threshold), got %d", len(groups))
+	}
+}
+
+// CompleteLinkageGrouping tests
+
+func TestCompleteLinkageGroupingEmpty(t *testing.T) {
+	grouping := NewCompleteLinkageGrouping[*testItem](0.8)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups for empty input, got %d", len(groups))
+	}
+}
+
+func TestCompleteLinkageGroupingTriangle(t *testing.T) {
+	grouping := NewCompleteLinkageGrouping[*testItem](0.8)
+
+	// Three items forming a complete triangle (clique)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		pair(item1, item3, 0.9, domain.Type1Clone),
+	})
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group (triangle is a clique), got %d", len(groups))
+	}
+	if len(groups[0].Items) != 3 {
+		t.Errorf("Expected group size 3, got %d", len(groups[0].Items))
+	}
+}
+
+func TestCompleteLinkageGroupingNonClique(t *testing.T) {
+	grouping := NewCompleteLinkageGrouping[*testItem](0.8)
+
+	// Three items but only 2 edges: 1-2, 2-3 (not a complete clique)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		// Missing item1-item3 edge
+	})
+
+	// Complete-linkage clustering merges one pair first; the chained item
+	// cannot join because it lacks an edge to every member. One group remains.
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group (complete-linkage merges one pair), got %d", len(groups))
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("Expected group size 2, got %d", len(groups[0].Items))
+	}
+}
+
+func TestCompleteLinkageGroupingBelowThreshold(t *testing.T) {
+	grouping := NewCompleteLinkageGrouping[*testItem](0.9)
+
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.8, domain.Type2Clone),
+	})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups (below threshold), got %d", len(groups))
+	}
+}
+
+// CentroidGrouping tests
+
+func TestCentroidGroupingEmpty(t *testing.T) {
+	grouping := NewCentroidGrouping[*testItem](0.8)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups for empty input, got %d", len(groups))
+	}
+}
+
+func TestCentroidGroupingSinglePair(t *testing.T) {
+	grouping := NewCentroidGrouping[*testItem](0.8)
+
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+	})
+
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(groups))
+	}
+	if len(groups[0].Items) != 2 {
+		t.Errorf("Expected group size 2, got %d", len(groups[0].Items))
+	}
+}
+
+func TestCentroidGroupingTransitivityRejection(t *testing.T) {
+	grouping := NewCentroidGrouping[*testItem](0.8)
+
+	// A~B, B~C but A is NOT similar to C.
+	// Centroid should reject C from joining the group with A and B.
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		pair(item1, item3, 0.5, domain.Type3Clone), // Below threshold
+	})
+
+	for _, g := range groups {
+		if len(g.Items) == 3 {
+			t.Errorf("Expected no group of size 3 due to transitive rejection, but found one")
 		}
 	}
 }
 
-// --- Items sorted within groups ---
+func TestCentroidGroupingAllSimilar(t *testing.T) {
+	grouping := NewCentroidGrouping[*testItem](0.8)
 
-func TestItemsSortedWithinGroup(t *testing.T) {
-	a := &testItem{id: 1, key: "z_file|1|10|0|0"}
-	b := &testItem{id: 2, key: "a_file|1|10|0|0"}
-	pairs := []*ItemPair[*testItem]{makePair(a, b, 0.9, 1)}
+	// All items similar to each other (complete clique)
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+	item3 := ti(3, "c.js", 1, 10)
 
-	s := NewGroupingStrategy[*testItem](GroupingConfig{Mode: ModeConnected})
-	groups := s.GroupItems(pairs)
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.9, domain.Type1Clone),
+		pair(item2, item3, 0.9, domain.Type1Clone),
+		pair(item1, item3, 0.85, domain.Type2Clone),
+	})
 
-	if len(groups) != 1 || len(groups[0].Items) != 2 {
-		t.Fatal("expected 1 group with 2 items")
+	if len(groups) != 1 {
+		t.Fatalf("Expected 1 group, got %d", len(groups))
 	}
-	if groups[0].Items[0].ItemKey() > groups[0].Items[1].ItemKey() {
-		t.Fatal("items should be sorted by ItemKey within group")
+	if len(groups[0].Items) != 3 {
+		t.Errorf("Expected group size 3, got %d", len(groups[0].Items))
+	}
+}
+
+func TestCentroidGroupingBelowThreshold(t *testing.T) {
+	grouping := NewCentroidGrouping[*testItem](0.9)
+
+	item1 := ti(1, "a.js", 1, 10)
+	item2 := ti(2, "b.js", 1, 10)
+
+	groups := grouping.GroupItems([]*ItemPair[*testItem]{
+		pair(item1, item2, 0.8, domain.Type2Clone),
+	})
+
+	if len(groups) != 0 {
+		t.Errorf("Expected 0 groups (below threshold), got %d", len(groups))
 	}
 }


### PR DESCRIPTION
## Summary

First of the per-area refresh PRs bringing the February extraction up to current jscan/pyscn algorithm parity (grouping had the largest drift: 987 churned lines in jscan since 2026-02-17).

- **API**: `GroupableItem` now exposes `ItemLocation()` (struct) instead of `ItemKey() string`, enabling location-aware dedup passes and numeric ordering; `ItemKey`/`PairKey` are derived helpers exported for adapters. `ItemPair`/`ItemGroup` use `domain.CloneType`.
- **Semantics refreshed to current jscan**:
  - `majorityType` picks the type of the highest-similarity edge (strictest type on ties, Type-4 fallback) instead of frequency counting
  - `averageGroupSimilarity` skips missing pairs instead of counting them as 0
  - CompleteLinkage: agglomerative clustering with a best-neighbor heap (replaces Bron-Kerbosch cliques)
  - StarMedoid: iterative medoid refinement (replaces greedy star expansion)
  - All strategies exclude singletons and sort groups by similarity/size/first-member
- **New exported group-dedup post-passes** ported from jscan: `DedupeStrictSubsetGroupMembers`, `DedupeCoveredGroups` (bipartite cover matching), `FilterGroupsWithoutBackingPairs`, `FilterPairsWithSuppressedMembers`, `FilterSuppressedPairs`

## Testing

Tests ported from jscan's current `grouping_strategy_test.go` and `group_dedup_test.go` (behavior-pinning cases included). `go test -race ./...` passes for all 13 packages.

## Follow-ups

Remaining refresh PRs in churn order: apted → clone classifier/detector → similarity gates (new extraction) → deadcode/scoring → lcom/dfa/semantic (pyscn side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)