### PR TITLE
core/lcom,dfa,semantic: refresh kernels to current pyscn parity

### DIFF
--- a/core/dfa/builder.go
+++ b/core/dfa/builder.go
@@ -14,6 +14,13 @@ type RefExtractor interface {
 	ExtractUses(stmt any, block *cfg.BasicBlock, pos int) []*VarReference
 }
 
+// ParamExtractor is an optional RefExtractor extension that seeds function
+// parameter definitions from the CFG's FunctionNode into the entry block, so
+// parameter uses inside the body link back to a definition.
+type ParamExtractor interface {
+	ExtractParameterDefs(functionNode any, entry *cfg.BasicBlock) []*VarReference
+}
+
 // DFABuilder builds DFA information from a CFG using a language-specific RefExtractor.
 type DFABuilder struct {
 	extractor RefExtractor
@@ -35,6 +42,13 @@ func (b *DFABuilder) Build(c *cfg.CFG) (*DFAInfo, error) {
 	}
 
 	info := NewDFAInfo(c)
+
+	// Phase 0: Seed function parameter definitions into the entry block.
+	if pe, ok := b.extractor.(ParamExtractor); ok && c.FunctionNode != nil && c.Entry != nil {
+		for _, def := range pe.ExtractParameterDefs(c.FunctionNode, c.Entry) {
+			info.AddDef(def)
+		}
+	}
 
 	// Phase 1: Collect definitions from all blocks
 	b.collectDefinitions(c, info)
@@ -109,13 +123,21 @@ func (b *DFABuilder) findDefInBlockBefore(varName string, block *cfg.BasicBlock,
 	defs := info.BlockDefs[block.ID]
 	var latest *VarReference
 	for _, def := range defs {
-		if def.Name == varName && def.Position < beforePos {
+		if def.Name == varName && defReachesUseAtPosition(def, beforePos) {
 			if latest == nil || def.Position > latest.Position {
 				latest = def
 			}
 		}
 	}
 	return latest
+}
+
+// defReachesUseAtPosition reports whether a definition reaches a use at the
+// given statement position. Pattern captures (match/case bindings) define and
+// use the variable within the same statement, so a same-position pattern
+// definition reaches the use.
+func defReachesUseAtPosition(def *VarReference, usePos int) bool {
+	return def.Position < usePos || (def.Kind == DefKindPattern && def.Position == usePos)
 }
 
 // findDefInPredecessors searches predecessor blocks for the most recent definition using BFS.

--- a/core/dfa/builder_test.go
+++ b/core/dfa/builder_test.go
@@ -1,0 +1,151 @@
+package dfa
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/cfg"
+)
+
+// patternRefExtractor extends testRefExtractor semantics with match-pattern
+// definitions: "case x:" defines x as DefKindPattern and uses it at the same
+// statement position; "use x" is a plain load.
+type patternRefExtractor struct{}
+
+func (e *patternRefExtractor) ExtractDefinitions(stmt any, block *cfg.BasicBlock, pos int) []*VarReference {
+	s, ok := stmt.(string)
+	if !ok {
+		return nil
+	}
+	if name, found := strings.CutPrefix(s, "case "); found {
+		name = strings.TrimSuffix(name, ":")
+		return []*VarReference{NewVarReference(name, DefKindPattern, block, stmt, pos)}
+	}
+	parts := strings.SplitN(s, " = ", 2)
+	if len(parts) == 2 {
+		return []*VarReference{NewVarReference(strings.TrimSpace(parts[0]), DefKindAssign, block, stmt, pos)}
+	}
+	return nil
+}
+
+func (e *patternRefExtractor) ExtractUses(stmt any, block *cfg.BasicBlock, pos int) []*VarReference {
+	s, ok := stmt.(string)
+	if !ok {
+		return nil
+	}
+	if name, found := strings.CutPrefix(s, "use "); found {
+		return []*VarReference{NewVarReference(name, UseKindLoad, block, stmt, pos)}
+	}
+	if name, found := strings.CutPrefix(s, "case "); found {
+		// The pattern statement also uses the captured name at the same position.
+		name = strings.TrimSuffix(name, ":")
+		return []*VarReference{NewVarReference(name, UseKindLoad, block, stmt, pos)}
+	}
+	return nil
+}
+
+// ExtractParameterDefs seeds comma-separated names from the FunctionNode
+// string as parameter defs.
+func (e *patternRefExtractor) ExtractParameterDefs(functionNode any, entry *cfg.BasicBlock) []*VarReference {
+	s, ok := functionNode.(string)
+	if !ok {
+		return nil
+	}
+	var defs []*VarReference
+	for _, name := range strings.Split(s, ",") {
+		if name = strings.TrimSpace(name); name != "" {
+			defs = append(defs, NewVarReference(name, DefKindParam, entry, functionNode, -1))
+		}
+	}
+	return defs
+}
+
+func TestDefKindPatternIsDef(t *testing.T) {
+	if !DefKindPattern.IsDef() {
+		t.Error("DefKindPattern must be classified as a definition")
+	}
+	if DefKindPattern.IsUse() {
+		t.Error("DefKindPattern must not be classified as a use")
+	}
+	if DefKindPattern.String() != "pattern" {
+		t.Errorf("String() = %q, want pattern", DefKindPattern.String())
+	}
+}
+
+func TestPatternDefReachesSamePositionUse(t *testing.T) {
+	c := cfg.NewCFG("match")
+	b1 := c.CreateBlock("b1")
+	b1.AddStatement("case captured:")
+	c.ConnectBlocks(c.Entry, b1, cfg.EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, cfg.EdgeNormal)
+
+	info, err := NewDFABuilder(&patternRefExtractor{}).Build(c)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	chain := info.Chains["captured"]
+	if chain == nil {
+		t.Fatal("expected chain for pattern-captured variable")
+	}
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("expected same-position pattern def to reach the use, got %d pairs", len(chain.Pairs))
+	}
+	if chain.Pairs[0].Def.Kind != DefKindPattern {
+		t.Errorf("expected pattern def in pair, got %v", chain.Pairs[0].Def.Kind)
+	}
+}
+
+func TestAssignDefDoesNotReachSamePositionUse(t *testing.T) {
+	// A regular assignment at the same position must NOT reach the use
+	// (the use happens before/while the def executes).
+	def := NewVarReference("x", DefKindAssign, nil, nil, 3)
+	if defReachesUseAtPosition(def, 3) {
+		t.Error("assign def at same position must not reach the use")
+	}
+	if !defReachesUseAtPosition(def, 4) {
+		t.Error("assign def at earlier position must reach the use")
+	}
+}
+
+func TestParamExtractorSeedsEntryDefs(t *testing.T) {
+	c := cfg.NewCFG("fn")
+	c.FunctionNode = "arg1, arg2"
+	b1 := c.CreateBlock("b1")
+	b1.AddStatement("use arg1")
+	c.ConnectBlocks(c.Entry, b1, cfg.EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, cfg.EdgeNormal)
+
+	info, err := NewDFABuilder(&patternRefExtractor{}).Build(c)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	chain := info.Chains["arg1"]
+	if chain == nil || len(chain.Defs) != 1 {
+		t.Fatal("expected parameter definition seeded for arg1")
+	}
+	if chain.Defs[0].Kind != DefKindParam {
+		t.Errorf("expected DefKindParam, got %v", chain.Defs[0].Kind)
+	}
+	if len(chain.Pairs) != 1 {
+		t.Fatalf("expected parameter def to reach body use, got %d pairs", len(chain.Pairs))
+	}
+}
+
+func TestBuildWithoutParamExtractorStillWorks(t *testing.T) {
+	c := cfg.NewCFG("fn")
+	c.FunctionNode = "arg1"
+	b1 := c.CreateBlock("b1")
+	b1.AddStatement("x = 1")
+	c.ConnectBlocks(c.Entry, b1, cfg.EdgeNormal)
+	c.ConnectBlocks(b1, c.Exit, cfg.EdgeNormal)
+
+	info, err := NewDFABuilder(&testRefExtractor{}).Build(c)
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if info.Chains["arg1"] != nil {
+		t.Error("extractor without ParamExtractor must not seed parameter defs")
+	}
+}

