### PR TITLE
fix(core): cap-consistent Optimized APTED results and scoring input guards

### DIFF
--- a/core/apted/apted.go
+++ b/core/apted/apted.go
@@ -112,8 +112,11 @@ func (a *APTEDAnalyzer) computeDistanceOptimized(tree1, tree2 *TreeNode) float64
 		return profileDistance
 	}
 
-	// Use the capped optimized algorithm. The profile distance below is a
-	// lower bound that keeps capped key roots from undercounting.
+	// Use the capped optimized algorithm, floored by the profile distance so
+	// capped key roots do not undercount. The label-profile floor is a true
+	// lower bound, but the shape-profile floor (used when labels fully cancel)
+	// is a heuristic: it can overestimate exact APTED when a structural
+	// reshuffle changes many node depths with few edits.
 	keyRoots1 := PrepareTreeForAPTED(tree1)
 	keyRoots2 := PrepareTreeForAPTED(tree2)
 
@@ -1026,7 +1029,7 @@ func NewOptimizedAPTEDAnalyzer(costModel CostModel, maxDistance float64) *Optimi
 
 // ComputeDistance computes tree edit distance with early stopping optimization.
 func (a *OptimizedAPTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64 {
-	if a.enableEarlyStop {
+	if a.enableEarlyStop && tree1 != nil && tree2 != nil {
 		sizeDiff := math.Abs(float64(tree1.Size() - tree2.Size()))
 		if sizeDiff > a.maxDistance {
 			return a.maxDistance + 1.0
@@ -1037,6 +1040,37 @@ func (a *OptimizedAPTEDAnalyzer) ComputeDistance(tree1, tree2 *TreeNode) float64
 		return a.maxDistance + 1.0
 	}
 	return distance
+}
+
+// ComputeDistanceAndSimilarity computes both distance and similarity with the
+// analyzer's early-stopping cap applied. Without this override, the method
+// promoted from the embedded APTEDAnalyzer would bypass the cap and return
+// the full uncapped distance.
+func (a *OptimizedAPTEDAnalyzer) ComputeDistanceAndSimilarity(tree1, tree2 *TreeNode) (float64, float64) {
+	distance := a.ComputeDistance(tree1, tree2)
+	return distance, a.normalizeSimilarity(distance, tree1, tree2)
+}
+
+// ComputeDetailedDistance computes detailed tree edit distance information
+// with the analyzer's early-stopping cap applied (see ComputeDistanceAndSimilarity).
+func (a *OptimizedAPTEDAnalyzer) ComputeDetailedDistance(tree1, tree2 *TreeNode) *TreeEditResult {
+	distance, similarity := a.ComputeDistanceAndSimilarity(tree1, tree2)
+
+	var size1, size2 int
+	if tree1 != nil {
+		size1 = tree1.Size()
+	}
+	if tree2 != nil {
+		size2 = tree2.Size()
+	}
+
+	return &TreeEditResult{
+		Distance:   distance,
+		Similarity: similarity,
+		Tree1Size:  size1,
+		Tree2Size:  size2,
+		Operations: int(distance),
+	}
 }
 
 // BatchComputeDistances computes distances between multiple tree pairs.

--- a/core/apted/apted_test.go
+++ b/core/apted/apted_test.go
@@ -719,3 +719,42 @@ func TestComputeApproximateDistanceNilTrees(t *testing.T) {
 		t.Errorf("Approximate distance to nil should equal tree size, got %f", distance)
 	}
 }
+
+func TestOptimizedAnalyzerDistanceAndSimilarityRespectsCap(t *testing.T) {
+	a := NewOptimizedAPTEDAnalyzer(NewDefaultCostModel(), 2.0)
+
+	// Same size (no size-diff early exit), but 6 renames needed: uncapped
+	// distance is 6, so the cap must kick in.
+	left := NewTreeNode(0, "Root")
+	right := NewTreeNode(100, "Root")
+	for i := 1; i <= 6; i++ {
+		left.AddChild(NewTreeNode(i, "L"))
+		right.AddChild(NewTreeNode(100+i, "R"))
+	}
+
+	capped := a.ComputeDistance(left, right)
+	if capped != 3.0 {
+		t.Fatalf("ComputeDistance = %f, want capped 3.0", capped)
+	}
+
+	distance, similarity := a.ComputeDistanceAndSimilarity(left, right)
+	if distance != capped {
+		t.Errorf("ComputeDistanceAndSimilarity distance = %f, want %f (must match capped ComputeDistance)", distance, capped)
+	}
+	if want := a.normalizeSimilarity(capped, left, right); similarity != want {
+		t.Errorf("similarity = %f, want %f (derived from capped distance)", similarity, want)
+	}
+
+	detailed := a.ComputeDetailedDistance(left, right)
+	if detailed.Distance != capped {
+		t.Errorf("ComputeDetailedDistance distance = %f, want %f", detailed.Distance, capped)
+	}
+
+	// Nil trees must not panic even with early stopping enabled.
+	if d := a.ComputeDistance(nil, left); d != a.maxDistance+1.0 && d != float64(left.Size()) {
+		t.Logf("nil-tree distance = %f", d)
+	}
+	if d, _ := a.ComputeDistanceAndSimilarity(nil, nil); d != 0 {
+		t.Errorf("nil trees distance = %f, want 0", d)
+	}
+}

--- a/core/domain/scoring.go
+++ b/core/domain/scoring.go
@@ -66,8 +66,9 @@ const (
 
 // LinearPenalty maps a value onto a 0..MaxScoreBase penalty that starts at 0
 // when value <= start and grows linearly to the maximum at saturation.
+// A NaN value is treated as missing data and yields no penalty.
 func LinearPenalty(value, start, saturation float64) int {
-	if value <= start {
+	if math.IsNaN(value) || value <= start {
 		return 0
 	}
 	if saturation <= start {
@@ -84,8 +85,9 @@ func LinearPenalty(value, start, saturation float64) int {
 
 // DuplicationPenalty calculates the penalty for code duplication (max 20).
 // Linear: 0% duplication = 0 penalty, DuplicationThresholdHigh (30%) = max.
+// A NaN percentage is treated as missing data and yields no penalty.
 func DuplicationPenalty(duplicationPercent float64) int {
-	if duplicationPercent <= DuplicationThresholdLow {
+	if math.IsNaN(duplicationPercent) || duplicationPercent <= DuplicationThresholdLow {
 		return 0
 	}
 
@@ -102,12 +104,15 @@ func DuplicationPenalty(duplicationPercent float64) int {
 // weighted ratio of problematic classes (High = 1.0, Medium = CouplingMediumWeight),
 // saturating at CouplingSaturationRatio.
 func CouplingPenalty(highCouplingClasses, mediumCouplingClasses, totalClasses int) int {
-	if totalClasses == 0 {
+	if totalClasses <= 0 {
 		return 0
 	}
 
 	weightedProblematicClasses := float64(highCouplingClasses) + (CouplingMediumWeight * float64(mediumCouplingClasses))
 	ratio := weightedProblematicClasses / float64(totalClasses)
+	if ratio < 0 {
+		ratio = 0
+	}
 
 	penalty := ratio / CouplingSaturationRatio * 20.0
 	if penalty > 20.0 {
@@ -165,8 +170,12 @@ func DependencyPenalty(totalModules, modulesInCycles, maxDepth int, mainSequence
 }
 
 // ArchitecturePenalty calculates the penalty for architecture compliance
-// (max 12). Compliance is a 0..1 ratio.
+// (max 12). Compliance is a 0..1 ratio. A NaN compliance is treated as
+// missing data and yields no penalty.
 func ArchitecturePenalty(compliance float64) int {
+	if math.IsNaN(compliance) {
+		return 0
+	}
 	if compliance < 0 {
 		compliance = 0
 	}
@@ -208,7 +217,8 @@ func PenaltyToScore(penalty int, maxPenalty int) int {
 }
 
 // HealthScoreFromPenalties returns 100 minus the sum of all penalties,
-// floored at MinimumScore.
+// floored at MinimumScore and capped at 100 (negative penalties cannot
+// raise the score above a clean result).
 func HealthScoreFromPenalties(penalties ...int) int {
 	score := 100
 	for _, p := range penalties {
@@ -216,6 +226,9 @@ func HealthScoreFromPenalties(penalties ...int) int {
 	}
 	if score < MinimumScore {
 		score = MinimumScore
+	}
+	if score > 100 {
+		score = 100
 	}
 	return score
 }

--- a/core/domain/scoring_test.go
+++ b/core/domain/scoring_test.go
@@ -1,6 +1,9 @@
 package domain
 
-import "testing"
+import (
+	"math"
+	"testing"
+)
 
 func TestLinearPenalty(t *testing.T) {
 	if p := LinearPenalty(1.0, 2.0, 15.0); p != 0 {
@@ -163,5 +166,31 @@ func TestIsHealthyScore(t *testing.T) {
 	}
 	if IsHealthyScore(69) {
 		t.Error("69 should not be healthy")
+	}
+}
+
+func TestPenaltiesGuardInvalidInputs(t *testing.T) {
+	nan := math.NaN()
+
+	if p := LinearPenalty(nan, 2.0, 15.0); p != 0 {
+		t.Errorf("LinearPenalty(NaN) = %d, want 0", p)
+	}
+	if p := DuplicationPenalty(nan); p != 0 {
+		t.Errorf("DuplicationPenalty(NaN) = %d, want 0", p)
+	}
+	if p := ArchitecturePenalty(nan); p != 0 {
+		t.Errorf("ArchitecturePenalty(NaN) = %d, want 0", p)
+	}
+	if p := DependencyPenalty(10, 0, 0, nan); p != 0 {
+		t.Errorf("DependencyPenalty(NaN MSD) = %d, want 0", p)
+	}
+	if p := CouplingPenalty(1, 0, -10); p != 0 {
+		t.Errorf("CouplingPenalty(negative total) = %d, want 0", p)
+	}
+	if p := CouplingPenalty(-3, 0, 10); p != 0 {
+		t.Errorf("CouplingPenalty(negative count) = %d, want 0", p)
+	}
+	if s := HealthScoreFromPenalties(-5); s != 100 {
+		t.Errorf("HealthScoreFromPenalties(-5) = %d, want capped 100", s)
 	}
 }


### PR DESCRIPTION
## Summary

Parity-neutral hardening from the review of #4 and #6. No output changes for valid inputs; behavior of the pyscn/jscan-ported algorithm paths is untouched.

- **`OptimizedAPTEDAnalyzer`**: `ComputeDistanceAndSimilarity` and `ComputeDetailedDistance` were promoted from the embedded `APTEDAnalyzer` and bypassed the early-stopping cap — a caller could get the full uncapped distance while `ComputeDistance` returned `maxDistance+1`. Both are now overridden to apply the cap, and the size-diff early exit no longer dereferences nil trees.
- **`apted`**: the `computeDistanceOptimized` comment claimed the profile distance is a lower bound; the shape-profile floor (used when labels fully cancel) is a heuristic that can overestimate, so the comment now says so.
- **`scoring`**: `LinearPenalty` / `DuplicationPenalty` / `ArchitecturePenalty` treat NaN metrics as missing data (0 penalty) instead of feeding NaN into `int(math.Round(...))`, matching `DependencyPenalty`'s existing NaN behavior; `CouplingPenalty` clamps negative counts; `HealthScoreFromPenalties` is capped at 100 so a negative penalty cannot raise the score.

Deliberately **not** touched (parity-bound, tracked separately): large-tree approximation overestimation, Type-1 whitespace normalization edge cases, Type-2 operator canonicalization, dead-code merge interleaving.

## Testing

- New tests: capped `ComputeDistanceAndSimilarity`/`ComputeDetailedDistance` through the Optimized analyzer; NaN/negative-input guards for all scoring functions
- `go test ./...` and `go vet` pass in `core/`; full jscan suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)