### PR TITLE
core/cfg,domain: refresh dead code post-processing and extract shared scoring

### DIFF
--- a/core/cfg/deadcode.go
+++ b/core/cfg/deadcode.go
@@ -1,5 +1,10 @@
 package cfg
 
+import (
+	"sort"
+	"strings"
+)
+
 // DeadCodeSeverity indicates the severity of a dead code finding.
 type DeadCodeSeverity int
 
@@ -30,6 +35,15 @@ type DeadCodeConfig struct {
 	Classifier StatementClassifier
 }
 
+// NoOpClassifier is an optional StatementClassifier extension reporting
+// statements with no actionable content (e.g. a bare `;` in JS/TS or `pass`
+// in Python). Unreachable blocks consisting solely of no-op statements are
+// technically dead but carry no signal for the user, so they are not
+// reported as findings.
+type NoOpClassifier interface {
+	IsNoOp(stmt any) bool
+}
+
 // DetectDeadCode identifies dead code in a CFG.
 // It uses AnalyzeReachability to find unreachable blocks, then examines
 // reachable blocks for code after terminators (return/break/continue/throw).
@@ -47,25 +61,38 @@ func DetectDeadCode(c *CFG, config DeadCodeConfig) *DeadCodeResult {
 	// unreachable when no alternative path reaches them.
 	reachResult := AnalyzeReachability(c, ReachabilityConfig{Classifier: config.Classifier})
 
-	// Find unreachable blocks.
+	// Iterate blocks in sorted ID order for deterministic finding order.
+	blockIDs := make([]string, 0, len(c.Blocks))
 	for id := range c.Blocks {
-		if !reachResult.Reachable[id] {
-			result.Findings = append(result.Findings, &DeadCodeFinding{
-				BlockID:  id,
-				Severity: SeverityCritical,
-				Reason:   "unreachable",
-			})
-			result.DeadBlocks++
+		blockIDs = append(blockIDs, id)
+	}
+	sort.Strings(blockIDs)
+
+	noOpClassifier, _ := config.Classifier.(NoOpClassifier)
+
+	// Find unreachable blocks.
+	for _, id := range blockIDs {
+		if reachResult.Reachable[id] {
+			continue
 		}
+		if noOpClassifier != nil && isOnlyNoOpStatements(c.Blocks[id], noOpClassifier) {
+			continue
+		}
+		result.Findings = append(result.Findings, &DeadCodeFinding{
+			BlockID:  id,
+			Severity: SeverityCritical,
+			Reason:   "unreachable",
+		})
+		result.DeadBlocks++
 	}
 
 	// For reachable blocks, check for code after terminators.
 	if config.Classifier != nil {
-		for id, block := range c.Blocks {
+		for _, id := range blockIDs {
 			if !reachResult.Reachable[id] {
 				continue
 			}
-			reason := findTerminatorInBlock(block, config.Classifier)
+			reason := findTerminatorInBlock(c.Blocks[id], config.Classifier)
 			if reason != "" {
 				severity := SeverityInfo
 				if reason == "after_return" || reason == "after_throw" {
@@ -82,6 +109,20 @@ func DetectDeadCode(c *CFG, config DeadCodeConfig) *DeadCodeResult {
 	}
 
 	return result
+}
+
+// isOnlyNoOpStatements reports whether every statement in the block is a
+// no-op separator. Blocks without statements return false.
+func isOnlyNoOpStatements(block *BasicBlock, classifier NoOpClassifier) bool {
+	if block == nil || len(block.Statements) == 0 {
+		return false
+	}
+	for _, stmt := range block.Statements {
+		if stmt == nil || !classifier.IsNoOp(stmt) {
+			return false
+		}
+	}
+	return true
 }
 
 // findTerminatorInBlock checks if a block has statements after a terminator.
@@ -106,4 +147,89 @@ func findTerminatorInBlock(block *BasicBlock, classifier StatementClassifier) st
 		}
 	}
 	return ""
+}
+
+// ---------------------------------------------------------------------------
+// Line-level finding post-processing
+// ---------------------------------------------------------------------------
+
+// LineFinding is the language-independent, line-level slice of a dead code
+// finding used by post-processing passes. Language adapters convert their
+// richer finding types to and from this representation (or embed it).
+type LineFinding struct {
+	StartLine   int
+	EndLine     int
+	Reason      string
+	Severity    DeadCodeSeverity
+	Description string
+	Code        string
+}
+
+// SortLineFindings sorts findings by start line, then end line, for
+// consistent output and as the precondition of MergeContiguousFindings.
+func SortLineFindings(findings []*LineFinding) {
+	sort.Slice(findings, func(i, j int) bool {
+		if findings[i].StartLine != findings[j].StartLine {
+			return findings[i].StartLine < findings[j].StartLine
+		}
+		return findings[i].EndLine < findings[j].EndLine
+	})
+}
+
+// MergeContiguousFindings collapses findings whose line ranges overlap or are
+// directly adjacent (no reachable line between them) and that share the same
+// reason into a single finding. Findings must be pre-sorted by StartLine (then
+// EndLine); use SortLineFindings. This removes the overlapping/duplicate
+// ranges that arise because a compound statement's finding spans its body
+// while the body's block emits its own nested finding.
+func MergeContiguousFindings(findings []*LineFinding) []*LineFinding {
+	if len(findings) <= 1 {
+		return findings
+	}
+
+	merged := make([]*LineFinding, 0, len(findings))
+	current := findings[0]
+
+	for _, next := range findings[1:] {
+		// Contiguous if the next finding starts at or before the line right after
+		// the current region's end (overlapping or back-to-back lines).
+		contiguous := next.StartLine <= current.EndLine+1
+		if contiguous && next.Reason == current.Reason {
+			if next.EndLine > current.EndLine {
+				current.EndLine = next.EndLine
+			}
+			current.Code = mergeCodeLines(current.Code, next.Code)
+			if next.Severity > current.Severity {
+				current.Severity = next.Severity
+				current.Description = next.Description
+			}
+			continue
+		}
+		merged = append(merged, current)
+		current = next
+	}
+	merged = append(merged, current)
+
+	return merged
+}
+
+// mergeCodeLines appends the lines of b to a, skipping a leading line of b that
+// duplicates the trailing line of a. This keeps the merged snippet readable when
+// a nested-body block repeats the line already shown by its enclosing statement.
+func mergeCodeLines(a, b string) string {
+	if a == "" {
+		return b
+	}
+	if b == "" {
+		return a
+	}
+	aLines := strings.Split(a, "\n")
+	bLines := strings.Split(b, "\n")
+	if len(aLines) > 0 && len(bLines) > 0 && aLines[len(aLines)-1] == bLines[0] {
+		bLines = bLines[1:]
+	}
+	if len(bLines) == 0 {
+		return a
+	}
+	return a + "\n" + strings.Join(bLines, "\n")
 }

--- a/core/cfg/deadcode_test.go
+++ b/core/cfg/deadcode_test.go
@@ -299,3 +299,156 @@ func TestDeadCodeAlternatePathAroundReturn(t *testing.T) {
 		}
 	}
 }
+
+// testNoOpClassifier extends testClassifier with no-op detection (";").
+type testNoOpClassifier struct {
+	testClassifier
+}
+
+func (tc *testNoOpClassifier) IsNoOp(stmt any) bool {
+	s, ok := stmt.(string)
+	return ok && s == ";"
+}
+
+func TestDeadCodeSkipsNoOpOnlyBlocks(t *testing.T) {
+	c := NewCFG("noop")
+	b1 := c.CreateBlock("b1")
+	orphan := c.CreateBlock("orphan")
+	orphan.AddStatement(";")
+	orphan.AddStatement(";")
+	c.ConnectBlocks(c.Entry, b1, EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, EdgeNormal)
+
+	result := DetectDeadCode(c, DeadCodeConfig{Classifier: &testNoOpClassifier{}})
+
+	if len(result.Findings) != 0 {
+		t.Fatalf("expected no findings for no-op-only unreachable block, got %d", len(result.Findings))
+	}
+}
+
+func TestDeadCodeReportsMixedNoOpBlocks(t *testing.T) {
+	c := NewCFG("mixed")
+	b1 := c.CreateBlock("b1")
+	orphan := c.CreateBlock("orphan")
+	orphan.AddStatement(";")
+	orphan.AddStatement("call()")
+	c.ConnectBlocks(c.Entry, b1, EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, EdgeNormal)
+
+	result := DetectDeadCode(c, DeadCodeConfig{Classifier: &testNoOpClassifier{}})
+
+	if len(result.Findings) != 1 {
+		t.Fatalf("expected 1 finding for block with real statements, got %d", len(result.Findings))
+	}
+}
+
+func TestDeadCodeFindingsAreDeterministicallyOrdered(t *testing.T) {
+	c := NewCFG("order")
+	b1 := c.CreateBlock("b1")
+	c.ConnectBlocks(c.Entry, b1, EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, EdgeNormal)
+	// Multiple orphan blocks; findings must come back in sorted block-ID order.
+	for _, id := range []string{"orphan_c", "orphan_a", "orphan_b"} {
+		c.CreateBlock(id)
+	}
+
+	result := DetectDeadCode(c, DeadCodeConfig{Classifier: &testClassifier{}})
+
+	if len(result.Findings) != 3 {
+		t.Fatalf("expected 3 findings, got %d", len(result.Findings))
+	}
+	for i := 1; i < len(result.Findings); i++ {
+		if result.Findings[i-1].BlockID > result.Findings[i].BlockID {
+			t.Fatalf("findings not sorted by block ID: %s > %s", result.Findings[i-1].BlockID, result.Findings[i].BlockID)
+		}
+	}
+}
+
+// --- Line-level merge pass ---
+
+func lf(start, end int, reason string, sev DeadCodeSeverity) *LineFinding {
+	return &LineFinding{StartLine: start, EndLine: end, Reason: reason, Severity: sev, Code: "x"}
+}
+
+func TestMergeContiguousFindings(t *testing.T) {
+	t.Run("merges overlapping same-reason findings", func(t *testing.T) {
+		in := []*LineFinding{
+			lf(4, 6, "after_throw", SeverityWarning),
+			lf(6, 6, "after_throw", SeverityCritical),
+		}
+		out := MergeContiguousFindings(in)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(out))
+		}
+		if out[0].StartLine != 4 || out[0].EndLine != 6 {
+			t.Errorf("expected merged range 4-6, got %d-%d", out[0].StartLine, out[0].EndLine)
+		}
+		if out[0].Severity != SeverityCritical {
+			t.Errorf("expected highest severity to be kept, got %d", out[0].Severity)
+		}
+	})
+
+	t.Run("merges adjacent same-reason findings", func(t *testing.T) {
+		in := []*LineFinding{
+			lf(4, 6, "after_throw", SeverityCritical),
+			lf(7, 8, "after_throw", SeverityCritical),
+		}
+		out := MergeContiguousFindings(in)
+		if len(out) != 1 {
+			t.Fatalf("expected 1 finding, got %d", len(out))
+		}
+		if out[0].EndLine != 8 {
+			t.Errorf("expected merged end line 8, got %d", out[0].EndLine)
+		}
+	})
+
+	t.Run("does not merge across a gap", func(t *testing.T) {
+		in := []*LineFinding{
+			lf(4, 4, "after_throw", SeverityCritical),
+			lf(6, 6, "after_throw", SeverityCritical),
+		}
+		out := MergeContiguousFindings(in)
+		if len(out) != 2 {
+			t.Errorf("expected 2 findings, got %d", len(out))
+		}
+	})
+
+	t.Run("does not merge different reasons", func(t *testing.T) {
+		in := []*LineFinding{
+			lf(4, 6, "after_throw", SeverityCritical),
+			lf(6, 6, "unreachable", SeverityWarning),
+		}
+		out := MergeContiguousFindings(in)
+		if len(out) != 2 {
+			t.Errorf("expected 2 findings, got %d", len(out))
+		}
+	})
+}
+
+func TestSortLineFindings(t *testing.T) {
+	in := []*LineFinding{
+		lf(5, 9, "unreachable", SeverityCritical),
+		lf(2, 8, "unreachable", SeverityCritical),
+		lf(2, 3, "unreachable", SeverityCritical),
+	}
+	SortLineFindings(in)
+	if in[0].EndLine != 3 || in[1].EndLine != 8 || in[2].StartLine != 5 {
+		t.Errorf("expected sort by StartLine then EndLine, got %+v", in)
+	}
+}
+
+func TestMergeCodeLines(t *testing.T) {
+	if got := mergeCodeLines("", "b"); got != "b" {
+		t.Errorf("empty a: got %q", got)
+	}
+	if got := mergeCodeLines("a", ""); got != "a" {
+		t.Errorf("empty b: got %q", got)
+	}
+	// Duplicated boundary line is emitted once.
+	if got := mergeCodeLines("if (x) {\n  dead()", "  dead()\n}"); got != "if (x) {\n  dead()\n}" {
+		t.Errorf("boundary dedup failed: got %q", got)
+	}
+	if got := mergeCodeLines("a", "b"); got != "a\nb" {
+		t.Errorf("simple join: got %q", got)
+	}
+}

