### PR TITLE
core/clone: refresh pair classification and add Type-1/2 similarity gates

### DIFF
--- a/core/clone/classifier.go
+++ b/core/clone/classifier.go
@@ -1,21 +1,25 @@
 package clone
 
 import (
-	"sort"
+	"math"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
 )
 
-// ClassifierConfig holds configuration for the clone classifier.
+// ClassifierConfig holds configuration for clone pair classification.
 type ClassifierConfig struct {
-	Type1Threshold            float64
-	Type2Threshold            float64
-	Type3Threshold            float64
-	Type4Threshold            float64
-	EnableType1               bool
-	EnableType2               bool
-	EnableType3               bool
-	EnableType4               bool
+	Type1Threshold float64
+	Type2Threshold float64
+	Type3Threshold float64
+	Type4Threshold float64
+	EnableType1    bool
+	EnableType2    bool
+	EnableType3    bool
+	EnableType4    bool
+	// JaccardPreFilterThreshold is the feature Jaccard similarity below which
+	// pairs are rejected before expensive structural analysis. Only used for
+	// rejection — all non-rejected pairs proceed to structural classification.
+	// Zero disables the pre-filter.
 	JaccardPreFilterThreshold float64
 }
 
@@ -30,118 +34,134 @@ func DefaultClassifierConfig() ClassifierConfig {
 		EnableType2:               true,
 		EnableType3:               true,
 		EnableType4:               true,
-		JaccardPreFilterThreshold: 0.0,
+		JaccardPreFilterThreshold: 0.10,
 	}
 }
 
