### PR TITLE
core/apted: refresh to current jscan/pyscn parity

### DIFF
--- a/core/apted/apted.go
+++ b/core/apted/apted.go
@@ -47,8 +47,6 @@ const (
 	maxKeyRoots                = 100
 	earlyTermSizeFactor        = 0.8
 	optimizedMaxDistFactor     = 0.5
-	approxDepthWeight          = 2.0
-	approxSizeWeight           = 0.5
 	maxSameShapeAlignmentCells = 20000
 )
 
@@ -161,15 +159,9 @@ func (a *APTEDAnalyzer) computeApproximateDistanceWithSizes(tree1, tree2 *TreeNo
 	profile1 := collectTreeProfile(tree1)
 	profile2 := collectTreeProfile(tree2)
 
-	// Compute structural differences
-	depthDiff := math.Abs(float64(profile1.height - profile2.height))
-	sizeDiff := math.Abs(float64(size1 - size2))
-
-	structuralDistance := (depthDiff * approxDepthWeight) + (sizeDiff * approxSizeWeight)
 	labelDistance := a.computeLabelProfileDistance(profile1.labels, profile2.labels)
-	distance := math.Max(structuralDistance, labelDistance)
-	if distance > 0 {
-		return distance
+	if labelDistance > 0 {
+		return labelDistance
 	}
 
 	return computeShapeProfileDistance(tree1, tree2)
@@ -193,7 +185,6 @@ type labelProfile struct {
 
 type treeProfile struct {
 	labels map[string]*labelProfile
-	height int
 }
 
 func collectTreeProfile(root *TreeNode) treeProfile {
@@ -204,20 +195,11 @@ func collectTreeProfile(root *TreeNode) treeProfile {
 		return profile
 	}
 
-	type profileStackEntry struct {
-		node  *TreeNode
-		depth int
-	}
-	stack := []profileStackEntry{{node: root}}
+	stack := []*TreeNode{root}
 	for len(stack) > 0 {
 		last := len(stack) - 1
-		item := stack[last]
+		node := stack[last]
 		stack = stack[:last]
-
-		node := item.node
-		if item.depth > profile.height {
-			profile.height = item.depth
-		}
 
 		entry := profile.labels[node.Label]
 		if entry == nil {
@@ -227,7 +209,7 @@ func collectTreeProfile(root *TreeNode) treeProfile {
 		entry.count++
 		for _, child := range node.Children {
 			if child != nil {
-				stack = append(stack, profileStackEntry{node: child, depth: item.depth + 1})
+				stack = append(stack, child)
 			}
 		}
 	}
@@ -407,6 +389,9 @@ func (a *APTEDAnalyzer) computeBoundedSameShapeDistance(tree1, tree2 *TreeNode) 
 	if !sameTreeShape(tree1, tree2) {
 		return 0, false
 	}
+	if shiftDistance, ok := a.singleNodeChainShiftDistance(tree1, tree2); ok {
+		return shiftDistance, true
+	}
 
 	state := sameShapeDistanceState{
 		distances:               make(map[nodePair]float64),
@@ -415,6 +400,68 @@ func (a *APTEDAnalyzer) computeBoundedSameShapeDistance(tree1, tree2 *TreeNode) 
 		alignmentCellsRemaining: maxSameShapeAlignmentCells,
 	}
 	return a.sameShapeNodeDistance(tree1, tree2, &state), true
+}
+
+func (a *APTEDAnalyzer) singleNodeChainShiftDistance(tree1, tree2 *TreeNode) (float64, bool) {
+	left, leftIsChain := linearChainNodes(tree1)
+	right, rightIsChain := linearChainNodes(tree2)
+	if !leftIsChain || !rightIsChain || len(left) != len(right) || len(left) < 2 {
+		return 0, false
+	}
+
+	start := 0
+	for start < len(left) && a.nodeDistance(left[start], right[start]) == 0 {
+		start++
+	}
+	if start == len(left) {
+		return 0, true
+	}
+
+	end := len(left) - 1
+	for end > start && a.nodeDistance(left[end], right[end]) == 0 {
+		end--
+	}
+	if start == end {
+		return 0, false
+	}
+
+	forwardMatches := true
+	backwardMatches := true
+	for i := start; i < end; i++ {
+		forwardMatches = forwardMatches && a.nodeDistance(left[i+1], right[i]) == 0
+		backwardMatches = backwardMatches && a.nodeDistance(left[i], right[i+1]) == 0
+	}
+
+	best := math.Inf(1)
+	if forwardMatches {
+		best = a.costModel.Delete(left[start]) + a.costModel.Insert(right[end])
+	}
+	if backwardMatches {
+		best = math.Min(best, a.costModel.Delete(left[end])+a.costModel.Insert(right[start]))
+	}
+	return best, !math.IsInf(best, 1)
+}
+
+func linearChainNodes(root *TreeNode) ([]*TreeNode, bool) {
+	nodes := make([]*TreeNode, 0)
+	for root != nil {
+		nodes = append(nodes, root)
+		if len(root.Children) == 0 {
+			return nodes, true
+		}
+		if len(root.Children) != 1 || root.Children[0] == nil {
+			return nil, false
+		}
+		root = root.Children[0]
+	}
+	return nodes, true
+}
+
+func (a *APTEDAnalyzer) nodeDistance(left, right *TreeNode) float64 {
+	return math.Min(
+		a.costModel.Rename(left, right),
+		a.costModel.Delete(left)+a.costModel.Insert(right),
+	)
 }
 
 func sameTreeShape(tree1, tree2 *TreeNode) bool {

--- a/core/apted/apted.go
+++ b/core/apted/apted.go
@@ -3,6 +3,7 @@ package apted
 import (
 	"math"
 	"sort"
+	"strings"
 )
 
 // NormalizationMode controls how similarity is normalized from distance.
@@ -10,10 +11,9 @@ type NormalizationMode int
 
 const (
 	// NormalizeByMax uses max(size1, size2) — stricter, reduces false positives.
-	// Used by pyscn.
+	// Used by both pyscn and jscan.
 	NormalizeByMax NormalizationMode = iota
 	// NormalizeBySum uses size1 + size2 (Jaccard-like).
-	// Used by jscan.
 	NormalizeBySum
 )
 
@@ -42,13 +42,14 @@ func NewAPTEDAnalyzerWithNormalization(costModel CostModel, mode NormalizationMo
 }
 
 const (
-	largeTreeThreshold     = 500
-	veryLargeTreeThreshold = 2000
-	maxKeyRoots            = 100
-	earlyTermSizeFactor    = 0.8
-	optimizedMaxDistFactor = 0.5
-	approxDepthWeight      = 2.0
-	approxSizeWeight       = 0.5
+	largeTreeThreshold         = 500
+	veryLargeTreeThreshold     = 2000
+	maxKeyRoots                = 100
+	earlyTermSizeFactor        = 0.8
+	optimizedMaxDistFactor     = 0.5
+	approxDepthWeight          = 2.0
+	approxSizeWeight           = 0.5
+	maxSameShapeAlignmentCells = 20000
 )
 
 // ComputeDistance computes the tree edit distance between two trees.
@@ -77,22 +78,48 @@ func (a *APTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
 	return a.apted(tree1, tree2, keyRoots1, keyRoots2)
 }
 
+// ComputeDistanceAndSimilarity computes both APTED distance and normalized
+// similarity from one distance pass.
+func (a *APTEDAnalyzer) ComputeDistanceAndSimilarity(tree1, tree2 *TreeNode) (float64, float64) {
+	distance := a.ComputeDistance(tree1, tree2)
+	return distance, a.normalizeSimilarity(distance, tree1, tree2)
+}
+
+// computeDistanceOptimized keeps the large-tree clone-detection path fast
+// without letting the optimization erase real label or shape differences. This
+// is a bounded heuristic for large inputs, not an exact APTED replacement.
 func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64 {
+	// Early termination based on size difference
 	size1, size2 := tree1.Size(), tree2.Size()
 	sizeDiff := math.Abs(float64(size1 - size2))
+
+	// If size difference is too large, return early upper bound
 	maxDistance := math.Max(float64(size1), float64(size2))
-
 	if sizeDiff > maxDistance*earlyTermSizeFactor {
-		return sizeDiff
+		return sizeDiff // Conservative estimate
+	}
+	if size1 == size2 {
+		if sameShapeDistance, ok := a.computeBoundedSameShapeDistance(tree1, tree2); ok {
+			return sameShapeDistance
+		}
 	}
 
+	profileDistance := a.computeApproximateDistanceWithSizes(tree1, tree2, size1, size2)
+	if profileDistance >= maxDistance {
+		return profileDistance
+	}
+
+	// Use a simplified dynamic programming approach for very large trees
 	if size1 > veryLargeTreeThreshold || size2 > veryLargeTreeThreshold {
-		return a.computeApproximateDistance(tree1, tree2)
+		return profileDistance
 	}
 
+	// Use the capped optimized algorithm. The profile distance below is a
+	// lower bound that keeps capped key roots from undercounting.
 	keyRoots1 := PrepareTreeForAPTED(tree1)
 	keyRoots2 := PrepareTreeForAPTED(tree2)
 
+	// Limit key roots to reduce computation
 	if len(keyRoots1) > maxKeyRoots {
 		keyRoots1 = keyRoots1[:maxKeyRoots]
 	}
@@ -103,22 +130,572 @@ func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64
 	sort.Ints(keyRoots1)
 	sort.Ints(keyRoots2)
 
-	return a.aptedOptimized(tree1, tree2, keyRoots1, keyRoots2, maxDistance*optimizedMaxDistFactor)
+	optimizedDistance := a.aptedOptimized(tree1, tree2, keyRoots1, keyRoots2, maxDistance*optimizedMaxDistFactor)
+	return math.Max(optimizedDistance, profileDistance)
 }
 
+// computeApproximateDistance computes an approximate distance for very large trees.
 func (a *APTEDAnalyzer) computeApproximateDistance(tree1, tree2 *TreeNode) float64 {
+	size1, size2 := 0, 0
+	if tree1 != nil {
+		size1 = tree1.Size()
+	}
+	if tree2 != nil {
+		size2 = tree2.Size()
+	}
+	return a.computeApproximateDistanceWithSizes(tree1, tree2, size1, size2)
+}
+
+func (a *APTEDAnalyzer) computeApproximateDistanceWithSizes(tree1, tree2 *TreeNode, size1, size2 int) float64 {
+	// Handle nil cases
 	if tree1 == nil && tree2 == nil {
 		return 0.0
 	}
 	if tree1 == nil {
-		return float64(tree2.Size())
+		return float64(size2)
 	}
 	if tree2 == nil {
-		return float64(tree1.Size())
+		return float64(size1)
 	}
-	depthDiff := math.Abs(float64(tree1.Height() - tree2.Height()))
-	sizeDiff := math.Abs(float64(tree1.Size() - tree2.Size()))
-	return (depthDiff * approxDepthWeight) + (sizeDiff * approxSizeWeight)
+
+	profile1 := collectTreeProfile(tree1)
+	profile2 := collectTreeProfile(tree2)
+
+	// Compute structural differences
+	depthDiff := math.Abs(float64(profile1.height - profile2.height))
+	sizeDiff := math.Abs(float64(size1 - size2))
+
+	structuralDistance := (depthDiff * approxDepthWeight) + (sizeDiff * approxSizeWeight)
+	labelDistance := a.computeLabelProfileDistance(profile1.labels, profile2.labels)
+	distance := math.Max(structuralDistance, labelDistance)
+	if distance > 0 {
+		return distance
+	}
+
+	return computeShapeProfileDistance(tree1, tree2)
+}
+
+func (a *APTEDAnalyzer) computeLabelProfileDistance(labels1, labels2 map[string]*labelProfile) float64 {
+	cancelSharedLabels(labels1, labels2)
+
+	targetCandidates := buildLabelProfileIndex(labels2)
+	sourceCandidates := buildLabelProfileIndex(labels1)
+
+	deleteDistance := a.unmatchedSourceCost(labels1, targetCandidates)
+	insertDistance := a.unmatchedTargetCost(sourceCandidates, labels2)
+	return math.Max(deleteDistance, insertDistance)
+}
+
+type labelProfile struct {
+	node  *TreeNode
+	count int
+}
+
+type treeProfile struct {
+	labels map[string]*labelProfile
+	height int
+}
+
+func collectTreeProfile(root *TreeNode) treeProfile {
+	profile := treeProfile{
+		labels: make(map[string]*labelProfile),
+	}
+	if root == nil {
+		return profile
+	}
+
+	type profileStackEntry struct {
+		node  *TreeNode
+		depth int
+	}
+	stack := []profileStackEntry{{node: root}}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		item := stack[last]
+		stack = stack[:last]
+
+		node := item.node
+		if item.depth > profile.height {
+			profile.height = item.depth
+		}
+
+		entry := profile.labels[node.Label]
+		if entry == nil {
+			entry = &labelProfile{node: node}
+			profile.labels[node.Label] = entry
+		}
+		entry.count++
+		for _, child := range node.Children {
+			if child != nil {
+				stack = append(stack, profileStackEntry{node: child, depth: item.depth + 1})
+			}
+		}
+	}
+
+	return profile
+}
+
+type shapeProfile struct {
+	levelCounts map[int]int
+	childCounts map[int]int
+}
+
+func computeShapeProfileDistance(tree1, tree2 *TreeNode) float64 {
+	profile1 := collectShapeProfile(tree1)
+	profile2 := collectShapeProfile(tree2)
+	return math.Max(
+		profileCountDistance(profile1.levelCounts, profile2.levelCounts),
+		profileCountDistance(profile1.childCounts, profile2.childCounts),
+	)
+}
+
+func collectShapeProfile(root *TreeNode) shapeProfile {
+	profile := shapeProfile{
+		levelCounts: make(map[int]int),
+		childCounts: make(map[int]int),
+	}
+	if root == nil {
+		return profile
+	}
+
+	type shapeStackEntry struct {
+		node  *TreeNode
+		depth int
+	}
+	stack := []shapeStackEntry{{node: root}}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		item := stack[last]
+		stack = stack[:last]
+
+		node := item.node
+		profile.levelCounts[item.depth]++
+		profile.childCounts[len(node.Children)]++
+
+		for _, child := range node.Children {
+			if child != nil {
+				stack = append(stack, shapeStackEntry{node: child, depth: item.depth + 1})
+			}
+		}
+	}
+
+	return profile
+}
+
+func profileCountDistance(profile1, profile2 map[int]int) float64 {
+	difference := 0
+	for key, count1 := range profile1 {
+		difference += absInt(count1 - profile2[key])
+	}
+	for key, count2 := range profile2 {
+		if _, ok := profile1[key]; !ok {
+			difference += count2
+		}
+	}
+	return float64(difference) * 0.5
+}
+
+func absInt(value int) int {
+	if value < 0 {
+		return -value
+	}
+	return value
+}
+
+type labelProfileIndex map[string]*labelProfile
+
+func buildLabelProfileIndex(profile map[string]*labelProfile) labelProfileIndex {
+	index := make(labelProfileIndex)
+
+	for label, entry := range profile {
+		if entry.count <= 0 {
+			continue
+		}
+
+		key := labelProfileKey(label)
+		if betterLabelProfile(entry, index[key]) {
+			index[key] = entry
+		}
+	}
+
+	return index
+}
+
+func betterLabelProfile(candidate, current *labelProfile) bool {
+	if current == nil {
+		return true
+	}
+	if candidate.count != current.count {
+		return candidate.count > current.count
+	}
+	return candidate.node.Label < current.node.Label
+}
+
+func labelProfileKey(label string) string {
+	if idx := strings.Index(label, "("); idx >= 0 {
+		return label[:idx]
+	}
+	return label
+}
+
+func cancelSharedLabels(profile1, profile2 map[string]*labelProfile) {
+	for label, entry1 := range profile1 {
+		entry2 := profile2[label]
+		if entry2 == nil {
+			continue
+		}
+
+		shared := minLabelCount(entry1.count, entry2.count)
+		entry1.count -= shared
+		entry2.count -= shared
+	}
+}
+
+// sortedProfileLabels returns the profile's labels in sorted order so float
+// cost sums are accumulated deterministically regardless of map iteration.
+func sortedProfileLabels(profile map[string]*labelProfile) []string {
+	labels := make([]string, 0, len(profile))
+	for label := range profile {
+		labels = append(labels, label)
+	}
+	sort.Strings(labels)
+	return labels
+}
+
+func (a *APTEDAnalyzer) unmatchedSourceCost(sources map[string]*labelProfile, targets labelProfileIndex) float64 {
+	total := 0.0
+	for _, label := range sortedProfileLabels(sources) {
+		source := sources[label]
+		if source.count <= 0 {
+			continue
+		}
+
+		best := a.costModel.Delete(source.node)
+		if target := targets[labelProfileKey(source.node.Label)]; target != nil {
+			best = math.Min(best, a.costModel.Rename(source.node, target.node))
+		}
+		total += float64(source.count) * best
+	}
+	return total
+}
+
+func (a *APTEDAnalyzer) unmatchedTargetCost(sources labelProfileIndex, targets map[string]*labelProfile) float64 {
+	total := 0.0
+	for _, label := range sortedProfileLabels(targets) {
+		target := targets[label]
+		if target.count <= 0 {
+			continue
+		}
+
+		best := a.costModel.Insert(target.node)
+		if source := sources[labelProfileKey(target.node.Label)]; source != nil {
+			best = math.Min(best, a.costModel.Rename(source.node, target.node))
+		}
+		total += float64(target.count) * best
+	}
+	return total
+}
+
+func minLabelCount(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func (a *APTEDAnalyzer) computeBoundedSameShapeDistance(tree1, tree2 *TreeNode) (float64, bool) {
+	if !sameTreeShape(tree1, tree2) {
+		return 0, false
+	}
+
+	state := sameShapeDistanceState{
+		distances:               make(map[nodePair]float64),
+		deleteCosts:             make(map[*TreeNode]float64),
+		insertCosts:             make(map[*TreeNode]float64),
+		alignmentCellsRemaining: maxSameShapeAlignmentCells,
+	}
+	return a.sameShapeNodeDistance(tree1, tree2, &state), true
+}
+
+func sameTreeShape(tree1, tree2 *TreeNode) bool {
+	stack := [][2]*TreeNode{{tree1, tree2}}
+	for len(stack) > 0 {
+		last := len(stack) - 1
+		pair := stack[last]
+		stack = stack[:last]
+
+		left := pair[0]
+		right := pair[1]
+		if left == nil || right == nil {
+			return left == right
+		}
+		if len(left.Children) != len(right.Children) {
+			return false
+		}
+
+		for i := range left.Children {
+			stack = append(stack, [2]*TreeNode{left.Children[i], right.Children[i]})
+		}
+	}
+
+	return true
+}
+
+type nodePair struct {
+	left  *TreeNode
+	right *TreeNode
+}
+
+type sameShapeDistanceState struct {
+	distances               map[nodePair]float64
+	deleteCosts             map[*TreeNode]float64
+	insertCosts             map[*TreeNode]float64
+	alignmentCellsRemaining int
+}
+
+func (a *APTEDAnalyzer) sameShapeNodeDistance(left, right *TreeNode, state *sameShapeDistanceState) float64 {
+	if left == nil && right == nil {
+		return 0
+	}
+	if left == nil {
+		return a.cachedInsertCost(right, state)
+	}
+	if right == nil {
+		return a.cachedDeleteCost(left, state)
+	}
+
+	if len(left.Children) == 0 && len(right.Children) == 0 {
+		return math.Min(
+			a.costModel.Rename(left, right),
+			a.costModel.Delete(left)+a.costModel.Insert(right),
+		)
+	}
+
+	key := nodePair{left: left, right: right}
+	if distance, ok := state.distances[key]; ok {
+		return distance
+	}
+
+	rootCost := math.Min(
+		a.costModel.Rename(left, right),
+		a.costModel.Delete(left)+a.costModel.Insert(right),
+	)
+	childrenCost := a.sameShapeChildrenDistance(left.Children, right.Children, state)
+	distance := rootCost + childrenCost
+	state.distances[key] = distance
+	return distance
+}
+
+func (a *APTEDAnalyzer) sameShapeChildrenDistance(left, right []*TreeNode, state *sameShapeDistanceState) float64 {
+	if len(left) == 0 && len(right) == 0 {
+		return 0
+	}
+
+	positionalDistance := a.positionalChildrenDistance(left, right, state)
+	if positionalDistance == 0 || !canRealignChildren(left, right) {
+		return positionalDistance
+	}
+	if len(left) == len(right) {
+		if shiftDistance, exact := a.singleChildShiftDistance(left, right, state); exact && shiftDistance < positionalDistance {
+			return shiftDistance
+		}
+	}
+
+	if !state.reserveAlignmentCells(len(left) * len(right)) {
+		// Keep the large-tree path bounded. This may overestimate exact APTED
+		// for complex sibling reorders, but avoids hiding differences as zero.
+		return positionalDistance
+	}
+	alignedDistance := a.alignChildSequences(left, right, state)
+	if len(left) == len(right) {
+		return math.Min(positionalDistance, alignedDistance)
+	}
+	return alignedDistance
+}
+
+func (a *APTEDAnalyzer) positionalChildrenDistance(left, right []*TreeNode, state *sameShapeDistanceState) float64 {
+	total := 0.0
+	shared := minLabelCount(len(left), len(right))
+	for i := 0; i < shared; i++ {
+		total += a.sameShapeNodeDistance(left[i], right[i], state)
+	}
+	for _, child := range left[shared:] {
+		total += a.cachedDeleteCost(child, state)
+	}
+	for _, child := range right[shared:] {
+		total += a.cachedInsertCost(child, state)
+	}
+	return total
+}
+
+func canRealignChildren(left, right []*TreeNode) bool {
+	if len(left) < 2 || len(right) < 2 {
+		return false
+	}
+
+	rightLabels := make(map[string]childPosition, len(right))
+	needsProfileKeys := false
+	for i, child := range right {
+		rightLabels[child.Label] = addChildPosition(rightLabels[child.Label], i)
+		needsProfileKeys = needsProfileKeys || labelProfileKey(child.Label) != child.Label
+	}
+	for i, child := range left {
+		position, ok := rightLabels[child.Label]
+		if ok && (position.count > 1 || position.index != i) {
+			return true
+		}
+		needsProfileKeys = needsProfileKeys || labelProfileKey(child.Label) != child.Label
+	}
+
+	if !needsProfileKeys {
+		return false
+	}
+
+	rightKeys := make(map[string]childPosition, len(right))
+	for i, child := range right {
+		key := labelProfileKey(child.Label)
+		rightKeys[key] = addChildPosition(rightKeys[key], i)
+	}
+	for i, child := range left {
+		key := labelProfileKey(child.Label)
+		position, ok := rightKeys[key]
+		if ok && (position.count > 1 || position.index != i) {
+			return true
+		}
+	}
+
+	return false
+}
+
+type childPosition struct {
+	index int
+	count int
+}
+
+func addChildPosition(position childPosition, index int) childPosition {
+	if position.count == 0 {
+		position.index = index
+	}
+	position.count++
+	return position
+}
+
+func (a *APTEDAnalyzer) singleChildShiftDistance(left, right []*TreeNode, state *sameShapeDistanceState) (float64, bool) {
+	if len(left) != len(right) || len(left) < 2 {
+		return 0, false
+	}
+
+	start := 0
+	for start < len(left) && a.sameShapeNodeDistance(left[start], right[start], state) == 0 {
+		start++
+	}
+	if start == len(left) {
+		return 0, true
+	}
+
+	end := len(left) - 1
+	for end > start && a.sameShapeNodeDistance(left[end], right[end], state) == 0 {
+		end--
+	}
+	if start == end {
+		return 0, false
+	}
+
+	forwardCost, forwardExact := a.childShiftDistance(left, right, start, end, true, state)
+	backwardCost, backwardExact := a.childShiftDistance(left, right, start, end, false, state)
+	if forwardExact && (!backwardExact || forwardCost <= backwardCost) {
+		return forwardCost, true
+	}
+	if backwardExact {
+		return backwardCost, true
+	}
+	return 0, false
+}
+
+func (a *APTEDAnalyzer) childShiftDistance(
+	left, right []*TreeNode,
+	start, end int,
+	leftDeletion bool,
+	state *sameShapeDistanceState,
+) (float64, bool) {
+	matchedDistance := 0.0
+	if leftDeletion {
+		for i := start; i < end; i++ {
+			matchedDistance += a.sameShapeNodeDistance(left[i+1], right[i], state)
+		}
+		return a.cachedDeleteCost(left[start], state) + a.cachedInsertCost(right[end], state) + matchedDistance, matchedDistance == 0
+	}
+
+	for i := start; i < end; i++ {
+		matchedDistance += a.sameShapeNodeDistance(left[i], right[i+1], state)
+	}
+	return a.cachedDeleteCost(left[end], state) + a.cachedInsertCost(right[start], state) + matchedDistance, matchedDistance == 0
+}
+
+func (state *sameShapeDistanceState) reserveAlignmentCells(cells int) bool {
+	if cells <= 0 {
+		return true
+	}
+	if cells > state.alignmentCellsRemaining {
+		return false
+	}
+	state.alignmentCellsRemaining -= cells
+	return true
+}
+
+func (a *APTEDAnalyzer) alignChildSequences(left, right []*TreeNode, state *sameShapeDistanceState) float64 {
+	prev := make([]float64, len(right)+1)
+	for j, child := range right {
+		prev[j+1] = prev[j] + a.cachedInsertCost(child, state)
+	}
+
+	for _, leftChild := range left {
+		curr := make([]float64, len(right)+1)
+		curr[0] = prev[0] + a.cachedDeleteCost(leftChild, state)
+
+		for j, rightChild := range right {
+			deleteCost := prev[j+1] + a.cachedDeleteCost(leftChild, state)
+			insertCost := curr[j] + a.cachedInsertCost(rightChild, state)
+			matchCost := prev[j] + a.sameShapeNodeDistance(leftChild, rightChild, state)
+			curr[j+1] = math.Min(deleteCost, math.Min(insertCost, matchCost))
+		}
+
+		prev = curr
+	}
+
+	return prev[len(right)]
+}
+
+func (a *APTEDAnalyzer) cachedDeleteCost(node *TreeNode, state *sameShapeDistanceState) float64 {
+	if node == nil {
+		return 0
+	}
+	if cost, ok := state.deleteCosts[node]; ok {
+		return cost
+	}
+
+	cost := a.costModel.Delete(node)
+	for _, child := range node.Children {
+		cost += a.cachedDeleteCost(child, state)
+	}
+	state.deleteCosts[node] = cost
+	return cost
+}
+
+func (a *APTEDAnalyzer) cachedInsertCost(node *TreeNode, state *sameShapeDistanceState) float64 {
+	if node == nil {
+		return 0
+	}
+	if cost, ok := state.insertCosts[node]; ok {
+		return cost
+	}
+
+	cost := a.costModel.Insert(node)
+	for _, child := range node.Children {
+		cost += a.cachedInsertCost(child, state)
+	}
+	state.insertCosts[node] = cost
+	return cost
 }
 
 func (a *APTEDAnalyzer) aptedOptimized(tree1, tree2 *TreeNode, keyRoots1, keyRoots2 []int, maxDistance float64) float64 {
@@ -317,14 +894,20 @@ func (a *APTEDAnalyzer) computeSubtreeCost(root *TreeNode, maxDepth int, insert 
 // ComputeSimilarity computes similarity score between two trees (0.0 to 1.0).
 // The normalization mode is controlled by the analyzer's NormalizationMode setting.
 func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode) float64 {
+	_, similarity := a.ComputeDistanceAndSimilarity(tree1, tree2)
+	return similarity
+}
+
+// normalizeSimilarity converts a distance into a [0, 1] similarity using the
+// analyzer's normalization mode.
+func (a *APTEDAnalyzer) normalizeSimilarity(distance float64, tree1, tree2 *TreeNode) float64 {
 	if tree1 == nil && tree2 == nil {
-		return 1.0
+		return 1.0 // Identical (both empty)
 	}
 	if tree1 == nil || tree2 == nil {
-		return 0.0
+		return 0.0 // Completely different (one empty)
 	}
 
-	distance := a.ComputeDistance(tree1, tree2)
 	size1 := float64(tree1.Size())
 	size2 := float64(tree2.Size())
 
@@ -332,7 +915,10 @@ func (a *APTEDAnalyzer) ComputeSimilarity(tree1, tree2 *TreeNode) float64 {
 	switch a.normalizationMode {
 	case NormalizeBySum:
 		maxPossible = size1 + size2
-	default: // NormalizeByMax
+	default:
+		// NormalizeByMax: a tree can be transformed into another with at most
+		// max(size1, size2) operations when we delete one tree and insert the
+		// other optimally. Stricter than size1+size2, reduces false positives.
 		maxPossible = math.Max(size1, size2)
 	}
 
@@ -356,8 +942,7 @@ type TreeEditResult struct {
 
 // ComputeDetailedDistance computes detailed tree edit distance information.
 func (a *APTEDAnalyzer) ComputeDetailedDistance(tree1, tree2 *TreeNode) *TreeEditResult {
-	distance := a.ComputeDistance(tree1, tree2)
-	similarity := a.ComputeSimilarity(tree1, tree2)
+	distance, similarity := a.ComputeDistanceAndSimilarity(tree1, tree2)
 
 	var size1, size2 int
 	if tree1 != nil {
@@ -379,7 +964,7 @@ func (a *APTEDAnalyzer) ComputeDetailedDistance(tree1, tree2 *TreeNode) *TreeEdi
 // OptimizedAPTEDAnalyzer extends APTEDAnalyzer with early stopping.
 type OptimizedAPTEDAnalyzer struct {
 	*APTEDAnalyzer
-	maxDistance      float64
+	maxDistance     float64
 	enableEarlyStop bool
 }
 
@@ -387,7 +972,7 @@ type OptimizedAPTEDAnalyzer struct {
 func NewOptimizedAPTEDAnalyzer(costModel CostModel, maxDistance float64) *OptimizedAPTEDAnalyzer {
 	return &OptimizedAPTEDAnalyzer{
 		APTEDAnalyzer:   NewAPTEDAnalyzer(costModel),
-		maxDistance:      maxDistance,
+		maxDistance:     maxDistance,
 		enableEarlyStop: maxDistance > 0,
 	}
 }

--- a/core/apted/apted_test.go
+++ b/core/apted/apted_test.go
@@ -603,6 +603,37 @@ func TestAPTEDAnalyzerSameShapeDistanceMatchesExactAPTED(t *testing.T) {
 	})
 }
 
+func TestAPTEDAnalyzerLargeChainShift(t *testing.T) {
+	const size = largeTreeThreshold + 1
+	tree1 := createShiftedChain(size, 0)
+	tree2 := createShiftedChain(size, 1)
+	analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+	distance := analyzer.ComputeDistance(tree1, tree2)
+
+	if distance != 2.0 {
+		t.Errorf("single-node chain shift should cost one delete and one insert: want 2.0, got %f", distance)
+	}
+}
+
+func TestAPTEDAnalyzerLargeDepthChangeUsesEditCost(t *testing.T) {
+	const size = largeTreeThreshold + 1
+	tree1 := createShiftedChain(size, 0)
+	tree2 := createShiftedChain(size, 0)
+	leaf := tree2
+	for len(leaf.Children) == 1 {
+		leaf = leaf.Children[0]
+	}
+	leaf.AddChild(NewTreeNode(size+1, fmt.Sprintf("node_%d", size)))
+	analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+	distance := analyzer.ComputeDistance(tree1, tree2)
+
+	if distance != 1.0 {
+		t.Errorf("adding one leaf should cost one insert: want 1.0, got %f", distance)
+	}
+}
+
 func createWideTreeWithLabels(nodeCount int, labelPrefix string) *TreeNode {
 	root := NewTreeNode(1, labelPrefix+"_root")
 	for i := 2; i <= nodeCount; i++ {
@@ -652,6 +683,17 @@ func createTwoLevelTreeWithLabel(parentCount, childrenPerParent int, label strin
 			parent.AddChild(NewTreeNode(nextID, label))
 			nextID++
 		}
+	}
+	return root
+}
+
+func createShiftedChain(nodeCount, shift int) *TreeNode {
+	root := NewTreeNode(1, fmt.Sprintf("node_%d", shift))
+	current := root
+	for i := 1; i < nodeCount; i++ {
+		child := NewTreeNode(i+1, fmt.Sprintf("node_%d", i+shift))
+		current.AddChild(child)
+		current = child
 	}
 	return root
 }

--- a/core/apted/apted_test.go
+++ b/core/apted/apted_test.go
@@ -1,6 +1,7 @@
 package apted
 
 import (
+	"fmt"
 	"math"
 	"testing"
 )
@@ -375,5 +376,304 @@ func BenchmarkTreePreparation(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		PrepareTreeForAPTED(root)
+	}
+}
+
+// identifierInsensitiveCostModel emulates a language cost model that ignores
+// identifier name differences: renaming between labels that share the same
+// profile key (text before "(") is free.
+type identifierInsensitiveCostModel struct {
+	base CostModel
+}
+
+func (m *identifierInsensitiveCostModel) Insert(node *TreeNode) float64 { return m.base.Insert(node) }
+func (m *identifierInsensitiveCostModel) Delete(node *TreeNode) float64 { return m.base.Delete(node) }
+func (m *identifierInsensitiveCostModel) Rename(node1, node2 *TreeNode) float64 {
+	if labelProfileKey(node1.Label) == labelProfileKey(node2.Label) {
+		return 0.0
+	}
+	return m.base.Rename(node1, node2)
+}
+
+func TestAPTEDAnalyzerLargeTreesPreserveLabelDistance(t *testing.T) {
+	for _, size := range []int{501, 2001} {
+		t.Run("different_labels", func(t *testing.T) {
+			tree1 := createWideTreeWithLabels(size, "left")
+			tree2 := createWideTreeWithLabels(size, "right")
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != float64(size) {
+				t.Errorf("every node label differs, so each node needs one rename: want %d, got %f", size, distance)
+			}
+			if similarity != 0.0 {
+				t.Errorf("fully different labels must not produce clone similarity, got %f", similarity)
+			}
+		})
+
+		t.Run("identical_labels", func(t *testing.T) {
+			tree1 := createWideTreeWithLabels(size, "same")
+			tree2 := createWideTreeWithLabels(size, "same")
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != 0.0 {
+				t.Errorf("expected zero distance, got %f", distance)
+			}
+			if similarity != 1.0 {
+				t.Errorf("expected similarity 1.0, got %f", similarity)
+			}
+		})
+
+		t.Run("ignored_identifier_labels", func(t *testing.T) {
+			tree1 := createWideIdentifierTree(size, "left")
+			tree2 := createWideIdentifierTree(size, "right")
+			analyzer := NewAPTEDAnalyzer(&identifierInsensitiveCostModel{base: NewDefaultCostModel()})
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != 0.0 {
+				t.Errorf("expected zero distance with ignored identifiers, got %f", distance)
+			}
+			if similarity != 1.0 {
+				t.Errorf("expected similarity 1.0 with ignored identifiers, got %f", similarity)
+			}
+		})
+
+		t.Run("weighted_rename_cost", func(t *testing.T) {
+			tree1 := createWideTreeWithLabels(size, "left")
+			tree2 := createWideTreeWithLabels(size, "right")
+			costModel := NewWeightedCostModel(3.0, 3.0, 0.25, NewDefaultCostModel())
+			analyzer := NewAPTEDAnalyzer(costModel)
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != float64(size)*0.25 {
+				t.Errorf("large-tree profiles should use rename cost when it is cheaper: want %f, got %f", float64(size)*0.25, distance)
+			}
+			if similarity != 0.75 {
+				t.Errorf("expected similarity 0.75, got %f", similarity)
+			}
+		})
+
+		t.Run("shifted_siblings", func(t *testing.T) {
+			tree1 := createWideTreeWithShiftedChildren(size, 0)
+			tree2 := createWideTreeWithShiftedChildren(size, 1)
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != 2.0 {
+				t.Errorf("same-shape sibling shifts should use delete/insert alignment: want 2.0, got %f", distance)
+			}
+			expected := 1.0 - (2.0 / float64(size))
+			if math.Abs(similarity-expected) > 0.001 {
+				t.Errorf("expected similarity %f, got %f", expected, similarity)
+			}
+		})
+
+		t.Run("reversed_siblings", func(t *testing.T) {
+			tree1 := createWideTreeWithLabels(size, "child")
+			tree2 := createWideTreeWithReversedChildren(size)
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+			distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+			if distance != float64(size-1) {
+				t.Errorf("complex wide reorders should stay bounded: want %d, got %f", size-1, distance)
+			}
+			expected := 1.0 - (float64(size-1) / float64(size))
+			if math.Abs(similarity-expected) > 0.001 {
+				t.Errorf("expected similarity %f, got %f", expected, similarity)
+			}
+		})
+	}
+
+	t.Run("same_labels_different_large_shape", func(t *testing.T) {
+		tree1 := createTwoLevelTreeWithLabel(1000, 1, "same")
+		tree2 := createTwoLevelTreeWithLabel(500, 3, "same")
+		analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+		distance, similarity := analyzer.ComputeDistanceAndSimilarity(tree1, tree2)
+
+		if distance <= 0.0 {
+			t.Errorf("large trees with different shape must not look identical, got distance %f", distance)
+		}
+		if similarity >= 1.0 {
+			t.Errorf("expected similarity < 1.0, got %f", similarity)
+		}
+	})
+}
+
+func TestAPTEDAnalyzerSameShapeDistanceMatchesExactAPTED(t *testing.T) {
+	tests := []struct {
+		name      string
+		costModel CostModel
+		tree1     *TreeNode
+		tree2     *TreeNode
+	}{
+		{
+			name:      "default",
+			costModel: NewDefaultCostModel(),
+			tree1:     createWideTreeWithLabels(31, "left"),
+			tree2:     createWideTreeWithLabels(31, "right"),
+		},
+		{
+			name:      "weighted",
+			costModel: NewWeightedCostModel(3.0, 3.0, 0.25, NewDefaultCostModel()),
+			tree1:     createWideTreeWithLabels(31, "left"),
+			tree2:     createWideTreeWithLabels(31, "right"),
+		},
+		{
+			name:      "ignored_identifiers",
+			costModel: &identifierInsensitiveCostModel{base: NewDefaultCostModel()},
+			tree1:     createWideIdentifierTree(31, "left"),
+			tree2:     createWideIdentifierTree(31, "right"),
+		},
+		{
+			name:      "shifted_siblings",
+			costModel: NewDefaultCostModel(),
+			tree1:     createWideTreeWithShiftedChildren(31, 0),
+			tree2:     createWideTreeWithShiftedChildren(31, 1),
+		},
+		{
+			name:      "reversed_siblings",
+			costModel: NewDefaultCostModel(),
+			tree1:     createWideTreeWithLabels(31, "child"),
+			tree2:     createWideTreeWithReversedChildren(31),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			analyzer := NewAPTEDAnalyzer(tt.costModel)
+			exactDistance := analyzer.ComputeDistance(tt.tree1, tt.tree2)
+
+			sameShapeDistance, ok := analyzer.computeBoundedSameShapeDistance(tt.tree1, tt.tree2)
+
+			if !ok {
+				t.Fatal("expected same-shape distance to be computed")
+			}
+			if sameShapeDistance != exactDistance {
+				t.Errorf("same-shape distance %f should match exact APTED %f", sameShapeDistance, exactDistance)
+			}
+		})
+	}
+
+	t.Run("shape_mismatch", func(t *testing.T) {
+		analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+		_, ok := analyzer.computeBoundedSameShapeDistance(
+			createTwoLevelTreeWithLabel(5, 1, "same"),
+			createTwoLevelTreeWithLabel(3, 3, "same"),
+		)
+
+		if ok {
+			t.Error("expected shape mismatch to be rejected")
+		}
+	})
+
+	t.Run("budget_exhaustion_keeps_positional_child_cost", func(t *testing.T) {
+		analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+		// The large-tree same-shape path is a bounded clone-detection heuristic:
+		// when alignment budget is gone, it returns the positional signal rather
+		// than pretending the children are identical.
+		state := &sameShapeDistanceState{
+			distances:               make(map[nodePair]float64),
+			deleteCosts:             make(map[*TreeNode]float64),
+			insertCosts:             make(map[*TreeNode]float64),
+			alignmentCellsRemaining: 0,
+		}
+		left := []*TreeNode{
+			NewTreeNode(1, "A"),
+			NewTreeNode(2, "B"),
+			NewTreeNode(3, "C"),
+		}
+		right := []*TreeNode{
+			NewTreeNode(4, "A"),
+		}
+
+		distance := analyzer.sameShapeChildrenDistance(left, right, state)
+
+		if distance != 2.0 {
+			t.Errorf("expected positional child cost 2.0, got %f", distance)
+		}
+	})
+}
+
+func createWideTreeWithLabels(nodeCount int, labelPrefix string) *TreeNode {
+	root := NewTreeNode(1, labelPrefix+"_root")
+	for i := 2; i <= nodeCount; i++ {
+		root.AddChild(NewTreeNode(i, fmt.Sprintf("%s_%d", labelPrefix, i)))
+	}
+	return root
+}
+
+func createWideIdentifierTree(nodeCount int, namePrefix string) *TreeNode {
+	root := NewTreeNode(1, "Program")
+	for i := 2; i <= nodeCount; i++ {
+		root.AddChild(NewTreeNode(i, fmt.Sprintf("Identifier(%s_%d)", namePrefix, i)))
+	}
+	return root
+}
+
+func createWideTreeWithShiftedChildren(nodeCount, shift int) *TreeNode {
+	root := NewTreeNode(1, "root")
+	if nodeCount <= 1 {
+		return root
+	}
+
+	childCount := nodeCount - 1
+	for i := 0; i < childCount; i++ {
+		labelIndex := ((i + shift) % childCount) + 2
+		root.AddChild(NewTreeNode(i+2, fmt.Sprintf("child_%d", labelIndex)))
+	}
+	return root
+}
+
+func createWideTreeWithReversedChildren(nodeCount int) *TreeNode {
+	root := NewTreeNode(1, "child_root")
+	for i := nodeCount; i >= 2; i-- {
+		root.AddChild(NewTreeNode(i, fmt.Sprintf("child_%d", i)))
+	}
+	return root
+}
+
+func createTwoLevelTreeWithLabel(parentCount, childrenPerParent int, label string) *TreeNode {
+	root := NewTreeNode(1, label)
+	nextID := 2
+	for i := 0; i < parentCount; i++ {
+		parent := NewTreeNode(nextID, label)
+		nextID++
+		root.AddChild(parent)
+		for j := 0; j < childrenPerParent; j++ {
+			parent.AddChild(NewTreeNode(nextID, label))
+			nextID++
+		}
+	}
+	return root
+}
+
+func TestComputeApproximateDistanceNilTrees(t *testing.T) {
+	analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+
+	// Both nil
+	if distance := analyzer.computeApproximateDistance(nil, nil); distance != 0.0 {
+		t.Errorf("Approximate distance between two nil trees should be 0, got %f", distance)
+	}
+
+	tree := NewTreeNode(1, "test")
+	tree.AddChild(NewTreeNode(2, "child"))
+
+	// First nil
+	if distance := analyzer.computeApproximateDistance(nil, tree); distance != float64(tree.Size()) {
+		t.Errorf("Approximate distance from nil should equal tree size, got %f", distance)
+	}
+
+	// Second nil
+	if distance := analyzer.computeApproximateDistance(tree, nil); distance != float64(tree.Size()) {
+		t.Errorf("Approximate distance to nil should equal tree size, got %f", distance)
 	}
 }


### PR DESCRIPTION
## Summary

Second refresh PR (churn order): brings core/apted up to jscan's current implementation while keeping core's `NormalizationMode` and named constants.

- **Label-profile approximate distance**: cost-model-aware matching (delete/insert vs rename against the best same-key candidate) with shared-label cancellation, plus a shape-profile fallback so equal-label trees with different shapes don't read as identical
- **Bounded same-shape distance** for equal-size trees: memoized node/children distances, single-shift detection, budgeted sequence alignment (20k cells); returns the positional signal when the budget is exhausted rather than hiding differences
- **Optimized path hardening**: the profile distance now serves as a lower bound for the capped key-root computation (`max(optimized, profile)`)
- **New API**: `ComputeDistanceAndSimilarity` (one distance pass); `ComputeSimilarity`/`ComputeDetailedDistance` delegate to it, normalization stays mode-aware
- **Determinism hardening beyond jscan**: unmatched-cost float sums iterate labels in sorted order

Not ported: jscan's `apted_tree.go` changes (TreeConverter — parser-specific, stays in the language adapter).

## Testing

Ported jscan's large-tree/same-shape test suite; the jscan-specific identifier-insensitive cost model is emulated with a test-local `CostModel`. `go test -race ./...` green on all 13 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)