--- a/core/domain/scoring.go
+++ b/core/domain/scoring.go
@@ -1,0 +1,243 @@
+package domain
+
+import "math"
+
+// Health score calculation constants shared by all language analyzers.
+// Grade computation must match across tools; language-specific penalty
+// formulas (complexity, dead code) live in each analyzer and compose with
+// the shared calculators below.
+const (
+	// Complexity thresholds and penalties
+	ComplexityThresholdHigh   = 20
+	ComplexityThresholdMedium = 10
+	ComplexityThresholdLow    = 5
+	ComplexityPenaltyHigh     = 20
+	ComplexityPenaltyMedium   = 12
+	ComplexityPenaltyLow      = 6
+
+	// Code duplication thresholds and penalties
+	// 0% = perfect, 30% = max penalty (using fragment ratio: clonedFragments/totalFragments)
+	DuplicationThresholdHigh   = 30.0
+	DuplicationThresholdMedium = 15.0
+	DuplicationThresholdLow    = 0.0
+	DuplicationPenaltyHigh     = 20
+	DuplicationPenaltyMedium   = 12
+	DuplicationPenaltyLow      = 6
+
+	// CBO coupling scoring curve (used by CouplingPenalty)
+	// Penalty grows linearly with the weighted ratio of problematic classes
+	// and saturates (reaches the max penalty) at CouplingSaturationRatio.
+	CouplingMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
+	CouplingSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
+
+	// Maximum penalties
+	MaxDeadCodePenalty = 20
+	MaxCriticalPenalty = 10
+	MaxCyclesPenalty   = 10
+	MaxDepthPenalty    = 3
+	MaxArchPenalty     = 12
+	MaxMSDPenalty      = 3
+
+	// Score display scale - all categories normalized to this base
+	MaxScoreBase = 20
+
+	// Actual maximum penalty values for normalization
+	MaxDependencyPenalty   = MaxCyclesPenalty + MaxDepthPenalty + MaxMSDPenalty // 16
+	MaxArchitecturePenalty = MaxArchPenalty                                     // 12
+
+	// Grade thresholds
+	GradeAThreshold = 90
+	GradeBThreshold = 75
+	GradeCThreshold = 60
+	GradeDThreshold = 45
+
+	// Score quality thresholds (aligned with grade thresholds)
+	ScoreThresholdExcellent = 90 // Excellent: 90-100
+	ScoreThresholdGood      = 75 // Good: 75-89
+	ScoreThresholdFair      = 60 // Fair: 60-74
+	// Poor: 0-59 (below ScoreThresholdFair)
+
+	// Other constants
+	MinimumScore                = 0 // Allow truly low scores for severely problematic code
+	HealthyThreshold            = 70
+	FallbackComplexityThreshold = 10
+	FallbackPenalty             = 5
+)
+
+// LinearPenalty maps a value onto a 0..MaxScoreBase penalty that starts at 0
+// when value <= start and grows linearly to the maximum at saturation.
+func LinearPenalty(value, start, saturation float64) int {
+	if value <= start {
+		return 0
+	}
+	if saturation <= start {
+		return MaxScoreBase
+	}
+
+	penalty := (value - start) / (saturation - start) * float64(MaxScoreBase)
+	if penalty > float64(MaxScoreBase) {
+		penalty = float64(MaxScoreBase)
+	}
+
+	return int(math.Round(penalty))
+}
+
+// DuplicationPenalty calculates the penalty for code duplication (max 20).
+// Linear: 0% duplication = 0 penalty, DuplicationThresholdHigh (30%) = max.
+func DuplicationPenalty(duplicationPercent float64) int {
+	if duplicationPercent <= DuplicationThresholdLow {
+		return 0
+	}
+
+	penaltyRange := DuplicationThresholdHigh - DuplicationThresholdLow
+	penalty := (duplicationPercent - DuplicationThresholdLow) / penaltyRange * 20.0
+	if penalty > 20.0 {
+		penalty = 20.0
+	}
+
+	return int(math.Round(penalty))
+}
+
+// CouplingPenalty calculates the penalty for class coupling (max 20) from the
+// weighted ratio of problematic classes (High = 1.0, Medium = CouplingMediumWeight),
+// saturating at CouplingSaturationRatio.
+func CouplingPenalty(highCouplingClasses, mediumCouplingClasses, totalClasses int) int {
+	if totalClasses == 0 {
+		return 0
+	}
+
+	weightedProblematicClasses := float64(highCouplingClasses) + (CouplingMediumWeight * float64(mediumCouplingClasses))
+	ratio := weightedProblematicClasses / float64(totalClasses)
+
+	penalty := ratio / CouplingSaturationRatio * 20.0
+	if penalty > 20.0 {
+		penalty = 20.0
+	}
+
+	return int(math.Round(penalty))
+}
+
+// DependencyPenalty calculates the penalty for module dependencies
+// (max 16: cycles=10, depth=3, main sequence deviation=3).
+func DependencyPenalty(totalModules, modulesInCycles, maxDepth int, mainSequenceDeviation float64) int {
+	penalty := 0
+
+	// Cycles penalty (max 10): uses larger of proportion-based and log-scaled floor.
+	// The log-scaled floor ensures that circular dependencies always contribute
+	// a meaningful penalty, even in large codebases where the proportion is small.
+	if totalModules > 0 && modulesInCycles > 0 {
+		ratio := float64(modulesInCycles) / float64(totalModules)
+		if ratio > 1 {
+			ratio = 1
+		}
+		proportionPenalty := float64(MaxCyclesPenalty) * ratio
+		logFloor := math.Log2(float64(modulesInCycles) + 1)
+		cyclePenalty := math.Max(logFloor, proportionPenalty)
+		if cyclePenalty > float64(MaxCyclesPenalty) {
+			cyclePenalty = float64(MaxCyclesPenalty)
+		}
+		penalty += int(math.Round(cyclePenalty))
+	}
+
+	// Depth penalty (max 3): excess over expected depth ~ O(log N)
+	if totalModules > 0 {
+		expected := int(math.Max(3, math.Ceil(math.Log2(float64(totalModules)+1))+1))
+		excess := maxDepth - expected
+		if excess < 0 {
+			excess = 0
+		}
+		if excess > MaxDepthPenalty {
+			excess = MaxDepthPenalty
+		}
+		penalty += excess
+	}
+
+	// Main sequence deviation penalty (max 3)
+	if mainSequenceDeviation > 0 {
+		msd := mainSequenceDeviation
+		if msd > 1 {
+			msd = 1
+		}
+		penalty += int(math.Round(msd * float64(MaxMSDPenalty)))
+	}
+
+	return penalty
+}
+
+// ArchitecturePenalty calculates the penalty for architecture compliance
+// (max 12). Compliance is a 0..1 ratio.
+func ArchitecturePenalty(compliance float64) int {
+	if compliance < 0 {
+		compliance = 0
+	}
+	if compliance > 1 {
+		compliance = 1
+	}
+	return int(math.Round(float64(MaxArchPenalty) * (1 - compliance)))
+}
+
+// NormalizeToScoreBase normalizes a penalty value to the MaxScoreBase scale
+// (0-20) so all category scores use a consistent display scale.
+func NormalizeToScoreBase(penalty int, maxPenalty int) int {
+	if maxPenalty == 0 {
+		return 0
+	}
+	normalized := int(math.Round(float64(penalty) / float64(maxPenalty) * float64(MaxScoreBase)))
+	if normalized < 0 {
+		normalized = 0
+	}
+	if normalized > MaxScoreBase {
+		normalized = MaxScoreBase
+	}
+	return normalized
+}
+
+// PenaltyToScore converts a penalty value to a 0-100 score.
+func PenaltyToScore(penalty int, maxPenalty int) int {
+	if maxPenalty == 0 {
+		return 100
+	}
+	score := 100 - int(math.Round(float64(penalty)*100.0/float64(maxPenalty)))
+	if score < 0 {
+		score = 0
+	}
+	if score > 100 {
+		score = 100
+	}
+	return score
+}
+
+// HealthScoreFromPenalties returns 100 minus the sum of all penalties,
+// floored at MinimumScore.
+func HealthScoreFromPenalties(penalties ...int) int {
+	score := 100
+	for _, p := range penalties {
+		score -= p
+	}
+	if score < MinimumScore {
+		score = MinimumScore
+	}
+	return score
+}
+
+// GradeFromScore maps a health score to a letter grade. This mapping must
+// stay identical across all language analyzers.
+func GradeFromScore(score int) string {
+	switch {
+	case score >= GradeAThreshold:
+		return "A"
+	case score >= GradeBThreshold:
+		return "B"
+	case score >= GradeCThreshold:
+		return "C"
+	case score >= GradeDThreshold:
+		return "D"
+	default:
+		return "F"
+	}
+}
+
+// IsHealthyScore reports whether a health score is considered healthy.
+func IsHealthyScore(score int) bool {
+	return score >= HealthyThreshold
+}

