### PR TITLE
docs: point documentation link at docs.codescan.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Each module is tagged with a directory prefix, e.g. `core/v0.2.1`, `jscan/v0.9.1
 
 ## Documentation
 
-📖 **[pyscn documentation site](https://ludo-technologies.github.io/pyscn/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)**
+📖 **[pyscn documentation site](https://docs.codescan.dev/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)**
 
 For contributors: **[Contributing](CONTRIBUTING.md)** • **[Code of Conduct](CODE_OF_CONDUCT.md)** • **[Security](SECURITY.md)**
 


### PR DESCRIPTION
The pyscn MkDocs site is moving to `docs.codescan.dev`, a subdomain of the polyscan project site. This updates the documentation link in the root README to match.

Depends on [ludo-technologies/pyscn#685](https://github.com/ludo-technologies/pyscn/pull/685) — merge that first, or this link 404s until the docs deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)