### PR TITLE
docs: rework root README as pyscn-style landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # polyscan
 
-**Code quality analyzers for vibe coders — in every language.**
+**Code quality analyzers for AI Agent**
 
 Building with Cursor, Claude, or ChatGPT? polyscan performs structural analysis to keep your codebase maintainable: one command scores your whole codebase and shows what to fix first.
 
@@ -13,15 +13,25 @@ Building with Cursor, Claude, or ChatGPT? polyscan performs structural analysis 
 
 </div>
 
-## Pick Your Language
+## Quick Start
+No installation needed — the quick-start commands below run the full analysis directly.
 
-| Language | Analyzer | Quick start |
-|----------|----------|-------------|
-| JavaScript / TypeScript | [**jscan**](jscan/) | `npx jscan analyze src/` |
-| Python | [**pyscn**](https://github.com/ludo-technologies/pyscn) | `uvx pyscn@latest analyze .` |
-| Go | **goscan** | planned |
+### JavaScript / TypeScript
+```
+npx jscan analyze src/
+```
 
-No installation needed — the quick-start commands above run the full analysis directly.
+See: [**jscan**](jscan/)
+
+### Python
+```
+uvx pyscn@latest analyze .
+```
+
+See: [**pyscn**](https://github.com/ludo-technologies/pyscn)
+
+### Others
+We are also planning to support other languages (C++, Go, Rust and etc...)
 
 ## What You Get
 
@@ -44,10 +54,10 @@ The analyzers ship Agent Skills that teach AI coding agents when and how to run 
 npx skills add ludo-technologies/polyscan
 
 # pyscn Skills
-npx skills add ludo-technologies/pyscn
+uvx add-skills ludo-technologies/pyscn
 ```
 
-They work with Claude Code, Cursor, Codex, Gemini CLI, and [70+ other agents](https://github.com/vercel-labs/skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
+They work with Claude Code, Cursor, Codex, Gemini CLI, and other agents.
 
 Then just ask your agent:
 

--- a/README.md
+++ b/README.md
@@ -1,26 +1,97 @@
+<div align="center">
+
 # polyscan
 
-Multi-language code quality analysis, built as a monorepo around a shared algorithmic core.
+**Code quality analyzers for vibe coders, in every language.**
 
-## Layout
+Building with Cursor, Claude, or ChatGPT? The polyscan family performs structural analysis to keep your codebase maintainable — one shared algorithmic core, one analyzer per language.
+
+[![CI](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml/badge.svg)](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/jscan?style=flat-square&logo=npm&label=jscan)](https://www.npmjs.com/package/jscan)
+[![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi&label=pyscn)](https://pypi.org/project/pyscn/)
+[![Go](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat-square&logo=go)](https://go.dev/)
+[![License](https://img.shields.io/github/license/ludo-technologies/polyscan?style=flat-square)](LICENSE)
+
+</div>
+
+## Analyzers
+
+| Language | Analyzer | Install | Where |
+|----------|----------|---------|-------|
+| JavaScript / TypeScript | [**jscan**](jscan/) | `npx jscan analyze src/` | this monorepo — [`jscan/`](jscan/) |
+| Python | [**pyscn**](https://github.com/ludo-technologies/pyscn) | `uvx pyscn@latest analyze .` | independent repository |
+| Go | **goscan** | — | planned |
+
+Every analyzer works the same way: one command scores your whole codebase (0-100 with an A-F grade) and generates an HTML report that shows what to fix first.
+
+- 🧹 **Dead code** - unreachable code you can safely delete
+- 📋 **Duplicate code** - copy-pasted and structurally similar code worth merging (Type 1-4 clone detection)
+- 🌀 **Complexity** - functions that are hard to read and test
+- 🏗️ **Dependencies** - circular imports and unstable module dependencies
+- 🧩 **Class design** - classes that do too much or depend on too much (CBO coupling, LCOM cohesion)
+
+**Built with Go + tree-sitter**
+
+## Shared Core
+
+All analyzers are built on [`core/`](core/), a standalone, language-agnostic Go module: APTED tree edit distance, LSH/MinHash clone indexing, CFG analysis, dead code detection, and coupling/cohesion metrics. Language-specific behavior is injected via interfaces, so a new analyzer only implements parsing and classification.
+
+```bash
+go get github.com/ludo-technologies/polyscan/core
+```
+
+See [`core/README.md`](core/README.md) for the package catalog and extension points.
+
+## AI Agent Integration
+
+The analyzers ship Agent Skills that teach AI coding agents when and how to run each analysis: health checks, refactoring, architecture review, and CI-friendly reports.
+
+```bash
+# jscan Skills (from this monorepo)
+uvx add-skills ludo-technologies/polyscan
+
+# pyscn Skills
+uvx add-skills ludo-technologies/pyscn
+```
+
+They work with Claude Code, Cursor, Codex, Gemini CLI, and [many other agents](https://github.com/ludo-technologies/add-skills).
+
+**Claude Code plugin marketplace:**
+
+```bash
+claude plugin marketplace add ludo-technologies/polyscan
+claude plugin install jscan@polyscan-marketplace
+```
+
+## Repository Layout
 
 | Directory | Description |
 |-----------|-------------|
-| [`core/`](core/) | Language-agnostic analysis algorithms (APTED tree edit distance, LSH/MinHash, CFG analysis, clone detection, coupling/cohesion metrics) as a standalone Go module |
+| [`core/`](core/) | Language-agnostic analysis algorithms as a standalone Go module |
 | [`jscan/`](jscan/) | JavaScript/TypeScript code quality analyzer and standalone Go module |
 
 jscan moved here from its former standalone repository, [ludo-technologies/jscan](https://github.com/ludo-technologies/jscan); releases up to v0.9.0 live there, and newer releases ship from this monorepo under the same npm package name [`jscan`](https://www.npmjs.com/package/jscan).
 
-Language analyzers planned to move into or start life in this monorepo:
+### Versioning
 
-- **goscan** (Go) — planned
+Each module is tagged with a directory prefix, e.g. `core/v0.2.1`, `jscan/v0.9.1`.
 
-[pyscn](https://github.com/ludo-technologies/pyscn) (Python) remains an independent repository and consumes `core/` as a Go module dependency.
+---
 
-## Versioning
+## Documentation
 
-Each module is tagged with a directory prefix, e.g. `core/v0.2.0`.
+📖 **[pyscn documentation site](https://ludo-technologies.github.io/pyscn/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)**
+
+For contributors: **[Contributing](CONTRIBUTING.md)** • **[Code of Conduct](CODE_OF_CONDUCT.md)** • **[Security](SECURITY.md)**
+
+## Enterprise Support
+
+For commercial support, custom integrations, or consulting services, contact us at contact@ludo-tech.org
 
 ## License
 
-MIT
+MIT License — see [LICENSE](LICENSE)
+
+---
+
+*Built with ❤️ using Go and tree-sitter*

--- a/README.md
+++ b/README.md
@@ -48,13 +48,13 @@ The analyzers ship Agent Skills that teach AI coding agents when and how to run 
 
 ```bash
 # jscan Skills (from this monorepo)
-uvx add-skills ludo-technologies/polyscan
+npx skills add ludo-technologies/polyscan
 
 # pyscn Skills
-uvx add-skills ludo-technologies/pyscn
+npx skills add ludo-technologies/pyscn
 ```
 
-They work with Claude Code, Cursor, Codex, Gemini CLI, and [many other agents](https://github.com/ludo-technologies/add-skills).
+They work with Claude Code, Cursor, Codex, Gemini CLI, and [70+ other agents](https://github.com/vercel-labs/skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
 
 **Claude Code plugin marketplace:**
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,30 @@
 
 # polyscan
 
-**Code quality analyzers for vibe coders, in every language.**
+**Code quality analyzers for vibe coders — in every language.**
 
-Building with Cursor, Claude, or ChatGPT? The polyscan family performs structural analysis to keep your codebase maintainable — one shared algorithmic core, one analyzer per language.
+Building with Cursor, Claude, or ChatGPT? polyscan performs structural analysis to keep your codebase maintainable: one command scores your whole codebase and shows what to fix first.
 
 [![CI](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml/badge.svg)](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/jscan?style=flat-square&logo=npm&label=jscan)](https://www.npmjs.com/package/jscan)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi&label=pyscn)](https://pypi.org/project/pyscn/)
-[![Go](https://img.shields.io/badge/Go-1.24+-00ADD8?style=flat-square&logo=go)](https://go.dev/)
 [![License](https://img.shields.io/github/license/ludo-technologies/polyscan?style=flat-square)](LICENSE)
 
 </div>
 
-## Analyzers
+## Pick Your Language
 
-| Language | Analyzer | Install | Where |
-|----------|----------|---------|-------|
-| JavaScript / TypeScript | [**jscan**](jscan/) | `npx jscan analyze src/` | this monorepo — [`jscan/`](jscan/) |
-| Python | [**pyscn**](https://github.com/ludo-technologies/pyscn) | `uvx pyscn@latest analyze .` | independent repository |
-| Go | **goscan** | — | planned |
+| Language | Analyzer | Quick start |
+|----------|----------|-------------|
+| JavaScript / TypeScript | [**jscan**](jscan/) | `npx jscan analyze src/` |
+| Python | [**pyscn**](https://github.com/ludo-technologies/pyscn) | `uvx pyscn@latest analyze .` |
+| Go | **goscan** | planned |
 
-Every analyzer works the same way: one command scores your whole codebase (0-100 with an A-F grade) and generates an HTML report that shows what to fix first.
+No installation needed — the quick-start commands above run the full analysis directly.
+
+## What You Get
+
+Every analyzer scores your codebase (0-100 with an A-F grade) and generates an HTML report that shows what to fix first, looking at your code from five angles:
 
 - 🧹 **Dead code** - unreachable code you can safely delete
 - 📋 **Duplicate code** - copy-pasted and structurally similar code worth merging (Type 1-4 clone detection)
@@ -30,24 +33,14 @@ Every analyzer works the same way: one command scores your whole codebase (0-100
 - 🏗️ **Dependencies** - circular imports and unstable module dependencies
 - 🧩 **Class design** - classes that do too much or depend on too much (CBO coupling, LCOM cohesion)
 
-**Built with Go + tree-sitter**
-
-## Shared Core
-
-All analyzers are built on [`core/`](core/), a standalone, language-agnostic Go module: APTED tree edit distance, LSH/MinHash clone indexing, CFG analysis, dead code detection, and coupling/cohesion metrics. Language-specific behavior is injected via interfaces, so a new analyzer only implements parsing and classification.
-
-```bash
-go get github.com/ludo-technologies/polyscan/core
-```
-
-See [`core/README.md`](core/README.md) for the package catalog and extension points.
+**Built with Go + tree-sitter** — fast enough to run on every commit.
 
 ## AI Agent Integration
 
 The analyzers ship Agent Skills that teach AI coding agents when and how to run each analysis: health checks, refactoring, architecture review, and CI-friendly reports.
 
 ```bash
-# jscan Skills (from this monorepo)
+# jscan Skills
 npx skills add ludo-technologies/polyscan
 
 # pyscn Skills
@@ -56,6 +49,14 @@ npx skills add ludo-technologies/pyscn
 
 They work with Claude Code, Cursor, Codex, Gemini CLI, and [70+ other agents](https://github.com/vercel-labs/skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
 
+Then just ask your agent:
+
+1. "Analyze the code quality of the src/ directory"
+
+2. "Find duplicate code and help me refactor it"
+
+3. "Show me complex code and help me simplify it"
+
 **Claude Code plugin marketplace:**
 
 ```bash
@@ -63,20 +64,24 @@ claude plugin marketplace add ludo-technologies/polyscan
 claude plugin install jscan@polyscan-marketplace
 ```
 
-## Repository Layout
+---
+
+## How It's Built
+
+All analyzers share [`core/`](core/), a standalone, language-agnostic Go module: APTED tree edit distance, LSH/MinHash clone indexing, CFG analysis, dead code detection, and coupling/cohesion metrics. Language-specific behavior is injected via interfaces, so a new analyzer only implements parsing and classification.
+
+```bash
+go get github.com/ludo-technologies/polyscan/core
+```
 
 | Directory | Description |
 |-----------|-------------|
 | [`core/`](core/) | Language-agnostic analysis algorithms as a standalone Go module |
 | [`jscan/`](jscan/) | JavaScript/TypeScript code quality analyzer and standalone Go module |
 
-jscan moved here from its former standalone repository, [ludo-technologies/jscan](https://github.com/ludo-technologies/jscan); releases up to v0.9.0 live there, and newer releases ship from this monorepo under the same npm package name [`jscan`](https://www.npmjs.com/package/jscan).
-
-### Versioning
+jscan moved here from its former standalone repository, [ludo-technologies/jscan](https://github.com/ludo-technologies/jscan); releases up to v0.9.0 live there, and newer releases ship from this monorepo under the same npm package name [`jscan`](https://www.npmjs.com/package/jscan). [pyscn](https://github.com/ludo-technologies/pyscn) remains an independent repository and consumes `core/` as a Go module dependency.
 
 Each module is tagged with a directory prefix, e.g. `core/v0.2.1`, `jscan/v0.9.1`.
-
----
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # polyscan
 
-**Code quality analyzers for AI Agent**
+**Code quality analyzers for AI agents**
 
 Building with Cursor, Claude, or ChatGPT? polyscan performs structural analysis to keep your codebase maintainable: one command scores your whole codebase and shows what to fix first.
 
@@ -31,7 +31,7 @@ uvx pyscn@latest analyze .
 See: [**pyscn**](https://github.com/ludo-technologies/pyscn)
 
 ### Others
-We are also planning to support other languages (C++, Go, Rust and etc...)
+We are also planning to support other languages (C++, Go, Rust, and more).
 
 ## What You Get
 

--- a/jscan/README.md
+++ b/jscan/README.md
@@ -48,10 +48,10 @@ jscan ships Agent Skills that teach AI coding agents when and how to run each an
 ### Agent Skills (Recommended)
 
 ```bash
-uvx add-skills ludo-technologies/polyscan
+npx skills add ludo-technologies/polyscan
 ```
 
-This installs the Skills into your project. They work with Claude Code, Cursor, Codex, Gemini CLI, and [many other agents](https://github.com/ludo-technologies/add-skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
+This installs the Skills into your project. They work with Claude Code, Cursor, Codex, Gemini CLI, and [70+ other agents](https://github.com/vercel-labs/skills) (add `--agent cursor` etc. to target one, `--global` for all projects).
 
 Then just ask your agent:
 


### PR DESCRIPTION
## Summary
- Rework the root README from a bare monorepo layout page into a pyscn/jscan-style landing page
- Add centered header with tagline and badges (CI, jscan npm, pyscn PyPI, Go, License)
- Add analyzer family table (jscan / pyscn / goscan planned) with the shared five analysis angles
- Add Shared Core, AI Agent Integration, and footer sections
- Switch skill installation from `uvx add-skills` to the Vercel skills CLI (`npx skills add`) in both the root and jscan READMEs — verified it discovers all 4 jscan skills from this repo
- Keep the jscan migration note and per-module tag versioning (examples verified against actual git tags)

🤖 Generated with [Claude Code](https://claude.com/claude-code)