--- a/core/domain/scoring_test.go
+++ b/core/domain/scoring_test.go
@@ -1,0 +1,167 @@
+package domain
+
+import "testing"
+
+func TestLinearPenalty(t *testing.T) {
+	if p := LinearPenalty(1.0, 2.0, 15.0); p != 0 {
+		t.Errorf("below start: got %d, want 0", p)
+	}
+	if p := LinearPenalty(15.0, 2.0, 15.0); p != MaxScoreBase {
+		t.Errorf("at saturation: got %d, want %d", p, MaxScoreBase)
+	}
+	if p := LinearPenalty(100.0, 2.0, 15.0); p != MaxScoreBase {
+		t.Errorf("beyond saturation: got %d, want %d", p, MaxScoreBase)
+	}
+	if p := LinearPenalty(8.5, 2.0, 15.0); p != 10 {
+		t.Errorf("midpoint: got %d, want 10", p)
+	}
+	if p := LinearPenalty(5.0, 2.0, 2.0); p != MaxScoreBase {
+		t.Errorf("degenerate saturation: got %d, want %d", p, MaxScoreBase)
+	}
+}
+
+func TestDuplicationPenalty(t *testing.T) {
+	if p := DuplicationPenalty(0.0); p != 0 {
+		t.Errorf("0%%: got %d, want 0", p)
+	}
+	if p := DuplicationPenalty(15.0); p != 10 {
+		t.Errorf("15%%: got %d, want 10", p)
+	}
+	if p := DuplicationPenalty(30.0); p != 20 {
+		t.Errorf("30%%: got %d, want 20", p)
+	}
+	if p := DuplicationPenalty(90.0); p != 20 {
+		t.Errorf("90%%: got %d, want 20 (capped)", p)
+	}
+}
+
+func TestCouplingPenalty(t *testing.T) {
+	if p := CouplingPenalty(0, 0, 0); p != 0 {
+		t.Errorf("no classes: got %d, want 0", p)
+	}
+	if p := CouplingPenalty(0, 0, 10); p != 0 {
+		t.Errorf("no problematic classes: got %d, want 0", p)
+	}
+	// 4 high / 10 classes = 0.4 ratio = saturation -> max penalty
+	if p := CouplingPenalty(4, 0, 10); p != 20 {
+		t.Errorf("at saturation: got %d, want 20", p)
+	}
+	// 1 high + 2 medium (0.3 each) = 1.6 / 10 = 0.16 -> 0.16/0.40*20 = 8
+	if p := CouplingPenalty(1, 2, 10); p != 8 {
+		t.Errorf("weighted ratio: got %d, want 8", p)
+	}
+}
+
+func TestDependencyPenaltyCyclesLogFloor(t *testing.T) {
+	// Large codebase, few modules in cycles: proportion alone would be ~0,
+	// but the log floor keeps a meaningful penalty.
+	// 3 modules in cycles -> log2(4) = 2.
+	p := DependencyPenalty(1000, 3, 3, 0)
+	if p < 2 {
+		t.Errorf("log floor should keep cycles penalty >= 2, got %d", p)
+	}
+
+	// No cycles -> no cycles penalty.
+	if p := DependencyPenalty(1000, 0, 3, 0); p != 0 {
+		t.Errorf("no cycles/depth/msd: got %d, want 0", p)
+	}
+}
+
+func TestDependencyPenaltyDepthAndMSD(t *testing.T) {
+	// 100 modules: expected depth = max(3, ceil(log2(101))+1) = 8.
+	// maxDepth 20 -> excess 12 capped at MaxDepthPenalty (3).
+	p := DependencyPenalty(100, 0, 20, 0)
+	if p != MaxDepthPenalty {
+		t.Errorf("depth excess: got %d, want %d", p, MaxDepthPenalty)
+	}
+
+	// MSD 1.0 -> full MSD penalty.
+	p = DependencyPenalty(100, 0, 0, 1.0)
+	if p != MaxMSDPenalty {
+		t.Errorf("full MSD: got %d, want %d", p, MaxMSDPenalty)
+	}
+
+	// All maxed: 10 + 3 + 3 = 16 = MaxDependencyPenalty.
+	p = DependencyPenalty(10, 10, 50, 1.0)
+	if p != MaxDependencyPenalty {
+		t.Errorf("all maxed: got %d, want %d", p, MaxDependencyPenalty)
+	}
+}
+
+func TestArchitecturePenalty(t *testing.T) {
+	if p := ArchitecturePenalty(1.0); p != 0 {
+		t.Errorf("full compliance: got %d, want 0", p)
+	}
+	if p := ArchitecturePenalty(0.0); p != MaxArchPenalty {
+		t.Errorf("zero compliance: got %d, want %d", p, MaxArchPenalty)
+	}
+	if p := ArchitecturePenalty(0.5); p != 6 {
+		t.Errorf("half compliance: got %d, want 6", p)
+	}
+	if p := ArchitecturePenalty(2.0); p != 0 {
+		t.Errorf("out-of-range compliance clamps: got %d, want 0", p)
+	}
+}
+
+func TestPenaltyToScore(t *testing.T) {
+	if s := PenaltyToScore(0, 20); s != 100 {
+		t.Errorf("no penalty: got %d, want 100", s)
+	}
+	if s := PenaltyToScore(20, 20); s != 0 {
+		t.Errorf("max penalty: got %d, want 0", s)
+	}
+	if s := PenaltyToScore(10, 20); s != 50 {
+		t.Errorf("half penalty: got %d, want 50", s)
+	}
+	if s := PenaltyToScore(5, 0); s != 100 {
+		t.Errorf("zero max: got %d, want 100", s)
+	}
+}
+
+func TestNormalizeToScoreBase(t *testing.T) {
+	if n := NormalizeToScoreBase(16, MaxDependencyPenalty); n != MaxScoreBase {
+		t.Errorf("full dependency penalty: got %d, want %d", n, MaxScoreBase)
+	}
+	if n := NormalizeToScoreBase(8, 16); n != 10 {
+		t.Errorf("half: got %d, want 10", n)
+	}
+	if n := NormalizeToScoreBase(5, 0); n != 0 {
+		t.Errorf("zero max: got %d, want 0", n)
+	}
+}
+
+func TestHealthScoreFromPenalties(t *testing.T) {
+	if s := HealthScoreFromPenalties(); s != 100 {
+		t.Errorf("no penalties: got %d, want 100", s)
+	}
+	if s := HealthScoreFromPenalties(20, 12, 6); s != 62 {
+		t.Errorf("summed penalties: got %d, want 62", s)
+	}
+	if s := HealthScoreFromPenalties(50, 60); s != MinimumScore {
+		t.Errorf("floored: got %d, want %d", s, MinimumScore)
+	}
+}
+
+func TestGradeFromScore(t *testing.T) {
+	tests := []struct {
+		score int
+		want  string
+	}{
+		{100, "A"}, {90, "A"}, {89, "B"}, {75, "B"},
+		{74, "C"}, {60, "C"}, {59, "D"}, {45, "D"}, {44, "F"}, {0, "F"},
+	}
+	for _, tt := range tests {
+		if got := GradeFromScore(tt.score); got != tt.want {
+			t.Errorf("GradeFromScore(%d) = %s, want %s", tt.score, got, tt.want)
+		}
+	}
+}
+
+func TestIsHealthyScore(t *testing.T) {
+	if !IsHealthyScore(70) {
+		t.Error("70 should be healthy")
+	}
+	if IsHealthyScore(69) {
+		t.Error("69 should not be healthy")
+	}
+}