-// ClassificationResult holds the result of classifying a clone pair.
-type ClassificationResult struct {
-	CloneType    domain.CloneType
-	Similarity   float64
-	Confidence   float64
-	AnalyzerName string
-}
-
-// Classifier performs cascade classification of clone pairs.
-type Classifier struct {
+// PairClassifier classifies clone pairs from structural similarity, gating
+// Type-1 on exact textual match and Type-2 on syntactic (normalized AST)
+// similarity.
+type PairClassifier struct {
 	config    ClassifierConfig
-	analyzers map[domain.CloneType]SimilarityAnalyzer
+	textual   *TextualSimilarityAnalyzer
+	syntactic *SyntacticSimilarityAnalyzer
 }
 
-// NewClassifier creates a new classifier with the given configuration.
-func NewClassifier(config ClassifierConfig) *Classifier {
-	return &Classifier{
+// NewPairClassifier creates a pair classifier. A nil textual analyzer disables
+// the Type-1 gate (no pair can be confirmed as Type-1); a nil syntactic
+// analyzer disables the Type-2 gate.
+func NewPairClassifier(config ClassifierConfig, textual *TextualSimilarityAnalyzer, syntactic *SyntacticSimilarityAnalyzer) *PairClassifier {
+	return &PairClassifier{
 		config:    config,
-		analyzers: make(map[domain.CloneType]SimilarityAnalyzer),
+		textual:   textual,
+		syntactic: syntactic,
 	}
 }
 
-// RegisterAnalyzer registers a similarity analyzer for the given clone type.
-func (c *Classifier) RegisterAnalyzer(cloneType domain.CloneType, analyzer SimilarityAnalyzer) {
-	c.analyzers[cloneType] = analyzer
+// ClassifyPair classifies a clone pair from its precomputed structural
+// (APTED) similarity. Returns the clone type (0 when the pair is not a
+// significant clone) and the possibly capped similarity actually used for
+// classification.
+func (c *PairClassifier) ClassifyPair(f1, f2 *CodeFragment, structuralSimilarity float64) (domain.CloneType, float64) {
+	if c.config.EnableType1 && c.textual != nil &&
+		structuralSimilarity >= c.config.Type1Threshold && c.textual.IsExactMatch(f1, f2) {
+		return domain.Type1Clone, structuralSimilarity
+	}
+
+	capped := c.capNonTextualSimilarity(structuralSimilarity)
+	if c.config.EnableType2 && c.syntactic != nil && capped >= c.config.Type2Threshold {
+		syntacticSimilarity := c.syntactic.ComputeSimilarity(f1, f2)
+		if syntacticSimilarity >= c.config.Type2Threshold {
+			return domain.Type2Clone, math.Min(capped, syntacticSimilarity)
+		}
+	}
+	if c.config.EnableType3 && capped >= c.config.Type3Threshold {
+		return domain.Type3Clone, capped
+	}
+	if c.config.EnableType4 && capped >= c.config.Type4Threshold {
+		return domain.Type4Clone, capped
+	}
+
+	return 0, capped
 }
 
-// Classify classifies a pair of code fragments using cascade classification.
-// It tries Type-1 first (highest threshold), then Type-2, Type-3, Type-4.
-// Returns nil if similarity is below all thresholds.
-func (c *Classifier) Classify(f1, f2 *CodeFragment) *ClassificationResult {
-	if f1 == nil || f2 == nil {
-		return nil
+// capNonTextualSimilarity caps structural similarity just below the Type-1
+// threshold so that pairs without an exact textual match never report a
+// Type-1-level similarity.
+func (c *PairClassifier) capNonTextualSimilarity(similarity float64) float64 {
+	if similarity < c.config.Type1Threshold {
+		return similarity
 	}
 
-	// Try each type in cascade order (strictest to most lenient)
-	types := []struct {
-		ct        domain.CloneType
-		threshold float64
-		enabled   bool
-	}{
-		{domain.Type1Clone, c.config.Type1Threshold, c.config.EnableType1},
-		{domain.Type2Clone, c.config.Type2Threshold, c.config.EnableType2},
-		{domain.Type3Clone, c.config.Type3Threshold, c.config.EnableType3},
-		{domain.Type4Clone, c.config.Type4Threshold, c.config.EnableType4},
+	capped := math.Nextafter(c.config.Type1Threshold, 0)
+	if capped < c.config.Type2Threshold {
+		return c.config.Type2Threshold
 	}
-
-	for _, t := range types {
-		if !t.enabled {
-			continue
-		}
-
-		analyzer, ok := c.analyzers[t.ct]
-		if !ok {
-			continue
-		}
-
-		sim := analyzer.ComputeSimilarity(f1, f2)
-		if sim >= t.threshold {
-			// Confidence is how far above the threshold the similarity is,
-			// normalized to 0-1 range above the threshold
-			confidence := 1.0
-			if t.threshold < 1.0 {
-				confidence = (sim - t.threshold) / (1.0 - t.threshold)
-			}
-			if confidence > 1.0 {
-				confidence = 1.0
-			}
-
-			return &ClassificationResult{
-				CloneType:    t.ct,
-				Similarity:   sim,
-				Confidence:   confidence,
-				AnalyzerName: analyzer.Name(),
-			}
-		}
-	}
-
-	return nil
+	return capped
 }
 
-// ClassifyBatch classifies multiple pairs and returns the results as ClonePairs.
-// Pairs that don't meet any threshold are excluded from the result.
-func (c *Classifier) ClassifyBatch(pairs [][2]*CodeFragment) []*ClonePair {
-	results := make([]*ClonePair, 0, len(pairs))
+// PassesJaccardPreFilter reports whether a pair survives the cheap feature
+// Jaccard rejection filter. Pairs without pre-computed features always pass.
+func (c *PairClassifier) PassesJaccardPreFilter(f1, f2 *CodeFragment) bool {
+	if c.config.JaccardPreFilterThreshold <= 0 {
+		return true
+	}
+	if f1 == nil || f2 == nil || len(f1.Features) == 0 || len(f2.Features) == 0 {
+		return true
+	}
+	return JaccardSimilarity(f1.Features, f2.Features) >= c.config.JaccardPreFilterThreshold
+}
 
-	for _, pair := range pairs {
-		result := c.Classify(pair[0], pair[1])
-		if result == nil {
-			continue
-		}
-		results = append(results, &ClonePair{
-			Fragment1:    pair[0],
-			Fragment2:    pair[1],
-			Similarity:   result.Similarity,
-			CloneType:    result.CloneType,
-			Confidence:   result.Confidence,
-			AnalyzerName: result.AnalyzerName,
-		})
+// ShouldCompareFragments applies cheap size/line prefilters: fragments whose
+// node counts or line counts differ too much cannot be clones.
+func ShouldCompareFragments(f1, f2 *CodeFragment) bool {
+	// Early filtering: Skip if size difference is too large (>50%)
+	sizeDiff := math.Abs(float64(f1.NodeCount - f2.NodeCount))
+	avgSize := float64(f1.NodeCount+f2.NodeCount) / 2.0
+	if avgSize > 0 && sizeDiff/avgSize > 0.5 {
+		return false // Too different in size to be clones
 	}
 
-	// Sort by similarity descending for deterministic output
-	sort.Slice(results, func(i, j int) bool {
-		if results[i].Similarity != results[j].Similarity {
-			return results[i].Similarity > results[j].Similarity
-		}
-		return results[i].Fragment1.ItemKey() < results[j].Fragment1.ItemKey()
-	})
+	// Early filtering: Skip if line count difference is too large
+	lineDiff := math.Abs(float64(f1.LineCount - f2.LineCount))
+	if lineDiff > float64(f1.LineCount)*0.5 && lineDiff > float64(f2.LineCount)*0.5 {
+		return false // Too different in line count
+	}
 
-	return results
+	return true
+}
+
+// CalculateConfidence calculates confidence in a clone pair from similarity,
+// fragment size, and complexity agreement.
+func CalculateConfidence(f1, f2 *CodeFragment, similarity float64) float64 {
+	confidence := similarity
+
+	// Increase confidence for larger fragments
+	avgSize := float64(f1.NodeCount+f2.NodeCount) / 2.0
+	sizeBonus := math.Min(avgSize/100.0, 0.2) // Up to 20% bonus for large fragments
+	confidence += sizeBonus
+
+	// Increase confidence if both fragments have similar complexity
+	if f1.Complexity > 0 && f2.Complexity > 0 {
+		complexityRatio := float64(min(f1.Complexity, f2.Complexity)) /
+			float64(max(f1.Complexity, f2.Complexity))
+		confidence += complexityRatio * 0.1 // Up to 10% bonus for similar complexity
+	}
+
+	if confidence > 1.0 {
+		confidence = 1.0
+	}
+
+	return confidence
+}
+
+// LocationsOverlap reports whether two locations overlap in the same file
+// (inclusive line ranges). Detectors use this to reject same-file pairs of
+// overlapping fragments, which describe containment rather than duplication.
+func LocationsOverlap(a, b ItemLocation) bool {
+	if a.FilePath != b.FilePath {
+		return false
+	}
+	// Ranges overlap unless one ends before the other starts.
+	return !(a.EndLine < b.StartLine || b.EndLine < a.StartLine)
 }

--- a/core/clone/classifier_test.go
+++ b/core/clone/classifier_test.go
@@ -1,247 +1,271 @@
 package clone
 
 import (
+	"math"
 	"testing"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
 )
 
-type mockAnalyzer struct {
-	similarity float64
-	name       string
+func testClassifierConfig() ClassifierConfig {
+	config := DefaultClassifierConfig()
+	config.Type1Threshold = 0.95
+	config.Type2Threshold = 0.85
+	config.Type3Threshold = 0.80
+	config.Type4Threshold = 0.75
+	return config
 }
 
-func (m *mockAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 { return m.similarity }
-func (m *mockAnalyzer) Name() string                                   { return m.name }
-
-func newTestClassifier(sim float64) *Classifier {
-	cfg := DefaultClassifierConfig()
-	c := NewClassifier(cfg)
-	mock := &mockAnalyzer{similarity: sim, name: "mock"}
-	c.RegisterAnalyzer(domain.Type1Clone, mock)
-	c.RegisterAnalyzer(domain.Type2Clone, mock)
-	c.RegisterAnalyzer(domain.Type3Clone, mock)
-	c.RegisterAnalyzer(domain.Type4Clone, mock)
-	return c
+func newTestPairClassifier() *PairClassifier {
+	return NewPairClassifier(
+		testClassifierConfig(),
+		NewTextualSimilarityAnalyzer(nil),
+		NewSyntacticSimilarityAnalyzer(),
+	)
 }
 
-func TestClassifyNilFragments(t *testing.T) {
-	c := newTestClassifier(0.9)
-	f := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
+func TestClassifyPairType1RequiresExactTextualMatch(t *testing.T) {
+	c := newTestPairClassifier()
 
-	if r := c.Classify(nil, f); r != nil {
-		t.Error("expected nil for nil f1")
-	}
-	if r := c.Classify(f, nil); r != nil {
-		t.Error("expected nil for nil f2")
-	}
-	if r := c.Classify(nil, nil); r != nil {
-		t.Error("expected nil for both nil")
-	}
-}
+	f1 := &CodeFragment{ID: 1, Content: "return a + b;"}
+	f2 := &CodeFragment{ID: 2, Content: "return  a +  b;"} // whitespace only
 
-func TestClassifyHighSimilarityReturnsType1(t *testing.T) {
-	c := newTestClassifier(0.95)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
-
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
+	cloneType, similarity := c.ClassifyPair(f1, f2, 0.99)
+	if cloneType != domain.Type1Clone {
+		t.Fatalf("expected Type1, got %v", cloneType)
 	}
-	if r.CloneType != domain.Type1Clone {
-		t.Errorf("CloneType = %v, want Type1Clone", r.CloneType)
-	}
-	if r.Similarity != 0.95 {
-		t.Errorf("Similarity = %f, want 0.95", r.Similarity)
-	}
-	if r.AnalyzerName != "mock" {
-		t.Errorf("AnalyzerName = %q, want %q", r.AnalyzerName, "mock")
+	if similarity != 0.99 {
+		t.Errorf("Type-1 similarity must be uncapped, got %f", similarity)
 	}
 }
 
-func TestClassifyMediumSimilarityReturnsType2(t *testing.T) {
-	// 0.82 is above Type2 threshold (0.80) but below Type1 threshold (0.85)
-	c := newTestClassifier(0.82)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+func TestClassifyPairHighStructuralWithoutTextualMatchIsCapped(t *testing.T) {
+	c := newTestPairClassifier()
 
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if r.CloneType != domain.Type2Clone {
-		t.Errorf("CloneType = %v, want Type2Clone", r.CloneType)
-	}
-}
+	// Same structure, renamed identifier: structural similarity is high but
+	// there is no exact textual match, so Type-1 similarity must not be
+	// reported. Identical features satisfy the Type-2 syntactic gate.
+	f1 := &CodeFragment{ID: 1, Content: "return alpha;", Features: []string{"f1", "f2"}}
+	f2 := &CodeFragment{ID: 2, Content: "return beta;", Features: []string{"f1", "f2"}}
 
-func TestClassifyType3Similarity(t *testing.T) {
-	// 0.75 is above Type3 threshold (0.70) but below Type2 threshold (0.80)
-	c := newTestClassifier(0.75)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
-
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
+	cloneType, similarity := c.ClassifyPair(f1, f2, 0.99)
+	if cloneType != domain.Type2Clone {
+		t.Fatalf("expected Type2, got %v", cloneType)
 	}
-	if r.CloneType != domain.Type3Clone {
-		t.Errorf("CloneType = %v, want Type3Clone", r.CloneType)
+	if similarity >= c.config.Type1Threshold {
+		t.Errorf("non-textual pair must report similarity below Type-1 threshold, got %f", similarity)
 	}
 }
 
-func TestClassifyType4Similarity(t *testing.T) {
-	// 0.67 is above Type4 threshold (0.65) but below Type3 threshold (0.70)
-	c := newTestClassifier(0.67)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+func TestClassifyPairType2RequiresSyntacticGate(t *testing.T) {
+	c := newTestPairClassifier()
 
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
-	}
-	if r.CloneType != domain.Type4Clone {
-		t.Errorf("CloneType = %v, want Type4Clone", r.CloneType)
-	}
-}
+	// High structural similarity but disjoint normalized features: the
+	// syntactic gate fails and classification falls through to Type-3.
+	f1 := &CodeFragment{ID: 1, Content: "if (a) { f(); }", Features: []string{"f1", "f2"}}
+	f2 := &CodeFragment{ID: 2, Content: "if (b) { g(); }", Features: []string{"g1", "g2"}}
 
-func TestClassifyBelowAllThresholds(t *testing.T) {
-	c := newTestClassifier(0.50)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
-
-	r := c.Classify(f1, f2)
-	if r != nil {
-		t.Errorf("expected nil for similarity below all thresholds, got %+v", r)
+	cloneType, _ := c.ClassifyPair(f1, f2, 0.90)
+	if cloneType != domain.Type3Clone {
+		t.Fatalf("expected Type3 when syntactic gate fails, got %v", cloneType)
 	}
 }
 
-func TestClassifyDisabledType(t *testing.T) {
-	cfg := DefaultClassifierConfig()
-	cfg.EnableType1 = false
-	c := NewClassifier(cfg)
-	mock := &mockAnalyzer{similarity: 0.95, name: "mock"}
-	c.RegisterAnalyzer(domain.Type1Clone, mock)
-	c.RegisterAnalyzer(domain.Type2Clone, mock)
-	c.RegisterAnalyzer(domain.Type3Clone, mock)
-	c.RegisterAnalyzer(domain.Type4Clone, mock)
+func TestClassifyPairType2SimilarityIsMinOfGates(t *testing.T) {
+	config := testClassifierConfig()
+	c := NewPairClassifier(config, NewTextualSimilarityAnalyzer(nil), NewSyntacticSimilarityAnalyzer())
 
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+	// Feature overlap of 6/7 ≈ 0.857 passes the 0.85 syntactic gate and is
+	// lower than the capped structural similarity, so it wins the min().
+	shared := []string{"a", "b", "c", "d", "e", "f"}
+	f1 := &CodeFragment{ID: 1, Content: "x", Features: append([]string{}, shared...)}
+	f2 := &CodeFragment{ID: 2, Content: "y", Features: append(append([]string{}, shared...), "g")}
 
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
+	cloneType, similarity := c.ClassifyPair(f1, f2, 0.99)
+	if cloneType != domain.Type2Clone {
+		t.Fatalf("expected Type2, got %v", cloneType)
 	}
-	// Type-1 is disabled, so it should fall through to Type-2
-	if r.CloneType != domain.Type2Clone {
-		t.Errorf("CloneType = %v, want Type2Clone (Type1 disabled)", r.CloneType)
+	want := 6.0 / 7.0
+	if math.Abs(similarity-want) > 1e-9 {
+		t.Errorf("expected min(structural, syntactic) = %f, got %f", want, similarity)
 	}
 }
 
-func TestClassifyBatch(t *testing.T) {
-	cfg := DefaultClassifierConfig()
-	c := NewClassifier(cfg)
+func TestClassifyPairType3AndType4(t *testing.T) {
+	c := newTestPairClassifier()
 
-	highMock := &mockAnalyzer{similarity: 0.90, name: "high"}
-	lowMock := &mockAnalyzer{similarity: 0.50, name: "low"}
+	f1 := &CodeFragment{ID: 1, Content: "a"}
+	f2 := &CodeFragment{ID: 2, Content: "b"}
 
-	// Register high analyzer for Type1, low for all others
-	c.RegisterAnalyzer(domain.Type1Clone, highMock)
-	c.RegisterAnalyzer(domain.Type2Clone, lowMock)
-	c.RegisterAnalyzer(domain.Type3Clone, lowMock)
-	c.RegisterAnalyzer(domain.Type4Clone, lowMock)
-
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
-	f3 := &CodeFragment{ID: 3, FilePath: "c.go", StartLine: 1, EndLine: 10}
-
-	pairs := [][2]*CodeFragment{
-		{f1, f2}, // high similarity -> Type1
-		{f2, f3}, // high similarity -> Type1
-		{f1, f3}, // high similarity -> Type1
+	if cloneType, _ := c.ClassifyPair(f1, f2, 0.82); cloneType != domain.Type3Clone {
+		t.Errorf("expected Type3 at 0.82, got %v", cloneType)
 	}
-
-	results := c.ClassifyBatch(pairs)
-	if len(results) != 3 {
-		t.Fatalf("expected 3 results, got %d", len(results))
-	}
-
-	for _, r := range results {
-		if r.CloneType != domain.Type1Clone {
-			t.Errorf("expected Type1Clone, got %v", r.CloneType)
-		}
+	if cloneType, _ := c.ClassifyPair(f1, f2, 0.76); cloneType != domain.Type4Clone {
+		t.Errorf("expected Type4 at 0.76, got %v", cloneType)
 	}
 }
 
-func TestClassifyBatchFiltersBelowThreshold(t *testing.T) {
-	cfg := DefaultClassifierConfig()
-	c := NewClassifier(cfg)
+func TestClassifyPairBelowAllThresholds(t *testing.T) {
+	c := newTestPairClassifier()
 
-	lowMock := &mockAnalyzer{similarity: 0.30, name: "low"}
-	c.RegisterAnalyzer(domain.Type1Clone, lowMock)
-	c.RegisterAnalyzer(domain.Type2Clone, lowMock)
-	c.RegisterAnalyzer(domain.Type3Clone, lowMock)
-	c.RegisterAnalyzer(domain.Type4Clone, lowMock)
+	f1 := &CodeFragment{ID: 1, Content: "a"}
+	f2 := &CodeFragment{ID: 2, Content: "b"}
 
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
-
-	pairs := [][2]*CodeFragment{{f1, f2}}
-	results := c.ClassifyBatch(pairs)
-	if len(results) != 0 {
-		t.Errorf("expected 0 results for below-threshold pairs, got %d", len(results))
+	cloneType, similarity := c.ClassifyPair(f1, f2, 0.5)
+	if cloneType != 0 {
+		t.Errorf("expected no clone type below all thresholds, got %v", cloneType)
+	}
+	if similarity != 0.5 {
+		t.Errorf("similarity below Type-1 threshold must pass through unchanged, got %f", similarity)
 	}
 }
 
-func TestDefaultClassifierConfig(t *testing.T) {
-	cfg := DefaultClassifierConfig()
+func TestClassifyPairDisabledTypesAreSkipped(t *testing.T) {
+	config := testClassifierConfig()
+	config.EnableType1 = false
+	config.EnableType2 = false
+	config.EnableType3 = false
+	c := NewPairClassifier(config, NewTextualSimilarityAnalyzer(nil), NewSyntacticSimilarityAnalyzer())
 
-	if cfg.Type1Threshold != domain.DefaultType1CloneThreshold {
-		t.Errorf("Type1Threshold = %f, want %f", cfg.Type1Threshold, domain.DefaultType1CloneThreshold)
-	}
-	if cfg.Type2Threshold != domain.DefaultType2CloneThreshold {
-		t.Errorf("Type2Threshold = %f, want %f", cfg.Type2Threshold, domain.DefaultType2CloneThreshold)
-	}
-	if cfg.Type3Threshold != domain.DefaultType3CloneThreshold {
-		t.Errorf("Type3Threshold = %f, want %f", cfg.Type3Threshold, domain.DefaultType3CloneThreshold)
-	}
-	if cfg.Type4Threshold != domain.DefaultType4CloneThreshold {
-		t.Errorf("Type4Threshold = %f, want %f", cfg.Type4Threshold, domain.DefaultType4CloneThreshold)
-	}
-	if !cfg.EnableType1 || !cfg.EnableType2 || !cfg.EnableType3 || !cfg.EnableType4 {
-		t.Error("all clone types should be enabled by default")
-	}
-	if cfg.JaccardPreFilterThreshold != 0.0 {
-		t.Errorf("JaccardPreFilterThreshold = %f, want 0.0", cfg.JaccardPreFilterThreshold)
+	f1 := &CodeFragment{ID: 1, Content: "same", Features: []string{"f"}}
+	f2 := &CodeFragment{ID: 2, Content: "same", Features: []string{"f"}}
+
+	cloneType, _ := c.ClassifyPair(f1, f2, 0.99)
+	if cloneType != domain.Type4Clone {
+		t.Errorf("expected Type4 with types 1-3 disabled, got %v", cloneType)
 	}
 }
 
-func TestClassifyConfidence(t *testing.T) {
-	// With similarity=1.0 and threshold=0.85, confidence should be 1.0
-	c := newTestClassifier(1.0)
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+func TestCapNonTextualSimilarity(t *testing.T) {
+	c := newTestPairClassifier()
 
-	r := c.Classify(f1, f2)
-	if r == nil {
-		t.Fatal("expected non-nil result")
+	// Below the Type-1 threshold: unchanged.
+	if got := c.capNonTextualSimilarity(0.90); got != 0.90 {
+		t.Errorf("below-threshold similarity must pass through, got %f", got)
 	}
-	if r.Confidence != 1.0 {
-		t.Errorf("Confidence = %f, want 1.0", r.Confidence)
+
+	// At or above the Type-1 threshold: capped just below it.
+	got := c.capNonTextualSimilarity(1.0)
+	if got >= c.config.Type1Threshold {
+		t.Errorf("capped similarity %f must be below Type-1 threshold %f", got, c.config.Type1Threshold)
+	}
+	if got < c.config.Type2Threshold {
+		t.Errorf("capped similarity %f must not fall below Type-2 threshold %f", got, c.config.Type2Threshold)
 	}
 }
 
-func TestClassifyNoAnalyzerRegistered(t *testing.T) {
-	cfg := DefaultClassifierConfig()
-	c := NewClassifier(cfg)
-	// No analyzers registered
+func TestPassesJaccardPreFilter(t *testing.T) {
+	c := newTestPairClassifier()
 
-	f1 := &CodeFragment{ID: 1, FilePath: "a.go", StartLine: 1, EndLine: 10}
-	f2 := &CodeFragment{ID: 2, FilePath: "b.go", StartLine: 1, EndLine: 10}
+	sharedFeatures := []string{"a", "b", "c", "d", "e", "f", "g", "h", "i"}
+	similar1 := &CodeFragment{ID: 1, Features: append([]string{}, sharedFeatures...)}
+	similar2 := &CodeFragment{ID: 2, Features: append(append([]string{}, sharedFeatures...), "j")}
+	if !c.PassesJaccardPreFilter(similar1, similar2) {
+		t.Error("highly similar features must pass the pre-filter")
+	}
 
-	r := c.Classify(f1, f2)
-	if r != nil {
-		t.Errorf("expected nil with no analyzers registered, got %+v", r)
+	disjoint := &CodeFragment{ID: 3, Features: []string{"x", "y", "z", "w", "v", "u", "t", "s", "r", "q"}}
+	if c.PassesJaccardPreFilter(similar1, disjoint) {
+		t.Error("disjoint features must be rejected by the pre-filter")
+	}
+
+	noFeatures := &CodeFragment{ID: 4}
+	if !c.PassesJaccardPreFilter(similar1, noFeatures) {
+		t.Error("fragments without features must always pass")
+	}
+
+	zeroConfig := testClassifierConfig()
+	zeroConfig.JaccardPreFilterThreshold = 0
+	czero := NewPairClassifier(zeroConfig, nil, nil)
+	if !czero.PassesJaccardPreFilter(similar1, disjoint) {
+		t.Error("zero threshold must disable the pre-filter")
+	}
+}
+
+func TestShouldCompareFragments(t *testing.T) {
+	base := &CodeFragment{ID: 1, NodeCount: 100, LineCount: 20}
+
+	similar := &CodeFragment{ID: 2, NodeCount: 110, LineCount: 22}
+	if !ShouldCompareFragments(base, similar) {
+		t.Error("similar-size fragments must be compared")
+	}
+
+	tooBig := &CodeFragment{ID: 3, NodeCount: 300, LineCount: 21}
+	if ShouldCompareFragments(base, tooBig) {
+		t.Error("fragments with >50% node-count difference must be skipped")
+	}
+
+	tooManyLines := &CodeFragment{ID: 4, NodeCount: 105, LineCount: 60}
+	if ShouldCompareFragments(base, tooManyLines) {
+		t.Error("fragments with large line-count difference must be skipped")
+	}
+}
+
+func TestCalculateConfidence(t *testing.T) {
+	f1 := &CodeFragment{ID: 1, NodeCount: 50, Complexity: 4}
+	f2 := &CodeFragment{ID: 2, NodeCount: 50, Complexity: 4}
+
+	confidence := CalculateConfidence(f1, f2, 0.8)
+	if confidence <= 0.8 {
+		t.Errorf("size and complexity bonuses should raise confidence above similarity, got %f", confidence)
+	}
+	if confidence > 1.0 {
+		t.Errorf("confidence must be capped at 1.0, got %f", confidence)
+	}
+
+	huge1 := &CodeFragment{ID: 3, NodeCount: 10000, Complexity: 10}
+	huge2 := &CodeFragment{ID: 4, NodeCount: 10000, Complexity: 10}
+	if confidence := CalculateConfidence(huge1, huge2, 0.99); confidence != 1.0 {
+		t.Errorf("confidence must be capped at 1.0, got %f", confidence)
+	}
+}
+
+func TestLocationsOverlap(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b ItemLocation
+		want bool
+	}{
+		{
+			"different files",
+			ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 10},
+			ItemLocation{FilePath: "b.js", StartLine: 1, EndLine: 10},
+			false,
+		},
+		{
+			"overlapping ranges",
+			ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 10},
+			ItemLocation{FilePath: "a.js", StartLine: 5, EndLine: 15},
+			true,
+		},
+		{
+			"containment",
+			ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 100},
+			ItemLocation{FilePath: "a.js", StartLine: 5, EndLine: 15},
+			true,
+		},
+		{
+			"adjacent but disjoint",
+			ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 10},
+			ItemLocation{FilePath: "a.js", StartLine: 11, EndLine: 20},
+			false,
+		},
+		{
+			"shared boundary line",
+			ItemLocation{FilePath: "a.js", StartLine: 1, EndLine: 10},
+			ItemLocation{FilePath: "a.js", StartLine: 10, EndLine: 20},
+			true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := LocationsOverlap(tt.a, tt.b); got != tt.want {
+				t.Errorf("LocationsOverlap = %v, want %v", got, tt.want)
+			}
+			if got := LocationsOverlap(tt.b, tt.a); got != tt.want {
+				t.Errorf("LocationsOverlap (reversed) = %v, want %v", got, tt.want)
+			}
+		})
 	}
 }

--- a/core/clone/fragment.go
+++ b/core/clone/fragment.go
@@ -10,16 +10,19 @@ import (
 // CodeFragment represents a code fragment for clone detection.
 // It implements GroupableItem so it can be used with the grouping framework.
 type CodeFragment struct {
-	ID        int
-	FilePath  string
-	StartLine int
-	EndLine   int
-	StartCol  int
-	EndCol    int
-	Content   string
-	ASTNode   *apted.TreeNode
-	NodeCount int
-	LineCount int
+	ID         int
+	FilePath   string
+	StartLine  int
+	EndLine    int
+	StartCol   int
+	EndCol     int
+	Content    string
+	Hash       string // Hex hash of Type-1 normalized content; "" when no source content
+	ASTNode    *apted.TreeNode
+	NodeCount  int
+	LineCount  int
+	Complexity int      // Cyclomatic complexity (if applicable)
+	Features   []string // Detector-populated clone feature cache for this fragment's tree
 }
 
 // ItemID returns the fragment's unique ID for GroupableItem.

--- a/core/clone/similarity.go
+++ b/core/clone/similarity.go
@@ -1,6 +1,11 @@
 package clone
 
 import (
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strings"
+
 	"github.com/ludo-technologies/polyscan/core/apted"
 )
 
@@ -9,6 +14,10 @@ type SimilarityAnalyzer interface {
 	ComputeSimilarity(f1, f2 *CodeFragment) float64
 	Name() string
 }
+
+// ---------------------------------------------------------------------------
+// Structural similarity (APTED tree edit distance)
+// ---------------------------------------------------------------------------
 
 // StructuralAnalyzer computes structural similarity using APTED tree edit distance.
 type StructuralAnalyzer struct {
@@ -33,7 +42,418 @@ func (s *StructuralAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
 	return s.analyzer.ComputeSimilarity(f1.ASTNode, f2.ASTNode)
 }
 
+// ComputeDistanceAndSimilarity computes both APTED distance and normalized
+// similarity from one distance pass.
+func (s *StructuralAnalyzer) ComputeDistanceAndSimilarity(f1, f2 *CodeFragment) (float64, float64) {
+	if f1 == nil || f2 == nil || f1.ASTNode == nil || f2.ASTNode == nil {
+		return 0.0, 0.0
+	}
+	return s.analyzer.ComputeDistanceAndSimilarity(f1.ASTNode, f2.ASTNode)
+}
+
 // Name returns the name of this analyzer.
 func (s *StructuralAnalyzer) Name() string {
 	return "structural"
+}
+
+// ---------------------------------------------------------------------------
+// Textual similarity (Type-1 gate)
+// ---------------------------------------------------------------------------
+
+// CommentStripper removes language-specific comments from source content.
+// Each language adapter provides its own implementation (e.g. `//` and
+// `/* */` for JS/TS, `#` for Python). A nil stripper keeps comments.
+type CommentStripper func(content string) string
+
+// TextualSimilarityAnalyzer computes textual similarity for Type-1 clone detection.
+// Type-1 clones are identical code fragments except for whitespace and comments.
+type TextualSimilarityAnalyzer struct {
+	normalizeWhitespace bool
+	stripComments       CommentStripper
+}
+
+// TextualSimilarityConfig holds configuration for textual similarity analysis.
+type TextualSimilarityConfig struct {
+	NormalizeWhitespace bool
+	StripComments       CommentStripper
+}
+
+// NewTextualSimilarityAnalyzer creates a textual similarity analyzer with
+// whitespace normalization enabled and the given language comment stripper.
+func NewTextualSimilarityAnalyzer(stripComments CommentStripper) *TextualSimilarityAnalyzer {
+	return &TextualSimilarityAnalyzer{
+		normalizeWhitespace: true,
+		stripComments:       stripComments,
+	}
+}
+
+// NewTextualSimilarityAnalyzerWithConfig creates a textual similarity analyzer
+// with custom configuration.
+func NewTextualSimilarityAnalyzerWithConfig(config TextualSimilarityConfig) *TextualSimilarityAnalyzer {
+	return &TextualSimilarityAnalyzer{
+		normalizeWhitespace: config.NormalizeWhitespace,
+		stripComments:       config.StripComments,
+	}
+}
+
+// ComputeSimilarity computes the textual similarity between two code fragments.
+// Returns 1.0 for identical content (after normalization), or a Levenshtein-based
+// similarity score for near-matches.
+func (t *TextualSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+
+	content1 := t.NormalizeContent(f1.Content)
+	content2 := t.NormalizeContent(f2.Content)
+
+	if content1 == "" && content2 == "" {
+		return 1.0 // Both empty = identical
+	}
+	if content1 == "" || content2 == "" {
+		return 0.0 // One empty = completely different
+	}
+
+	// Quick hash comparison for identical content
+	if t.hashContent(content1) == t.hashContent(content2) {
+		return 1.0
+	}
+
+	// If not identical, compute string similarity using Levenshtein distance
+	return t.computeLevenshteinSimilarity(content1, content2)
+}
+
+// IsExactMatch reports whether two fragments have identical source text after
+// Type-1 normalization. Near matches are deliberately not treated as Type-1.
+func (t *TextualSimilarityAnalyzer) IsExactMatch(f1, f2 *CodeFragment) bool {
+	if f1 == nil || f2 == nil {
+		return false
+	}
+
+	content1 := t.NormalizeContent(f1.Content)
+	content2 := t.NormalizeContent(f2.Content)
+	if content1 == "" || content2 == "" {
+		return false
+	}
+
+	return content1 == content2
+}
+
+// NormalizeContent normalizes source code content for comparison: strips
+// comments via the configured language stripper and collapses whitespace.
+func (t *TextualSimilarityAnalyzer) NormalizeContent(content string) string {
+	if content == "" {
+		return ""
+	}
+
+	result := content
+
+	if t.stripComments != nil {
+		result = t.stripComments(result)
+	}
+
+	if t.normalizeWhitespace {
+		result = t.normalizeWhitespaceInContent(result)
+	}
+
+	return result
+}
+
+// normalizeWhitespaceInContent normalizes code whitespace while preserving
+// whitespace inside string literals, where it changes behavior.
+func (t *TextualSimilarityAnalyzer) normalizeWhitespaceInContent(content string) string {
+	var b strings.Builder
+	b.Grow(len(content))
+	var quote byte
+	escaped := false
+	inWhitespace := false
+
+	for i := 0; i < len(content); i++ {
+		ch := content[i]
+		if quote != 0 {
+			b.WriteByte(ch)
+			if escaped {
+				escaped = false
+			} else if ch == '\\' {
+				escaped = true
+			} else if ch == quote {
+				quote = 0
+			}
+			continue
+		}
+
+		if ch == '\'' || ch == '"' || ch == '`' {
+			quote = ch
+			inWhitespace = false
+			b.WriteByte(ch)
+			continue
+		}
+		if isSourceWhitespace(ch) {
+			if !inWhitespace {
+				b.WriteByte(' ')
+				inWhitespace = true
+			}
+			continue
+		}
+		inWhitespace = false
+		b.WriteByte(ch)
+	}
+
+	return strings.TrimSpace(b.String())
+}
+
+func isSourceWhitespace(ch byte) bool {
+	switch ch {
+	case ' ', '\t', '\n', '\r', '\f':
+		return true
+	default:
+		return false
+	}
+}
+
+// hashContent computes a FNV-64 hash of the content for quick equality check.
+func (t *TextualSimilarityAnalyzer) hashContent(content string) uint64 {
+	h := fnv.New64a()
+	h.Write([]byte(content))
+	return h.Sum64()
+}
+
+// HashFragmentContent returns a hex-encoded FNV-64a hash of the Type-1
+// normalized content. Two fragments with the same hash are Type-1 clones of
+// each other. Returns "" when the content is empty after normalization (e.g.
+// the fragment was extracted without source content).
+func (t *TextualSimilarityAnalyzer) HashFragmentContent(content string) string {
+	normalized := t.NormalizeContent(content)
+	if normalized == "" {
+		return ""
+	}
+	return fmt.Sprintf("%016x", t.hashContent(normalized))
+}
+
+// computeLevenshteinSimilarity computes similarity based on Levenshtein distance.
+// Returns a value between 0.0 and 1.0.
+func (t *TextualSimilarityAnalyzer) computeLevenshteinSimilarity(s1, s2 string) float64 {
+	distance := t.levenshteinDistance(s1, s2)
+	maxLen := max(len(s1), len(s2))
+
+	if maxLen == 0 {
+		return 1.0
+	}
+
+	similarity := 1.0 - float64(distance)/float64(maxLen)
+	if similarity < 0.0 {
+		return 0.0
+	}
+	return similarity
+}
+
+// levenshteinDistance computes the Levenshtein edit distance between two strings.
+// Uses dynamic programming with O(min(m,n)) space optimization.
+func (t *TextualSimilarityAnalyzer) levenshteinDistance(s1, s2 string) int {
+	// Ensure s1 is the shorter string for space optimization
+	if len(s1) > len(s2) {
+		s1, s2 = s2, s1
+	}
+
+	m := len(s1)
+	n := len(s2)
+
+	if m == 0 {
+		return n
+	}
+	if n == 0 {
+		return m
+	}
+
+	// Use two rows for space optimization
+	prev := make([]int, m+1)
+	curr := make([]int, m+1)
+
+	for i := 0; i <= m; i++ {
+		prev[i] = i
+	}
+
+	for j := 1; j <= n; j++ {
+		curr[0] = j
+		for i := 1; i <= m; i++ {
+			cost := 0
+			if s1[i-1] != s2[j-1] {
+				cost = 1
+			}
+
+			curr[i] = min3(
+				prev[i]+1,      // deletion
+				curr[i-1]+1,    // insertion
+				prev[i-1]+cost, // substitution
+			)
+		}
+		prev, curr = curr, prev
+	}
+
+	return prev[m]
+}
+
+// Name returns the name of this analyzer.
+func (t *TextualSimilarityAnalyzer) Name() string {
+	return "textual"
+}
+
+// min3 returns the minimum of three integers.
+func min3(a, b, c int) int {
+	if a <= b && a <= c {
+		return a
+	}
+	if b <= c {
+		return b
+	}
+	return c
+}
+
+// ---------------------------------------------------------------------------
+// Syntactic similarity (Type-2 gate)
+// ---------------------------------------------------------------------------
+
+// SyntacticSimilarityAnalyzer computes syntactic similarity using normalized
+// AST hash comparison with Jaccard coefficient. This is used for Type-2 clone
+// detection (syntactically identical but with different identifiers/literals).
+//
+// Unlike an APTED-based approach which measures tree edit distance, this
+// implementation compares sets of normalized node hashes. This eliminates
+// false positives from structurally similar but semantically different code,
+// as only nodes with identical normalized structure contribute to similarity.
+type SyntacticSimilarityAnalyzer struct {
+	extractor *ASTFeatureExtractor
+}
+
+// NewSyntacticSimilarityAnalyzer creates a new syntactic similarity analyzer
+// using normalized AST hash comparison that ignores identifier and literal differences.
+func NewSyntacticSimilarityAnalyzer() *SyntacticSimilarityAnalyzer {
+	// Use ASTFeatureExtractor with includeLiterals=false to normalize
+	// identifiers and literals, focusing only on structural patterns.
+	extractor := NewASTFeatureExtractor().WithOptions(
+		3,     // maxSubtreeHeight
+		4,     // kGramSize
+		true,  // includeTypes
+		false, // includeLiterals - ignore literal values for Type-2
+	)
+	return &SyntacticSimilarityAnalyzer{extractor: extractor}
+}
+
+// ComputeSimilarity computes the syntactic similarity between two code fragments
+// using Jaccard coefficient of normalized AST hash sets. It ignores differences
+// in identifier names and literal values, focusing only on the structural
+// syntax pattern. Pre-computed fragment features are used when available.
+func (s *SyntacticSimilarityAnalyzer) ComputeSimilarity(f1, f2 *CodeFragment) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+
+	// Use pre-computed features if available (avoids redundant tree traversal)
+	if len(f1.Features) > 0 && len(f2.Features) > 0 {
+		return JaccardSimilarity(f1.Features, f2.Features)
+	}
+
+	if f1.ASTNode == nil || f2.ASTNode == nil {
+		return 0.0
+	}
+
+	features1, err1 := s.extractor.ExtractFeatures(f1.ASTNode)
+	features2, err2 := s.extractor.ExtractFeatures(f2.ASTNode)
+	if err1 != nil || err2 != nil {
+		return 0.0
+	}
+
+	return JaccardSimilarity(features1, features2)
+}
+
+// ComputeDistance computes the syntactic distance between two code fragments.
+// Returns 1 - similarity, so distance ranges from 0 (identical) to 1 (completely
+// different). Returns 0.0 for nil inputs (no distance can be computed).
+func (s *SyntacticSimilarityAnalyzer) ComputeDistance(f1, f2 *CodeFragment) float64 {
+	if f1 == nil || f2 == nil {
+		return 0.0
+	}
+	return 1.0 - s.ComputeSimilarity(f1, f2)
+}
+
+// Name returns the name of this analyzer.
+func (s *SyntacticSimilarityAnalyzer) Name() string {
+	return "syntactic"
+}
+
+// JaccardSimilarity computes the Jaccard coefficient between two string slices:
+// Jaccard(A, B) = |A ∩ B| / |A ∪ B|. Sorted inputs (as produced by
+// ASTFeatureExtractor.ExtractFeatures) are processed with an O(n+m) merge-join;
+// unsorted inputs are sorted into a copy first so the result stays correct.
+func JaccardSimilarity(set1, set2 []string) float64 {
+	if len(set1) == 0 && len(set2) == 0 {
+		return 1.0 // Both empty = identical
+	}
+	if len(set1) == 0 || len(set2) == 0 {
+		return 0.0 // One empty = no similarity
+	}
+
+	set1 = ensureSorted(set1)
+	set2 = ensureSorted(set2)
+
+	// Merge-join on sorted slices: count unique elements and intersection
+	i, j := 0, 0
+	intersection := 0
+	union := 0
+
+	for i < len(set1) && j < len(set2) {
+		if set1[i] == set2[j] {
+			intersection++
+			union++
+			// Skip duplicates in both
+			val := set1[i]
+			for i < len(set1) && set1[i] == val {
+				i++
+			}
+			for j < len(set2) && set2[j] == val {
+				j++
+			}
+		} else if set1[i] < set2[j] {
+			union++
+			val := set1[i]
+			for i < len(set1) && set1[i] == val {
+				i++
+			}
+		} else {
+			union++
+			val := set2[j]
+			for j < len(set2) && set2[j] == val {
+				j++
+			}
+		}
+	}
+	// Count remaining unique elements
+	for i < len(set1) {
+		union++
+		val := set1[i]
+		for i < len(set1) && set1[i] == val {
+			i++
+		}
+	}
+	for j < len(set2) {
+		union++
+		val := set2[j]
+		for j < len(set2) && set2[j] == val {
+			j++
+		}
+	}
+
+	if union == 0 {
+		return 0.0
+	}
+	return float64(intersection) / float64(union)
+}
+
+func ensureSorted(values []string) []string {
+	if sort.StringsAreSorted(values) {
+		return values
+	}
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return sorted
 }

--- a/core/clone/similarity.go
+++ b/core/clone/similarity.go
@@ -166,7 +166,7 @@ func (t *TextualSimilarityAnalyzer) normalizeWhitespaceInContent(content string)
 	b.Grow(len(content))
 	var quote byte
 	escaped := false
-	inWhitespace := false
+	pendingWhitespace := false
 
 	for i := 0; i < len(content); i++ {
 		ch := content[i]
@@ -184,22 +184,36 @@ func (t *TextualSimilarityAnalyzer) normalizeWhitespaceInContent(content string)
 
 		if ch == '\'' || ch == '"' || ch == '`' {
 			quote = ch
-			inWhitespace = false
+			pendingWhitespace = false
 			b.WriteByte(ch)
 			continue
 		}
 		if isSourceWhitespace(ch) {
-			if !inWhitespace {
-				b.WriteByte(' ')
-				inWhitespace = true
-			}
+			pendingWhitespace = true
 			continue
 		}
-		inWhitespace = false
+		if pendingWhitespace && b.Len() > 0 && needsTokenSeparator(contentByteAtEnd(&b), ch) {
+			b.WriteByte(' ')
+		}
+		pendingWhitespace = false
 		b.WriteByte(ch)
 	}
 
-	return strings.TrimSpace(b.String())
+	return b.String()
+}
+
+func contentByteAtEnd(b *strings.Builder) byte {
+	content := b.String()
+	return content[len(content)-1]
+}
+
+func needsTokenSeparator(left, right byte) bool {
+	return isTokenWordByte(left) && isTokenWordByte(right)
+}
+
+func isTokenWordByte(ch byte) bool {
+	return ch >= 0x80 || ch >= 'a' && ch <= 'z' || ch >= 'A' && ch <= 'Z' ||
+		ch >= '0' && ch <= '9' || ch == '_' || ch == '$'
 }
 
 func isSourceWhitespace(ch byte) bool {

--- a/core/clone/similarity_test.go
+++ b/core/clone/similarity_test.go
@@ -1,6 +1,8 @@
 package clone
 
 import (
+	"math"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/polyscan/core/apted"
@@ -85,4 +87,171 @@ func TestStructuralAnalyzerName(t *testing.T) {
 
 func TestStructuralAnalyzerImplementsInterface(t *testing.T) {
 	var _ SimilarityAnalyzer = &StructuralAnalyzer{}
+}
+
+// --- Textual similarity (Type-1 gate) ---
+
+// testStripLineComments is a simple line-comment stripper ("//" to end of
+// line) standing in for a language adapter's CommentStripper.
+func testStripLineComments(content string) string {
+	var b strings.Builder
+	for _, line := range strings.Split(content, "\n") {
+		if idx := strings.Index(line, "//"); idx >= 0 {
+			line = line[:idx]
+		}
+		b.WriteString(line)
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func TestTextualSimilarityExactMatchAfterNormalization(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(testStripLineComments)
+
+	f1 := &CodeFragment{ID: 1, Content: "const x = 1;\nreturn x; // result"}
+	f2 := &CodeFragment{ID: 2, Content: "const x = 1;   \n\n  return x;"}
+
+	if !ta.IsExactMatch(f1, f2) {
+		t.Error("expected exact match after comment/whitespace normalization")
+	}
+	if sim := ta.ComputeSimilarity(f1, f2); sim != 1.0 {
+		t.Errorf("expected similarity 1.0, got %f", sim)
+	}
+}
+
+func TestTextualSimilarityNearMatchIsNotExact(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(nil)
+
+	f1 := &CodeFragment{ID: 1, Content: "const alpha = 1;"}
+	f2 := &CodeFragment{ID: 2, Content: "const alphb = 1;"}
+
+	if ta.IsExactMatch(f1, f2) {
+		t.Error("near matches must not be exact matches")
+	}
+	sim := ta.ComputeSimilarity(f1, f2)
+	if sim <= 0.8 || sim >= 1.0 {
+		t.Errorf("expected Levenshtein-based near-match similarity in (0.8, 1.0), got %f", sim)
+	}
+}
+
+func TestTextualSimilarityEmptyContentNeverExact(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(nil)
+
+	f1 := &CodeFragment{ID: 1, Content: ""}
+	f2 := &CodeFragment{ID: 2, Content: ""}
+
+	if ta.IsExactMatch(f1, f2) {
+		t.Error("fragments without source content must not be exact matches")
+	}
+	if sim := ta.ComputeSimilarity(f1, f2); sim != 1.0 {
+		t.Errorf("both-empty similarity should be 1.0, got %f", sim)
+	}
+}
+
+func TestTextualSimilarityPreservesStringWhitespace(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(nil)
+
+	f1 := &CodeFragment{ID: 1, Content: `x = "a  b"`}
+	f2 := &CodeFragment{ID: 2, Content: `x = "a b"`}
+
+	if ta.IsExactMatch(f1, f2) {
+		t.Error("whitespace inside string literals must be preserved")
+	}
+}
+
+func TestHashFragmentContent(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(testStripLineComments)
+
+	h1 := ta.HashFragmentContent("const x = 1; // one")
+	h2 := ta.HashFragmentContent("const  x =  1;")
+	if h1 == "" || h1 != h2 {
+		t.Errorf("normalized-equal content must hash equal: %q vs %q", h1, h2)
+	}
+
+	if h := ta.HashFragmentContent(""); h != "" {
+		t.Errorf("empty content must hash to empty string, got %q", h)
+	}
+	if h := ta.HashFragmentContent("// only a comment"); h != "" {
+		t.Errorf("comment-only content must hash to empty string, got %q", h)
+	}
+}
+
+func TestTextualSimilarityName(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(nil)
+	if ta.Name() != "textual" {
+		t.Errorf("Name() = %q, want textual", ta.Name())
+	}
+	var _ SimilarityAnalyzer = ta
+}
+
+// --- Syntactic similarity (Type-2 gate) ---
+
+func TestSyntacticSimilarityUsesPrecomputedFeatures(t *testing.T) {
+	sa := NewSyntacticSimilarityAnalyzer()
+
+	f1 := &CodeFragment{ID: 1, Features: []string{"a", "b", "c"}}
+	f2 := &CodeFragment{ID: 2, Features: []string{"a", "b", "c"}}
+
+	if sim := sa.ComputeSimilarity(f1, f2); sim != 1.0 {
+		t.Errorf("identical feature sets: got %f, want 1.0", sim)
+	}
+
+	f3 := &CodeFragment{ID: 3, Features: []string{"x", "y", "z"}}
+	if sim := sa.ComputeSimilarity(f1, f3); sim != 0.0 {
+		t.Errorf("disjoint feature sets: got %f, want 0.0", sim)
+	}
+}
+
+func TestSyntacticSimilarityFromASTNodes(t *testing.T) {
+	sa := NewSyntacticSimilarityAnalyzer()
+
+	tree1 := apted.NewTreeNode(0, "FunctionDef")
+	tree1.AddChild(apted.NewTreeNode(1, "If"))
+	tree1.AddChild(apted.NewTreeNode(2, "Return"))
+	tree2 := apted.NewTreeNode(0, "FunctionDef")
+	tree2.AddChild(apted.NewTreeNode(1, "If"))
+	tree2.AddChild(apted.NewTreeNode(2, "Return"))
+
+	f1 := &CodeFragment{ID: 1, ASTNode: tree1}
+	f2 := &CodeFragment{ID: 2, ASTNode: tree2}
+
+	if sim := sa.ComputeSimilarity(f1, f2); sim != 1.0 {
+		t.Errorf("identical trees: got %f, want 1.0", sim)
+	}
+	if sim := sa.ComputeSimilarity(f1, nil); sim != 0.0 {
+		t.Errorf("nil fragment: got %f, want 0.0", sim)
+	}
+	if d := sa.ComputeDistance(f1, f2); d != 0.0 {
+		t.Errorf("identical trees distance: got %f, want 0.0", d)
+	}
+	if sa.Name() != "syntactic" {
+		t.Errorf("Name() = %q, want syntactic", sa.Name())
+	}
+}
+
+// --- Jaccard ---
+
+func TestJaccardSimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []string
+		want float64
+	}{
+		{"both empty", nil, nil, 1.0},
+		{"one empty", []string{"a"}, nil, 0.0},
+		{"identical", []string{"a", "b"}, []string{"a", "b"}, 1.0},
+		{"disjoint", []string{"a", "b"}, []string{"c", "d"}, 0.0},
+		{"half overlap", []string{"a", "b"}, []string{"b", "c"}, 1.0 / 3.0},
+		{"duplicates collapse", []string{"a", "a", "b"}, []string{"a", "b", "b"}, 1.0},
+		{"unsorted input", []string{"b", "a"}, []string{"a", "b"}, 1.0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := JaccardSimilarity(tt.a, tt.b)
+			if math.Abs(got-tt.want) > 1e-9 {
+				t.Errorf("JaccardSimilarity(%v, %v) = %f, want %f", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
 }

--- a/core/clone/similarity_test.go
+++ b/core/clone/similarity_test.go
@@ -119,6 +119,17 @@ func TestTextualSimilarityExactMatchAfterNormalization(t *testing.T) {
 	}
 }
 
+func TestTextualSimilarityIgnoresWhitespaceAroundPunctuation(t *testing.T) {
+	ta := NewTextualSimilarityAnalyzer(nil)
+
+	f1 := &CodeFragment{ID: 1, Content: "return a+b; foo(x);"}
+	f2 := &CodeFragment{ID: 2, Content: "return  a + b ; foo ( x ) ;"}
+
+	if !ta.IsExactMatch(f1, f2) {
+		t.Error("whitespace around punctuation must not prevent a Type-1 match")
+	}
+}
+
 func TestTextualSimilarityNearMatchIsNotExact(t *testing.T) {
 	ta := NewTextualSimilarityAnalyzer(nil)
 

--- a/core/domain/defaults.go
+++ b/core/domain/defaults.go
@@ -3,7 +3,7 @@ package domain
 // Clone type thresholds (similarity score 0.0-1.0).
 const (
 	DefaultType1CloneThreshold = 0.85
-	DefaultType2CloneThreshold = 0.80
+	DefaultType2CloneThreshold = 0.75
 	DefaultType3CloneThreshold = 0.70
 	DefaultType4CloneThreshold = 0.65
 )


### PR DESCRIPTION
## Summary

Third refresh PR, covering two related areas in one: the pair-classification refresh (jscan clone_detector churn 372) and the Type-1/Type-2 similarity-gate extraction that classification depends on (previously missing from core — the old similarity.go only had the structural analyzer).

- **TextualSimilarityAnalyzer** (Type-1 gate): normalization preserving string-literal whitespace, `IsExactMatch`, Levenshtein near-match scoring, `HashFragmentContent` fingerprinting. Language comment removal is injected via `CommentStripper` — jscan's JS/TS stripper and pyscn's `#` stripper stay in their adapters.
- **SyntacticSimilarityAnalyzer** (Type-2 gate): Jaccard over normalized AST features, exported `JaccardSimilarity` (merge-join; sorts unsorted inputs into a copy as a correctness guard).
- **PairClassifier**: port of jscan's `classifyClonePair` — Type-1 requires an exact textual match, non-textual pairs get similarity capped just below the Type-1 threshold (`math.Nextafter`), Type-2 requires the syntactic gate and reports `min(structural, syntactic)`. Per-type enable flags kept from the old core config (superset of jscan behavior).
- **Prefilters**: `PassesJaccardPreFilter` (jscan's 0.10 rejection const becomes config), `ShouldCompareFragments`, `CalculateConfidence`, `LocationsOverlap`.
- `CodeFragment` gains `Hash`/`Complexity`/`Features`; `DefaultType2CloneThreshold` aligned to current jscan (0.75).
- Removed: the February analyzer-registry cascade (`Classifier`/`RegisterAnalyzer`/`ClassifyBatch`) — predates the gated design, no consumers.

Remaining jscan clone_detector.go code (LSH orchestration, fragment extraction from parser AST, domain conversion) is language-adapter territory and stays in jscan.

## Testing

New behavior-pinning tests for gates and classification (Type-1 exact-match gating, similarity capping, min-of-gates, disabled tiers, prefilters, overlap symmetry). `go test -race ./...` green on all 13 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)