--- a/core/dfa/dfa.go
+++ b/core/dfa/dfa.go
@@ -10,19 +10,20 @@ type DefUseKind int
 
 const (
 	DefKindAssign    DefUseKind = iota // Assignment (x = ...)
-	DefKindAugAssign                    // Augmented assignment (x += ...)
-	DefKindParam                        // Function parameter
-	DefKindImport                       // Import statement
-	DefKindFor                          // For-loop variable
-	DefKindWith                         // With-statement variable
-	DefKindExcept                       // Exception handler variable
-	DefKindGlobal                       // Global declaration
-	DefKindNonlocal                     // Nonlocal declaration
-	DefKindDelete                       // Delete statement
-	UseKindLoad                         // Simple name load
-	UseKindAttribute                    // Attribute access
-	UseKindCall                         // Function call
-	UseKindSubscript                    // Subscript access
+	DefKindAugAssign                   // Augmented assignment (x += ...)
+	DefKindParam                       // Function parameter
+	DefKindImport                      // Import statement
+	DefKindFor                         // For-loop variable
+	DefKindWith                        // With-statement variable
+	DefKindExcept                      // Exception handler variable
+	DefKindGlobal                      // Global declaration
+	DefKindNonlocal                    // Nonlocal declaration
+	DefKindDelete                      // Delete statement
+	DefKindPattern                     // Match/case capture pattern (case x:)
+	UseKindLoad                        // Simple name load
+	UseKindAttribute                   // Attribute access
+	UseKindCall                        // Function call
+	UseKindSubscript                   // Subscript access
 )
 
 // String returns the string representation of a DefUseKind.