### PR DESCRIPTION
## Summary

Fourth refresh PR: dead code post-processing (jscan churn 100; the merge pass exists identically in pyscn) plus the shared scoring extraction.

**core/cfg (dead code)**
- `LineFinding` + `SortLineFindings` + `MergeContiguousFindings`: language-independent merge of overlapping/adjacent same-reason findings (fixes double-counted lines from compound statements spanning their bodies); highest severity wins; boundary code lines dedup
- `NoOpClassifier` (optional `StatementClassifier` extension): unreachable blocks of only no-op separators (`;` / `pass`) are skipped
- `DetectDeadCode` iterates blocks in sorted ID order (determinism hardening)

**core/domain (scoring — new `scoring.go`)**
- Shared constants (verified identical between pyscn and jscan): duplication/coupling curves, max penalties, grade thresholds, score base
- Shared calculators as pure functions: `LinearPenalty`, `DuplicationPenalty`, `CouplingPenalty`, `DependencyPenalty`, `ArchitecturePenalty`, `PenaltyToScore`, `NormalizeToScoreBase`, `HealthScoreFromPenalties`, `GradeFromScore`
- **Policy composition instead of interface injection**: the intentionally divergent penalties (complexity: jscan count-ratio vs pyscn max-of-linear; dead code: jscan per-file rate vs pyscn log normalization) and pyscn-only categories (cohesion, community) stay in each analyzer, composed from core's helpers. This keeps every scanner-specific metric field out of core while guaranteeing grade computation stays identical.
- `DependencyPenalty` adopts jscan's log-floor cycles improvement (pyscn currently proportion-only — it picks up the floor at core adoption; deliberate behavior change to flag then)

## Testing

Merge tests ported from jscan's dead_code_test.go; scoring functions covered with boundary-value tests (saturation points, grade edges, penalty caps). `go test -race ./...` green on all 13 packages.

🤖 Generated with [Claude Code](https://claude.com/claude-code)