### PR TITLE
fix(core/clone): restore literal-like label filtering in feature extraction

### DIFF
--- a/core/clone/features.go
+++ b/core/clone/features.go
@@ -27,6 +27,15 @@ type ASTFeatureExtractor struct {
 	// Language-specific: set this to match your AST node types.
 	// If nil, no pattern features are extracted.
 	PatternNames []string
+
+	// literalLikeNames holds base label names whose nodes carry identifier or
+	// literal payloads (e.g. Python's Name/Constant, JavaScript's
+	// Identifier/Literal). When includeLiterals is false, label features for
+	// these nodes (subtree hashes, k-gram members, and type features) are not
+	// emitted, so renamed identifiers and changed literals do not perturb the
+	// feature set. Language-specific: set via WithLiteralNames. If empty, no
+	// labels are filtered.
+	literalLikeNames map[string]struct{}
 }
 
 // NewASTFeatureExtractor creates a feature extractor with sensible defaults.
@@ -58,6 +67,28 @@ func (a *ASTFeatureExtractor) WithPatterns(patterns []string) *ASTFeatureExtract
 	return a
 }
 
+// WithLiteralNames sets the base label names treated as identifier/literal
+// payload carriers, which are excluded from label features when
+// includeLiterals is false.
+func (a *ASTFeatureExtractor) WithLiteralNames(names []string) *ASTFeatureExtractor {
+	a.literalLikeNames = make(map[string]struct{}, len(names))
+	for _, name := range names {
+		a.literalLikeNames[name] = struct{}{}
+	}
+	return a
+}
+
+// shouldEmitLabelFeature reports whether label features for a node should be
+// emitted. Identifier/literal-like nodes are skipped when includeLiterals is
+// false so their payload churn does not perturb the feature set.
+func (a *ASTFeatureExtractor) shouldEmitLabelFeature(lbl string) bool {
+	if a.includeLiterals || len(a.literalLikeNames) == 0 {
+		return true
+	}
+	_, isLiteralLike := a.literalLikeNames[a.baseType(lbl)]
+	return !isLiteralLike
+}
+
 // ExtractFeatures builds a mixed set of features from the tree.
 func (a *ASTFeatureExtractor) ExtractFeatures(ast *apted.TreeNode) ([]string, error) {
 	if ast == nil {
@@ -85,6 +116,9 @@ func (a *ASTFeatureExtractor) ExtractFeatures(ast *apted.TreeNode) ([]string, er
 	typeCounts := make(map[string]int)
 	preorder := a.preorderLabels(ast)
 	for _, lbl := range preorder {
+		if !a.shouldEmitLabelFeature(lbl) {
+			continue
+		}
 		base := a.baseType(lbl)
 		if a.includeTypes && base != "" {
 			typeCounts[base]++
@@ -139,7 +173,7 @@ func (a *ASTFeatureExtractor) ExtractSubtreeHashes(ast *apted.TreeNode, maxHeigh
 			_, _ = h.Write(b[:])
 		}
 		hv := h.Sum64()
-		if height <= maxHeight {
+		if height <= maxHeight && a.shouldEmitLabelFeature(n.Label) {
 			feats = append(feats, fmt.Sprintf("sub:%d:%016x", height, hv))
 		}
 		return hv, height
@@ -153,7 +187,7 @@ func (a *ASTFeatureExtractor) ExtractNodeSequences(ast *apted.TreeNode, k int) (
 	if ast == nil || k <= 1 {
 		return []string{}, nil
 	}
-	labels := a.preorderLabels(ast)
+	labels := a.preorderFeatureLabels(ast)
 	if len(labels) < k {
 		return []string{}, nil
 	}
@@ -186,6 +220,27 @@ func (a *ASTFeatureExtractor) preorderLabels(ast *apted.TreeNode) []string {
 			return
 		}
 		labels = append(labels, a.canonicalLabel(n.Label))
+		for _, ch := range n.Children {
+			walk(ch)
+		}
+	}
+	walk(ast)
+	return labels
+}
+
+// preorderFeatureLabels returns pre-order canonical labels with
+// identifier/literal-like labels filtered out per shouldEmitLabelFeature.
+func (a *ASTFeatureExtractor) preorderFeatureLabels(ast *apted.TreeNode) []string {
+	labels := []string{}
+	var walk func(n *apted.TreeNode)
+	walk = func(n *apted.TreeNode) {
+		if n == nil {
+			return
+		}
+		label := a.canonicalLabel(n.Label)
+		if a.shouldEmitLabelFeature(label) {
+			labels = append(labels, label)
+		}
 		for _, ch := range n.Children {
 			walk(ch)
 		}

--- a/core/clone/features_test.go
+++ b/core/clone/features_test.go
@@ -358,3 +358,72 @@ func BenchmarkExtractFeatures(b *testing.B) {
 		ext.ExtractFeatures(root)
 	}
 }
+
+func TestWithLiteralNames_FiltersLabelFeatures(t *testing.T) {
+	// def f(x): return x  — shaped tree with identifier/literal payloads
+	build := func(argName, constant string) *apted.TreeNode {
+		root := apted.NewTreeNode(0, "FunctionDef(f)")
+		arg := apted.NewTreeNode(1, "Arg("+argName+")")
+		ret := apted.NewTreeNode(2, "Return")
+		ret.AddChild(apted.NewTreeNode(3, "Name("+argName+")"))
+		ret.AddChild(apted.NewTreeNode(4, "Constant("+constant+")"))
+		root.AddChild(arg)
+		root.AddChild(ret)
+		return root
+	}
+	literalNames := []string{"Name", "Constant", "Arg", "Keyword"}
+
+	t.Run("renamed identifiers produce identical features when filtered", func(t *testing.T) {
+		ext := NewASTFeatureExtractor().WithLiteralNames(literalNames)
+		f1, err := ext.ExtractFeatures(build("x", "1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		f2, err := ext.ExtractFeatures(build("y", "2"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if JaccardSimilarity(f1, f2) != 1.0 {
+			t.Errorf("filtered features should be identical for renamed identifiers, got %v vs %v", f1, f2)
+		}
+		for _, f := range f1 {
+			if f == "type:Name" || f == "type:Constant" || f == "type:Arg" {
+				t.Errorf("literal-like type feature %q should not be emitted", f)
+			}
+		}
+	})
+
+	t.Run("includeLiterals bypasses the filter", func(t *testing.T) {
+		ext := NewASTFeatureExtractor().WithOptions(3, 4, true, true).WithLiteralNames(literalNames)
+		f1, err := ext.ExtractFeatures(build("x", "1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		f2, err := ext.ExtractFeatures(build("y", "2"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if JaccardSimilarity(f1, f2) == 1.0 {
+			t.Errorf("with literals included, renamed identifiers should differ")
+		}
+	})
+
+	t.Run("no configured names filters nothing", func(t *testing.T) {
+		plain, err := NewASTFeatureExtractor().ExtractFeatures(build("x", "1"))
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(plain) == 0 {
+			t.Fatal("expected features")
+		}
+		found := false
+		for _, f := range plain {
+			if f == "type:Name" {
+				found = true
+			}
+		}
+		if !found {
+			t.Errorf("unfiltered extractor should emit type:Name, got %v", plain)
+		}
+	})
+}

--- a/core/clone/similarity.go
+++ b/core/clone/similarity.go
@@ -353,6 +353,13 @@ func NewSyntacticSimilarityAnalyzer() *SyntacticSimilarityAnalyzer {
 	return &SyntacticSimilarityAnalyzer{extractor: extractor}
 }
 
+// NewSyntacticSimilarityAnalyzerWithExtractor creates a syntactic similarity
+// analyzer that uses a caller-configured feature extractor (e.g. with
+// language-specific pattern and literal-like label names).
+func NewSyntacticSimilarityAnalyzerWithExtractor(extractor *ASTFeatureExtractor) *SyntacticSimilarityAnalyzer {
+	return &SyntacticSimilarityAnalyzer{extractor: extractor}
+}
+
 // ComputeSimilarity computes the syntactic similarity between two code fragments
 // using Jaccard coefficient of normalized AST hash sets. It ignores differences
 // in identifier names and literal values, focusing only on the structural

--- a/jscan/internal/analyzer/clone_detector.go
+++ b/jscan/internal/analyzer/clone_detector.go
@@ -194,7 +194,11 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 
 	analyzer := apted.NewAPTEDAnalyzerWithNormalization(costModel, apted.NormalizeByMax)
 	textualAnalyzer := coreclone.NewTextualSimilarityAnalyzer(removeJSComments)
-	syntacticAnalyzer := coreclone.NewSyntacticSimilarityAnalyzer()
+	syntacticAnalyzer := coreclone.NewSyntacticSimilarityAnalyzerWithExtractor(
+		coreclone.NewASTFeatureExtractor().
+			WithOptions(3, 4, true, false).
+			WithPatterns(jsClonePatternNames).
+			WithLiteralNames(jsLiteralLikeNames))
 	classifier := coreclone.NewPairClassifier(coreclone.ClassifierConfig{
 		Type1Threshold: config.Type1Threshold, Type2Threshold: config.Type2Threshold,
 		Type3Threshold: config.Type3Threshold, Type4Threshold: config.Type4Threshold,
@@ -207,11 +211,13 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 		analyzer:            analyzer,
 		converter:           NewTreeConverter(),
 		textualAnalyzer:     textualAnalyzer,
-		featureExtractor:    coreclone.NewASTFeatureExtractor(),
-		pairClassifier:      classifier,
-		fragments:           []*CodeFragment{},
-		clonePairs:          []*domain.ClonePair{},
-		cloneGroups:         []*domain.CloneGroup{},
+		featureExtractor: coreclone.NewASTFeatureExtractor().
+			WithPatterns(jsClonePatternNames).
+			WithLiteralNames(jsLiteralLikeNames),
+		pairClassifier: classifier,
+		fragments:      []*CodeFragment{},
+		clonePairs:     []*domain.ClonePair{},
+		cloneGroups:    []*domain.CloneGroup{},
 	}
 }
 

--- a/jscan/internal/analyzer/clone_features.go
+++ b/jscan/internal/analyzer/clone_features.go
@@ -1,0 +1,36 @@
+package analyzer
+
+// jsClonePatternNames are the JS/TS AST constructs surfaced as structural
+// pattern features for clone feature extraction (core's extractor is
+// language-neutral and emits pattern features only for configured names).
+var jsClonePatternNames = []string{
+	// Control flow
+	"IfStatement", "SwitchStatement", "ForStatement", "ForInStatement",
+	"ForOfStatement", "WhileStatement", "DoWhileStatement", "TryStatement",
+	"WithStatement",
+	// Functions
+	"FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression",
+	"MethodDefinition", "AsyncFunctionDeclaration", "GeneratorFunctionDeclaration",
+	// Classes
+	"ClassDeclaration", "ClassExpression",
+	// Statements
+	"ReturnStatement", "ThrowStatement", "BreakStatement", "ContinueStatement",
+	"VariableDeclaration", "AssignmentExpression",
+	// Expressions
+	"CallExpression", "MemberExpression", "BinaryExpression", "LogicalExpression",
+	"ConditionalExpression", "NewExpression", "AwaitExpression", "YieldExpression",
+	// Modules
+	"ImportDeclaration", "ExportNamedDeclaration", "ExportDefaultDeclaration",
+	// TypeScript
+	"InterfaceDeclaration", "TypeAliasDeclaration", "EnumDeclaration",
+	// JSX
+	"JSXElement", "JSXFragment",
+}
+
+// jsLiteralLikeNames are the JS/TS node labels that carry identifier or
+// literal payloads; their label features are suppressed when literals are
+// excluded so renames and literal changes do not perturb the feature set.
+var jsLiteralLikeNames = []string{
+	"Identifier", "Literal", "StringLiteral", "NumberLiteral",
+	"BooleanLiteral", "NullLiteral", "RegExpLiteral",
+}


### PR DESCRIPTION
## Summary

While adopting \`core/clone\` in pyscn (#12), a fidelity gap surfaced: the pre-monorepo pyscn and jscan feature extractors skipped label features (subtree hashes, k-gram members, type features) for identifier/literal payload nodes (\`Name\`/\`Constant\`/… in pyscn, \`Identifier\`/\`Literal\`/… in jscan) when \`includeLiterals\` was false. \`core/clone\`'s extractor was created without that filter, and jscan silently lost it — along with its structural pattern features — when it adopted \`core/clone\` in #9.

## Changes

- \`core/clone\`: add \`WithLiteralNames\` (configurable like \`PatternNames\`) and apply the filter at all three label-feature emission sites (subtree hashes, k-grams via \`preorderFeatureLabels\`, type/typedist features)
- \`core/clone\`: add \`NewSyntacticSimilarityAnalyzerWithExtractor\` so language analyzers can inject a fully configured extractor into the Type-2 gate
- \`jscan\`: restore JS/TS pattern names and literal-like names on both the detector's feature extractor and the syntactic analyzer
- tests: renamed identifiers/literals yield identical filtered feature sets; \`includeLiterals\` bypasses the filter; empty config filters nothing

After merge this should be tagged \`core/v0.2.1\` so pyscn can depend on it.

Refs #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)