@@ -48,6 +49,8 @@ func (k DefUseKind) String() string {
 		return "nonlocal"
 	case DefKindDelete:
 		return "delete"
+	case DefKindPattern:
+		return "pattern"
 	case UseKindLoad:
 		return "load"
 	case UseKindAttribute:
@@ -63,7 +66,7 @@ func (k DefUseKind) String() string {
 
 // IsDef returns true if this kind represents a definition.
 func (k DefUseKind) IsDef() bool {
-	return k >= DefKindAssign && k <= DefKindDelete
+	return k >= DefKindAssign && k <= DefKindPattern
 }
 
 // IsUse returns true if this kind represents a use.

--- a/core/lcom/lcom.go
+++ b/core/lcom/lcom.go
@@ -6,10 +6,12 @@ import (
 	"github.com/ludo-technologies/polyscan/core/domain"
 )
 
-// MethodAccess describes a method and which instance variables it accesses.
+// MethodAccess describes a method, which instance variables it accesses, and
+// which sibling methods it calls (intra-class calls, e.g. self.helper()).
 type MethodAccess struct {
 	MethodName   string
 	InstanceVars map[string]bool
+	Calls        map[string]bool
 }
 
 // Result holds the LCOM4 analysis result for a class.
@@ -41,8 +43,9 @@ func DefaultConfig() Config {
 }
 
 // ComputeLCOM4 computes the LCOM4 metric using the Union-Find algorithm.
-// LCOM4 counts the number of connected components among methods,
-// where two methods are connected if they share at least one instance variable.
+// LCOM4 counts the number of connected components among methods, where two
+// methods are connected if they share at least one instance variable or one
+// calls the other (intra-class method calls).
 func ComputeLCOM4(methods []MethodAccess, config Config) *Result {
 	result := &Result{
 		MethodGroups: [][]string{},
@@ -131,6 +134,19 @@ func ComputeLCOM4(methods []MethodAccess, config Config) *Result {
 		}
 	}
 
+	// Union methods connected by intra-class method calls
+	methodIndex := make(map[string]int, len(sortedMethods))
+	for i, m := range sortedMethods {
+		methodIndex[m.MethodName] = i
+	}
+	for i, m := range sortedMethods {
+		for callee := range m.Calls {
+			if j, exists := methodIndex[callee]; exists {
+				union(i, j)
+			}
+		}
+	}
+
 	// Count connected components and build method groups
 	components := make(map[int][]int) // root -> list of method indices
 	for i := range sortedMethods {
@@ -138,17 +154,9 @@ func ComputeLCOM4(methods []MethodAccess, config Config) *Result {
 		components[root] = append(components[root], i)
 	}
 
-	// Sort component roots for deterministic output
-	roots := make([]int, 0, len(components))
-	for r := range components {
-		roots = append(roots, r)
-	}
-	sort.Ints(roots)
-
 	result.LCOM4 = len(components)
 	result.MethodGroups = make([][]string, 0, len(components))
-	for _, root := range roots {
-		indices := components[root]
+	for _, indices := range components {
 		group := make([]string, len(indices))
 		for i, idx := range indices {
 			group[i] = sortedMethods[idx].MethodName
@@ -156,6 +164,10 @@ func ComputeLCOM4(methods []MethodAccess, config Config) *Result {
 		sort.Strings(group)
 		result.MethodGroups = append(result.MethodGroups, group)
 	}
+	// Sort groups by first method name for deterministic output
+	sort.Slice(result.MethodGroups, func(i, j int) bool {
+		return result.MethodGroups[i][0] < result.MethodGroups[j][0]
+	})
 
 	result.RiskLevel = AssessRisk(result.LCOM4, config)
 	return result

--- a/core/lcom/lcom_test.go
+++ b/core/lcom/lcom_test.go
@@ -225,3 +225,50 @@ func TestAssessRisk_CustomConfig(t *testing.T) {
 		}
 	}
 }
+
+func TestComputeLCOM4MethodCallsConnect(t *testing.T) {
+	// Two methods share no instance variables but one calls the other:
+	// they belong to the same component.
+	methods := []MethodAccess{
+		{MethodName: "save", InstanceVars: map[string]bool{"db": true}},
+		{MethodName: "validate", InstanceVars: map[string]bool{}, Calls: map[string]bool{"save": true}},
+	}
+
+	result := ComputeLCOM4(methods, DefaultConfig())
+
+	if result.LCOM4 != 1 {
+		t.Errorf("expected LCOM4=1 (call edge connects methods), got %d", result.LCOM4)
+	}
+}
+
+func TestComputeLCOM4CallToNonMethodIgnored(t *testing.T) {
+	// Calls to names that are not sibling methods (e.g. free functions)
+	// must not affect grouping.
+	methods := []MethodAccess{
+		{MethodName: "a", InstanceVars: map[string]bool{"x": true}, Calls: map[string]bool{"print": true}},
+		{MethodName: "b", InstanceVars: map[string]bool{"y": true}, Calls: map[string]bool{"len": true}},
+	}
+
+	result := ComputeLCOM4(methods, DefaultConfig())
+
+	if result.LCOM4 != 2 {
+		t.Errorf("expected LCOM4=2 (external calls ignored), got %d", result.LCOM4)
+	}
+}
+
+func TestComputeLCOM4GroupsSortedByFirstMethod(t *testing.T) {
+	methods := []MethodAccess{
+		{MethodName: "zeta", InstanceVars: map[string]bool{"z": true}},
+		{MethodName: "alpha", InstanceVars: map[string]bool{"a": true}},
+		{MethodName: "mid", InstanceVars: map[string]bool{"m": true}},
+	}
+
+	result := ComputeLCOM4(methods, DefaultConfig())
+
+	if result.LCOM4 != 3 {
+		t.Fatalf("expected LCOM4=3, got %d", result.LCOM4)
+	}
+	if result.MethodGroups[0][0] != "alpha" || result.MethodGroups[1][0] != "mid" || result.MethodGroups[2][0] != "zeta" {
+		t.Errorf("expected groups sorted by first method name, got %v", result.MethodGroups)
+	}
+}

--- a/core/semantic/semantic.go
+++ b/core/semantic/semantic.go
@@ -11,12 +11,12 @@ import (
 
 // CFGFeatures holds structural features extracted from a CFG.
 type CFGFeatures struct {
-	BlockCount      int
-	EdgeCount       int
-	EdgeTypeCounts  map[cfg.EdgeType]int
+	BlockCount       int
+	EdgeCount        int
+	EdgeTypeCounts   map[cfg.EdgeType]int
 	CyclomaticNumber int
-	BranchingFactor float64
-	LoopEdgeCount   int
+	BranchingFactor  float64
+	LoopEdgeCount    int
 	ConditionalCount int
 }
 
@@ -240,4 +240,110 @@ func compareDefUseKindDistributions(d1, d2 map[dfa.DefUseKind]int) float64 {
 		return 0.0
 	}
 	return dotProduct / (math.Sqrt(norm1) * math.Sqrt(norm2))
+}
+
+// ---------------------------------------------------------------------------
+// Semantic evidence (AST-derived counter-evidence for Type-4 similarity)
+// ---------------------------------------------------------------------------
+
+// semanticMismatchPenalty is applied when two fragments share no strong
+// semantic signal, or when their return categories are incompatible. Matching
+// control flow alone is weak evidence of semantic equivalence.
+const semanticMismatchPenalty = 0.75
+
+// literalMismatchPenalty is applied when both fragments carry enough string
+// literals to compare and the sets are completely disjoint. Matching control
+// flow combined with a fully different literal vocabulary (dict keys, format
+// names, config values) is strong counter-evidence for semantic equivalence:
+// true Type-4 clones compute the same result, so the constants they emit
+// overlap. Calibrated to pull a saturated CFG score (1.0) below the default
+// Type-4 threshold.
+const literalMismatchPenalty = 0.5
+
+// minStringLiteralEvidence is the number of distinct meaningful string
+// literals each fragment must contain before disjoint literal sets are
+// treated as counter-evidence. Docstrings and other bare string statements
+// should be excluded from the count by the extractor.
+const minStringLiteralEvidence = 2
+
+// SemanticSignals holds the language-independent semantic evidence extracted
+// from a fragment's AST. Language adapters populate the sets: StrongSignals
+// with kind-prefixed identifiers (e.g. "call:open", "attr:write"),
+// ReturnCategories with return-shape categories (e.g. "none", "literal",
+// "collection"), and StringLiterals with meaningful string constants.
+type SemanticSignals struct {
+	StrongSignals    map[string]struct{}
+	ReturnCategories map[string]struct{}
+	StringLiterals   map[string]struct{}
+}
+
+// NewSemanticSignals returns an empty signal set ready to be populated.
+func NewSemanticSignals() SemanticSignals {
+	return SemanticSignals{
+		StrongSignals:    make(map[string]struct{}),
+		ReturnCategories: make(map[string]struct{}),
+		StringLiterals:   make(map[string]struct{}),
+	}
+}
+
+// ApplySemanticEvidence adjusts a base (CFG/DFA-derived) similarity with
+// AST-level counter-evidence: fully disjoint string-literal vocabularies,
+// absence of any shared strong signal, or incompatible return categories
+// each discount the score. Missing evidence on either side is given the
+// benefit of the doubt.
+func ApplySemanticEvidence(baseSimilarity float64, signals1, signals2 SemanticSignals) float64 {
+	if baseSimilarity == 0.0 {
+		return 0.0
+	}
+
+	if hasDisjointStringLiterals(signals1.StringLiterals, signals2.StringLiterals) {
+		return baseSimilarity * literalMismatchPenalty
+	}
+	if !hasSharedSemanticSignal(signals1.StrongSignals, signals2.StrongSignals) {
+		return baseSimilarity * semanticMismatchPenalty
+	}
+	if !hasCompatibleReturnCategories(signals1.ReturnCategories, signals2.ReturnCategories) {
+		return baseSimilarity * semanticMismatchPenalty
+	}
+	return baseSimilarity
+}
+
+func hasSharedSemanticSignal(signals1, signals2 map[string]struct{}) bool {
+	if len(signals1) == 0 || len(signals2) == 0 {
+		return true
+	}
+	for signal := range signals1 {
+		if _, ok := signals2[signal]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+// hasDisjointStringLiterals reports whether both fragments contain enough
+// distinct string literals to compare (minStringLiteralEvidence each) while
+// sharing none of them. Partial overlap or insufficient evidence on either
+// side is given the benefit of the doubt.
+func hasDisjointStringLiterals(literals1, literals2 map[string]struct{}) bool {
+	if len(literals1) < minStringLiteralEvidence || len(literals2) < minStringLiteralEvidence {
+		return false
+	}
+	for literal := range literals1 {
+		if _, ok := literals2[literal]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+func hasCompatibleReturnCategories(categories1, categories2 map[string]struct{}) bool {
+	if len(categories1) == 0 || len(categories2) == 0 {
+		return true
+	}
+	for category := range categories1 {
+		if _, ok := categories2[category]; ok {
+			return true
+		}
+	}
+	return false
 }

--- a/core/semantic/semantic_test.go
+++ b/core/semantic/semantic_test.go
@@ -269,3 +269,99 @@ func TestCompareEdgeDistributions_Orthogonal(t *testing.T) {
 		t.Errorf("orthogonal distributions should have sim 0.0, got %f", sim)
 	}
 }
+
+// --- Semantic evidence ---
+
+func sigs(strong, returns, literals []string) SemanticSignals {
+	s := NewSemanticSignals()
+	for _, v := range strong {
+		s.StrongSignals[v] = struct{}{}
+	}
+	for _, v := range returns {
+		s.ReturnCategories[v] = struct{}{}
+	}
+	for _, v := range literals {
+		s.StringLiterals[v] = struct{}{}
+	}
+	return s
+}
+
+func TestApplySemanticEvidence(t *testing.T) {
+	tests := []struct {
+		name string
+		s1   SemanticSignals
+		s2   SemanticSignals
+		base float64
+		want float64
+	}{
+		{
+			"shared strong signal keeps score",
+			sigs([]string{"call:open"}, []string{"none"}, nil),
+			sigs([]string{"call:open"}, []string{"none"}, nil),
+			1.0, 1.0,
+		},
+		{
+			"no shared strong signal is discounted",
+			sigs([]string{"call:open"}, nil, nil),
+			sigs([]string{"call:close"}, nil, nil),
+			1.0, semanticMismatchPenalty,
+		},
+		{
+			"missing signals on one side get benefit of the doubt",
+			sigs(nil, nil, nil),
+			sigs([]string{"call:open"}, nil, nil),
+			0.9, 0.9,
+		},
+		{
+			"incompatible return categories are discounted",
+			sigs([]string{"call:open"}, []string{"none"}, nil),
+			sigs([]string{"call:open"}, []string{"collection"}, nil),
+			1.0, semanticMismatchPenalty,
+		},
+		{
+			"disjoint literal vocabularies are strongly discounted",
+			sigs([]string{"call:open"}, nil, []string{"alpha", "beta"}),
+			sigs([]string{"call:open"}, nil, []string{"gamma", "delta"}),
+			1.0, literalMismatchPenalty,
+		},
+		{
+			"insufficient literal evidence is not counted against",
+			sigs([]string{"call:open"}, nil, []string{"alpha"}),
+			sigs([]string{"call:open"}, nil, []string{"gamma", "delta"}),
+			1.0, 1.0,
+		},
+		{
+			"partial literal overlap keeps score",
+			sigs([]string{"call:open"}, nil, []string{"alpha", "beta"}),
+			sigs([]string{"call:open"}, nil, []string{"alpha", "delta"}),
+			1.0, 1.0,
+		},
+		{
+			"zero base stays zero",
+			sigs(nil, nil, nil),
+			sigs(nil, nil, nil),
+			0.0, 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := ApplySemanticEvidence(tt.base, tt.s1, tt.s2)
+			if got != tt.want {
+				t.Errorf("ApplySemanticEvidence = %f, want %f", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestApplySemanticEvidenceLiteralCheckPrecedesSignals(t *testing.T) {
+	// Disjoint literals apply the stronger penalty even when strong signals
+	// also mismatch (checks are ordered: literals first).
+	s1 := sigs([]string{"call:open"}, nil, []string{"a", "b"})
+	s2 := sigs([]string{"call:close"}, nil, []string{"c", "d"})
+
+	got := ApplySemanticEvidence(1.0, s1, s2)
+	if got != literalMismatchPenalty {
+		t.Errorf("expected literal penalty %f to win, got %f", literalMismatchPenalty, got)
+	}
+}


### PR DESCRIPTION
## Summary

Fifth and final refresh PR, covering the pyscn-side areas. Most of pyscn's churn in these files since February is Python-AST adapter code (property decorators, ctypes fields, match-pattern extraction) — this PR ports only the kernel-level changes:

- **lcom**: `MethodAccess.Calls` + intra-class call-edge unions in `ComputeLCOM4` (methods connected by `self.helper()` calls belong to one component); group ordering aligned with pyscn (sorted by first method name)
- **dfa**: `DefKindPattern` kind (with `IsDef` bound fix), `defReachesUseAtPosition` (same-position pattern defs reach their use), and an optional `ParamExtractor` extension seeding parameter defs from `CFG.FunctionNode`
- **semantic**: the Type-4 semantic-evidence framework — `SemanticSignals` + `ApplySemanticEvidence` with pyscn's calibrated penalties (disjoint string-literal vocabularies ×0.5; no shared strong signal or incompatible return categories ×0.75). Extraction of signals from ASTs stays language-side.

## Testing

New tests: call-edge cohesion, external-call exclusion, pattern-def reaching (incl. the assign-at-same-position negative case), ParamExtractor seeding and its absence, and a table covering every evidence branch. `go test -race ./...` green on all 13 packages.

## Phase 1 complete

With this PR all five refresh areas are at current jscan/pyscn parity. Next: tag `core/v0.2.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)