### PR TITLE
fix(jscan): honor output.min_complexity in analyze

### DIFF
--- a/jscan/cmd/jscan/analyze.go
+++ b/jscan/cmd/jscan/analyze.go
@@ -297,6 +297,7 @@ func runComplexityAnalysisInternal(files []string, cfg *config.Config) (*domain.
 		Paths:           files,
 		LowThreshold:    cfg.Complexity.LowThreshold,
 		MediumThreshold: cfg.Complexity.MediumThreshold,
+		MinComplexity:   cfg.Output.MinComplexity,
 		SortBy:          domain.SortByComplexity,
 	}
 

--- a/jscan/cmd/jscan/analyze_config_test.go
+++ b/jscan/cmd/jscan/analyze_config_test.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/jscan/internal/config"
+)
+
+// complexityFixture defines three functions with complexity 1, 2 and 3 so that
+// min_complexity filtering can be observed without relying on report_unchanged.
+const complexityFixture = `
+function trivial(a) {
+  return a;
+}
+
+function branching(a) {
+  if (a) {
+    return 1;
+  }
+  return 0;
+}
+
+function nested(a, b) {
+  if (a) {
+    return 1;
+  }
+  if (b) {
+    return 2;
+  }
+  return 0;
+}
+`
+
+func writeComplexityFixture(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "fixture.js")
+	if err := os.WriteFile(path, []byte(complexityFixture), 0o644); err != nil {
+		t.Fatalf("failed to write fixture: %v", err)
+	}
+	return path
+}
+
+// TestRunComplexityAnalysisInternal_MinComplexityFromConfig ensures output.min_complexity
+// from the configuration file reaches the complexity request (regression for #22).
+func TestRunComplexityAnalysisInternal_MinComplexityFromConfig(t *testing.T) {
+	file := writeComplexityFixture(t)
+
+	cfg := config.DefaultConfig()
+	cfg.Complexity.ReportUnchanged = true
+
+	baseline, err := runComplexityAnalysisInternal([]string{file}, cfg)
+	if err != nil {
+		t.Fatalf("baseline analysis failed: %v", err)
+	}
+	if len(baseline.Functions) != 3 {
+		t.Fatalf("fixture should yield 3 functions, got %d", len(baseline.Functions))
+	}
+
+	cfg.Output.MinComplexity = 3
+	filtered, err := runComplexityAnalysisInternal([]string{file}, cfg)
+	if err != nil {
+		t.Fatalf("filtered analysis failed: %v", err)
+	}
+
+	for _, fn := range filtered.Functions {
+		if fn.Metrics.Complexity < cfg.Output.MinComplexity {
+			t.Errorf("function %s with complexity %d should have been filtered out",
+				fn.Name, fn.Metrics.Complexity)
+		}
+	}
+	if len(filtered.Functions) >= len(baseline.Functions) {
+		t.Errorf("min_complexity=3 should drop functions: got %d of %d",
+			len(filtered.Functions), len(baseline.Functions))
+	}
+	if filtered.Summary.TotalFunctions != len(filtered.Functions) {
+		t.Errorf("TotalFunctions should be the post-filter count, got %d for %d functions",
+			filtered.Summary.TotalFunctions, len(filtered.Functions))
+	}
+	if filtered.Summary.FunctionsParsed != len(baseline.Functions) {
+		t.Errorf("FunctionsParsed should stay at the pre-filter count %d, got %d",
+			len(baseline.Functions), filtered.Summary.FunctionsParsed)
+	}
+}

--- a/jscan/service/config_loader.go
+++ b/jscan/service/config_loader.go
@@ -111,8 +111,10 @@ func (c *ConfigurationLoaderImpl) MergeConfig(base *domain.ComplexityRequest, ov
 		merged.ShowDetails = override.ShowDetails
 	}
 
-	// Filtering and sorting - override if non-default
-	if override.MinComplexity != 1 {
+	// Filtering and sorting - override only when the caller asked for a stricter
+	// filter than the default; an unset (zero) override must not clobber the
+	// min_complexity that came from the configuration file.
+	if override.MinComplexity > config.DefaultMinComplexityFilter {
 		merged.MinComplexity = override.MinComplexity
 	}
 


### PR DESCRIPTION
Fixes #22

## Problem

`output.min_complexity` from a config file was silently ignored by `jscan analyze` — functions below the threshold were never filtered, whether the config was auto-discovered or passed with `-c`. No warning, no error. The setting could *appear* to work because the `jscan init` template also sets `complexity.report_unchanged: false`, which drops complexity-1 functions.

`cmd/jscan/analyze.go` built its `domain.ComplexityRequest` with only `LowThreshold` / `MediumThreshold` / `SortBy`, leaving `MinComplexity` at 0 (= no filtering in `ComplexityServiceImpl.filterFunctions`). The mapping existed in `service/config_loader.go`, but the analyze flow never goes through `ConfigurationLoaderImpl`.

## Changes

- **`cmd/jscan/analyze.go`** — map `cfg.Output.MinComplexity` into the request in `runComplexityAnalysisInternal`, the single entry point shared by the text, JSON and HTML paths, so all formats are fixed at once.
- **`service/config_loader.go`** — `MergeConfig` treated the magic sentinel `override.MinComplexity != 1` as "explicitly set", so a zero-valued (unset) override clobbered a config-file value with 0. It now overrides only for a value stricter than `DefaultMinComplexityFilter`.
- **`cmd/jscan/analyze_config_test.go`** — regression test over a 1/2/3-complexity fixture with `report_unchanged: true` to isolate from the unchanged filter. Asserts the filtered set, that `TotalFunctions` is the post-filter count, and that `FunctionsParsed` stays at the pre-filter count. Confirmed it fails on the pre-fix code (`3 of 3`, nothing filtered).

## Verification

E2E with a built binary and an auto-discovered `jscan.config.json` (`min_complexity: 3`, `report_unchanged: true`) over a 3-function file:

```console
$ jscan analyze --select complexity --text src
  Total functions: 1 reported / 3 parsed     # was: 3, unfiltered
```

`go build ./... && go vet ./... && go test ./...` all pass for the jscan module.

## Deliberately out of scope

- **`app/analyze_usecase.go`** (named in the issue) — `AnalyzeUseCase` / `DefaultAnalyzeConfig` have no production caller; references are test-only. Its `MinComplexity: 0` is never fed from a `config.Config`, so wiring it would mean inventing a caller.
- **`cmd/jscan/check.go`** — also omits `MinComplexity`, but `check` is a pass/fail gate rather than a report; applying a presentation filter there could hide violations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)