### PR TITLE
perf: make analysis finish on real codebases

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ Each module is tagged with a directory prefix, e.g. `core/v0.2.1`, `jscan/v0.9.1
 
 ## Documentation
 
-📖 **[pyscn documentation site](https://docs.codescan.dev/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)**
+📖 **[pyscn documentation site](https://docs.codescan.dev/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)** • **[Performance](docs/performance.md)**
 
 For contributors: **[Contributing](CONTRIBUTING.md)** • **[Code of Conduct](CODE_OF_CONDUCT.md)** • **[Security](SECURITY.md)**
 

--- a/core/apted/apted.go
+++ b/core/apted/apted.go
@@ -25,6 +25,8 @@ type APTEDAnalyzer struct {
 
 	td        []float64
 	fd        []float64
+	delBuf    []float64
+	insBuf    []float64
 	nodesBuf1 []*TreeNode
 	nodesBuf2 []*TreeNode
 }
@@ -61,6 +63,35 @@ func scratchFloats(buf *[]float64, n int) []float64 {
 	}
 	*buf = (*buf)[:n]
 	return *buf
+}
+
+// minCost returns the smaller of two edit costs. Edit costs are finite and
+// non-negative, so a plain comparison agrees with math.Min without its NaN and
+// signed-zero handling — which the innermost DP loops cannot afford.
+func minCost(a, b float64) float64 {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// nodeEditCosts precomputes the per-node delete and insert costs for the two
+// node sequences. A node's cost depends only on the node itself, so computing
+// them once per comparison keeps the O(n*m) inner loops free of cost-model
+// calls — which dominate the profile when a language cost model classifies
+// nodes by inspecting their labels.
+func (a *APTEDAnalyzer) nodeEditCosts(nodes1, nodes2 []*TreeNode) (deleteCosts, insertCosts []float64) {
+	deleteCosts = scratchFloats(&a.delBuf, len(nodes1))
+	for i, node := range nodes1 {
+		deleteCosts[i] = a.costModel.Delete(node)
+	}
+
+	insertCosts = scratchFloats(&a.insBuf, len(nodes2))
+	for j, node := range nodes2 {
+		insertCosts[j] = a.costModel.Insert(node)
+	}
+
+	return deleteCosts, insertCosts
 }
 
 // ComputeDistance computes the tree edit distance between two trees.
@@ -763,14 +794,13 @@ func (a *APTEDAnalyzer) aptedOptimized(tree1, tree2 *TreeNode, keyRoots1, keyRoo
 	stride := size2 + 1
 
 	td := scratchFloats(&a.td, (size1+1)*stride)
-	for i := range td {
-		td[i] = 0
-	}
+	clear(td)
 	fd := scratchFloats(&a.fd, (size1+1)*stride)
+	deleteCosts, insertCosts := a.nodeEditCosts(nodes1, nodes2)
 
 	for _, i := range keyRoots1 {
 		for _, j := range keyRoots2 {
-			a.computeForestDistanceOptimized(nodes1, nodes2, i, j, td, fd, stride, maxDistance)
+			a.computeForestDistanceOptimized(nodes1, nodes2, i, j, td, fd, deleteCosts, insertCosts, stride, maxDistance)
 			if td[size1*stride+size2] > maxDistance {
 				return td[size1*stride+size2]
 			}
@@ -787,14 +817,13 @@ func (a *APTEDAnalyzer) apted(tree1, tree2 *TreeNode, keyRoots1, keyRoots2 []int
 	stride := size2 + 1
 
 	td := scratchFloats(&a.td, (size1+1)*stride)
-	for i := range td {
-		td[i] = 0
-	}
+	clear(td)
 	fd := scratchFloats(&a.fd, (size1+1)*stride)
+	deleteCosts, insertCosts := a.nodeEditCosts(nodes1, nodes2)
 
 	for _, i := range keyRoots1 {
 		for _, j := range keyRoots2 {
-			a.computeForestDistance(nodes1, nodes2, i, j, td, fd, stride)
+			a.computeForestDistance(nodes1, nodes2, i, j, td, fd, deleteCosts, insertCosts, stride)
 		}
 	}
 	return td[size1*stride+size2]
@@ -809,7 +838,7 @@ func zeroForestRegion(fd []float64, stride, lmlI, i, lmlJ, j int) {
 func (a *APTEDAnalyzer) computeForestDistanceOptimized(
 	nodes1, nodes2 []*TreeNode,
 	i, j int,
-	td, fd []float64,
+	td, fd, deleteCosts, insertCosts []float64,
 	stride int,
 	maxDistance float64,
 ) {
@@ -822,31 +851,34 @@ func (a *APTEDAnalyzer) computeForestDistanceOptimized(
 	zeroForestRegion(fd, stride, lmlI, i, lmlJ, j)
 
 	for x := lmlI; x <= i; x++ {
-		fd[(x+1)*stride+lmlJ] = fd[x*stride+lmlJ] + a.costModel.Delete(nodes1[x])
+		fd[(x+1)*stride+lmlJ] = fd[x*stride+lmlJ] + deleteCosts[x]
 		if fd[(x+1)*stride+lmlJ] > maxDistance {
 			return
 		}
 	}
 	for y := lmlJ; y <= j; y++ {
-		fd[lmlI*stride+y+1] = fd[lmlI*stride+y] + a.costModel.Insert(nodes2[y])
+		fd[lmlI*stride+y+1] = fd[lmlI*stride+y] + insertCosts[y]
 		if fd[lmlI*stride+y+1] > maxDistance {
 			return
 		}
 	}
 
 	for x := lmlI; x <= i; x++ {
+		node1 := nodes1[x]
+		deleteCost := deleteCosts[x]
+		node1OnPath := node1.LeftMostLeaf == lmlI
 		for y := lmlJ; y <= j; y++ {
-			node1, node2 := nodes1[x], nodes2[y]
-			deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
-			insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
+			node2 := nodes2[y]
+			deleteOption := fd[x*stride+y+1] + deleteCost
+			insertOption := fd[(x+1)*stride+y] + insertCosts[y]
 			var distance float64
-			if node1.LeftMostLeaf == lmlI && node2.LeftMostLeaf == lmlJ {
+			if node1OnPath && node2.LeftMostLeaf == lmlJ {
 				renameCost := fd[x*stride+y] + a.costModel.Rename(node1, node2)
-				distance = math.Min(deleteCost, math.Min(insertCost, renameCost))
+				distance = minCost(deleteOption, minCost(insertOption, renameCost))
 				td[(x+1)*stride+y+1] = distance
 			} else {
 				subtreeCost := fd[node1.LeftMostLeaf*stride+node2.LeftMostLeaf] + td[(x+1)*stride+y+1]
-				distance = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
+				distance = minCost(deleteOption, minCost(insertOption, subtreeCost))
 			}
 			fd[(x+1)*stride+y+1] = distance
 			if distance > maxDistance {
@@ -856,7 +888,7 @@ func (a *APTEDAnalyzer) computeForestDistanceOptimized(
 	}
 }
 
-func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j int, td, fd []float64, stride int) {
+func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j int, td, fd, deleteCosts, insertCosts []float64, stride int) {
 	if i < 0 || i >= len(nodes1) || j < 0 || j >= len(nodes2) {
 		return
 	}
@@ -866,25 +898,28 @@ func (a *APTEDAnalyzer) computeForestDistance(nodes1, nodes2 []*TreeNode, i, j i
 	zeroForestRegion(fd, stride, lmlI, i, lmlJ, j)
 
 	for x := lmlI; x <= i; x++ {
-		fd[(x+1)*stride+lmlJ] = fd[x*stride+lmlJ] + a.costModel.Delete(nodes1[x])
+		fd[(x+1)*stride+lmlJ] = fd[x*stride+lmlJ] + deleteCosts[x]
 	}
 	for y := lmlJ; y <= j; y++ {
-		fd[lmlI*stride+y+1] = fd[lmlI*stride+y] + a.costModel.Insert(nodes2[y])
+		fd[lmlI*stride+y+1] = fd[lmlI*stride+y] + insertCosts[y]
 	}
 
 	for x := lmlI; x <= i; x++ {
+		node1 := nodes1[x]
+		deleteCost := deleteCosts[x]
+		node1OnPath := node1.LeftMostLeaf == lmlI
 		for y := lmlJ; y <= j; y++ {
-			node1, node2 := nodes1[x], nodes2[y]
-			deleteCost := fd[x*stride+y+1] + a.costModel.Delete(node1)
-			insertCost := fd[(x+1)*stride+y] + a.costModel.Insert(node2)
-			if node1.LeftMostLeaf == lmlI && node2.LeftMostLeaf == lmlJ {
+			node2 := nodes2[y]
+			deleteOption := fd[x*stride+y+1] + deleteCost
+			insertOption := fd[(x+1)*stride+y] + insertCosts[y]
+			if node1OnPath && node2.LeftMostLeaf == lmlJ {
 				renameCost := fd[x*stride+y] + a.costModel.Rename(node1, node2)
-				distance := math.Min(deleteCost, math.Min(insertCost, renameCost))
+				distance := minCost(deleteOption, minCost(insertOption, renameCost))
 				fd[(x+1)*stride+y+1] = distance
 				td[(x+1)*stride+y+1] = distance
 			} else {
 				subtreeCost := fd[node1.LeftMostLeaf*stride+node2.LeftMostLeaf] + td[(x+1)*stride+y+1]
-				fd[(x+1)*stride+y+1] = math.Min(deleteCost, math.Min(insertCost, subtreeCost))
+				fd[(x+1)*stride+y+1] = minCost(deleteOption, minCost(insertOption, subtreeCost))
 			}
 		}
 	}

--- a/core/apted/bench_test.go
+++ b/core/apted/bench_test.go
@@ -1,0 +1,113 @@
+package apted
+
+import (
+	"fmt"
+	"testing"
+)
+
+// benchLabels is a small closed label alphabet, mirroring how a real AST draws
+// node labels from a fixed set of node types.
+var benchLabels = []string{
+	"FunctionDeclaration", "IfStatement", "BinaryExpression", "CallExpression",
+	"MemberExpression", "Identifier", "Literal", "ReturnStatement",
+	"BlockStatement", "VariableDeclaration",
+}
+
+// buildBenchTree builds a deterministic tree of exactly nodeCount nodes with the
+// given branching factor. Labels cycle through benchLabels, offset by seed so
+// two trees built with different seeds differ in labels without differing in
+// shape — the case APTED spends the most work on.
+func buildBenchTree(nodeCount, branching, seed int) *TreeNode {
+	if nodeCount < 1 {
+		nodeCount = 1
+	}
+	root := NewTreeNode(0, benchLabels[seed%len(benchLabels)])
+	frontier := []*TreeNode{root}
+	for id := 1; id < nodeCount; id++ {
+		parent := frontier[0]
+		if len(parent.Children) == branching {
+			frontier = frontier[1:]
+			parent = frontier[0]
+		}
+		child := NewTreeNode(id, benchLabels[(id+seed)%len(benchLabels)])
+		parent.AddChild(child)
+		frontier = append(frontier, child)
+	}
+	return root
+}
+
+// benchTreeSizes covers the exact APTED path (below largeTreeThreshold) and the
+// bounded large-tree path above it.
+var benchTreeSizes = []int{100, 500, 1000, 2000, 5000}
+
+func BenchmarkAPTED_BySize(b *testing.B) {
+	for _, size := range benchTreeSizes {
+		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+			tree1 := buildBenchTree(size, 3, 0)
+			tree2 := buildBenchTree(size, 3, 1)
+			PrepareTreeForAPTED(tree1)
+			PrepareTreeForAPTED(tree2)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				analyzer.ComputeDistance(tree1, tree2)
+			}
+		})
+	}
+}
+
+// BenchmarkAPTED_IdenticalTrees measures the best case, where every Rename
+// short-circuits on equal labels.
+func BenchmarkAPTED_IdenticalTrees(b *testing.B) {
+	for _, size := range benchTreeSizes {
+		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+			tree1 := buildBenchTree(size, 3, 0)
+			tree2 := buildBenchTree(size, 3, 0)
+			PrepareTreeForAPTED(tree1)
+			PrepareTreeForAPTED(tree2)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				analyzer.ComputeDistance(tree1, tree2)
+			}
+		})
+	}
+}
+
+// BenchmarkAPTED_DeepTrees exercises the chain-shaped worst case for the
+// recursive traversals, where branching is 1 and depth equals node count.
+func BenchmarkAPTED_DeepTrees(b *testing.B) {
+	for _, size := range []int{100, 500, 1000} {
+		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
+			analyzer := NewAPTEDAnalyzer(NewDefaultCostModel())
+			tree1 := buildBenchTree(size, 1, 0)
+			tree2 := buildBenchTree(size, 1, 1)
+			PrepareTreeForAPTED(tree1)
+			PrepareTreeForAPTED(tree2)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				analyzer.ComputeDistance(tree1, tree2)
+			}
+		})
+	}
+}
+
+func BenchmarkPrepareTreeForAPTED_BySize(b *testing.B) {
+	for _, size := range benchTreeSizes {
+		b.Run(fmt.Sprintf("nodes=%d", size), func(b *testing.B) {
+			tree := buildBenchTree(size, 3, 0)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				PrepareTreeForAPTED(tree)
+			}
+		})
+	}
+}

--- a/core/apted/tree.go
+++ b/core/apted/tree.go
@@ -32,8 +32,11 @@ type TreeNode struct {
 	//   // pyscn
 	//   pyNode := treeNode.OriginalNode.(*parser.Node)
 	//
-	//   // jscan
-	//   jsNode := treeNode.OriginalNode.(*parser.Node)
+	// Populating it is a deliberate choice, not a default. A parser node that
+	// carries a parent pointer pins its whole file AST for as long as the
+	// converted tree lives, which is the entire run for clone detection —
+	// jscan's converter therefore leaves this empty, so do not assume an
+	// adapter has filled it in.
 	OriginalNode any
 }
 

--- a/core/graph/cycles.go
+++ b/core/graph/cycles.go
@@ -17,7 +17,8 @@ type CycleDetector struct {
 	onStack  map[string]bool
 	indices  map[string]int
 	lowlinks map[string]int
-	result   *CycleResult
+	// collect receives every completed component, including single-node ones.
+	collect func(scc []string)
 }
 
 // NewCycleDetector creates a new CycleDetector.
@@ -27,14 +28,38 @@ func NewCycleDetector() *CycleDetector {
 
 // DetectCycles finds all cycles (SCCs with size > 1) in the directed graph.
 func (d *CycleDetector) DetectCycles(g DirectedGraph) *CycleResult {
-	d.index = 0
-	d.stack = nil
-	d.onStack = make(map[string]bool)
-	d.indices = make(map[string]int)
-	d.lowlinks = make(map[string]int)
-	d.result = &CycleResult{
+	result := &CycleResult{
 		AffectedNodes: make(map[string]bool),
 	}
+
+	// Only SCCs with more than one node are actual cycles.
+	for _, scc := range StronglyConnectedComponents(g) {
+		if len(scc) <= 1 {
+			continue
+		}
+		result.Cycles = append(result.Cycles, scc)
+		for _, node := range scc {
+			result.AffectedNodes[node] = true
+		}
+	}
+
+	result.HasCycles = len(result.Cycles) > 0
+	return result
+}
+
+// StronglyConnectedComponents returns every strongly connected component of g,
+// including single-node components, using Tarjan's algorithm. Components are
+// returned in reverse topological order: a component appears before any
+// component it depends on.
+func StronglyConnectedComponents(g DirectedGraph) [][]string {
+	d := &CycleDetector{
+		onStack:  make(map[string]bool),
+		indices:  make(map[string]int),
+		lowlinks: make(map[string]int),
+	}
+
+	var components [][]string
+	d.collect = func(scc []string) { components = append(components, scc) }
 
 	for _, nodeID := range g.NodeIDs() {
 		if _, visited := d.indices[nodeID]; !visited {
@@ -42,8 +67,7 @@ func (d *CycleDetector) DetectCycles(g DirectedGraph) *CycleResult {
 		}
 	}
 
-	d.result.HasCycles = len(d.result.Cycles) > 0
-	return d.result
+	return components
 }
 
 func (d *CycleDetector) strongConnect(g DirectedGraph, v string) {
@@ -77,12 +101,8 @@ func (d *CycleDetector) strongConnect(g DirectedGraph, v string) {
 				break
 			}
 		}
-		// Only record SCCs with more than one node (actual cycles).
-		if len(scc) > 1 {
-			d.result.Cycles = append(d.result.Cycles, scc)
-			for _, node := range scc {
-				d.result.AffectedNodes[node] = true
-			}
+		if d.collect != nil {
+			d.collect(scc)
 		}
 	}
 }

--- a/core/graph/paths.go
+++ b/core/graph/paths.go
@@ -1,5 +1,7 @@
 package graph
 
+import "sort"
+
 // noComponent marks the absence of a component index.
 const noComponent = -1
 
@@ -7,14 +9,21 @@ const noComponent = -1
 //
 // Finding the longest simple path in a graph that may contain cycles is
 // NP-hard, so a ChainFinder walks the condensation instead: strongly connected
-// components are collapsed to single vertices and the longest path through the
-// resulting DAG is memoized in one linear pass. Each query then expands the
-// component path into a concrete route through the members of every component
-// it crosses, so every chain returned is a real simple path in the graph.
+// components are collapsed to single vertices and the heaviest path through the
+// resulting DAG is memoized in one linear pass, weighting each component by how
+// many nodes it holds. Each query then expands that component path into a
+// concrete route through the members of every component it crosses, so every
+// chain returned is a real simple path in the graph.
 //
-// Chains are compared by the number of components they cross. Ties are resolved
-// by traversal order, which is derived from the graph's node ordering, so
-// repeated queries over the same graph return the same chain.
+// The chain is maximal in dependency layers: no other simple path crosses more
+// strongly connected components. Within a component the route is not guaranteed
+// maximal — the final component is walked greedily through as many members as
+// it can reach, while components the chain passes through are crossed by the
+// shortest route between the edges that enter and leave them. Recovering the
+// longest route through a cycle is the NP-hard problem again.
+//
+// Ties are resolved by traversal order, which is derived from the graph's node
+// ordering, so repeated queries over the same graph return the same chain.
 type ChainFinder struct {
 	dag  *condensation
 	best []componentChain
@@ -51,10 +60,10 @@ func (f *ChainFinder) LongestChain() []string {
 		return nil
 	}
 
-	start, depth := noComponent, 0
+	start, nodes := noComponent, 0
 	for index, chain := range f.best {
-		if chain.depth > depth {
-			start, depth = index, chain.depth
+		if chain.nodes > nodes {
+			start, nodes = index, chain.nodes
 		}
 	}
 	if start == noComponent {
@@ -64,7 +73,7 @@ func (f *ChainFinder) LongestChain() []string {
 }
 
 func (f *ChainFinder) componentPathFrom(start int) []int {
-	path := make([]int, 0, f.best[start].depth)
+	var path []int
 	for index := start; index != noComponent; index = f.best[index].next {
 		path = append(path, index)
 	}
@@ -86,6 +95,13 @@ type condensation struct {
 
 func newCondensation(g DirectedGraph) *condensation {
 	components := StronglyConnectedComponents(g)
+	// Sort each component's members so a chain that starts inside a cycle starts
+	// at a predictable node rather than wherever Tarjan happened to pop it.
+	// These slices are this call's own; CycleDetector runs its own SCC pass, so
+	// its reported cycle order is untouched.
+	for _, component := range components {
+		sort.Strings(component)
+	}
 
 	dag := &condensation{
 		graph:       g,
@@ -122,15 +138,17 @@ func newCondensation(g DirectedGraph) *condensation {
 }
 
 // componentChain is the best chain reachable from one component: how many
-// components it spans and which component continues it.
+// graph nodes it spans and which component continues it.
 type componentChain struct {
-	depth int
+	nodes int
 	next  int
 }
 
-// longestChainPerComponent memoizes, for every component, the longest chain
-// starting there. The condensation is acyclic, so no component is reachable
-// from itself and a single memoized pass suffices.
+// longestChainPerComponent memoizes, for every component, the heaviest chain
+// starting there, weighting a component by its node count so that a chain
+// through a large cycle outranks an equally deep chain through single modules.
+// The condensation is acyclic, so no component is reachable from itself and a
+// single memoized pass suffices.
 func (dag *condensation) longestChainPerComponent() []componentChain {
 	best := make([]componentChain, len(dag.components))
 	resolved := make([]bool, len(dag.components))
@@ -142,10 +160,11 @@ func (dag *condensation) longestChainPerComponent() []componentChain {
 		}
 		resolved[index] = true
 
-		chain := componentChain{depth: 1, next: noComponent}
+		size := len(dag.components[index])
+		chain := componentChain{nodes: size, next: noComponent}
 		for _, successor := range dag.successors[index] {
-			if candidate := longestFrom(successor); candidate.depth+1 > chain.depth {
-				chain = componentChain{depth: candidate.depth + 1, next: successor}
+			if candidate := longestFrom(successor); candidate.nodes+size > chain.nodes {
+				chain = componentChain{nodes: candidate.nodes + size, next: successor}
 			}
 		}
 
@@ -184,17 +203,18 @@ func (dag *condensation) expand(componentPath []int, startNode string) []string 
 	return path
 }
 
-// routeWithin returns a simple path inside one component that starts at entry
-// (or the component's first node when entry is empty) and ends at exit (or at
-// entry itself when exit is empty). Every node of a strongly connected
-// component is reachable from every other, so a route always exists.
+// routeWithin returns a simple path inside one component, starting at entry (or
+// the component's first node when entry is empty).
+//
+// When exit is set the route ends there, by the shortest way through the
+// component. When it is empty — the component ends the chain, so nothing
+// constrains where the route stops — the route walks greedily through as many
+// members as it can reach. That greedy walk is what keeps a chain ending in a
+// cycle from collapsing to the single node it entered on.
 func (dag *condensation) routeWithin(index int, entry, exit string) []string {
 	component := dag.components[index]
 	if entry == "" {
 		entry = component[0]
-	}
-	if exit == "" || exit == entry {
-		return []string{entry}
 	}
 
 	members := make(map[string]struct{}, len(component))
@@ -202,6 +222,48 @@ func (dag *condensation) routeWithin(index int, entry, exit string) []string {
 		members[nodeID] = struct{}{}
 	}
 
+	if exit == "" {
+		return dag.walkWithin(entry, members)
+	}
+	if exit == entry {
+		return []string{entry}
+	}
+	return dag.shortestRouteWithin(entry, exit, members)
+}
+
+// walkWithin follows unvisited successors from entry for as long as it can,
+// staying inside members. Every step follows a real edge to a node not yet on
+// the path, so the result is a simple path; it is not guaranteed to be the
+// longest one, which is NP-hard to find.
+func (dag *condensation) walkWithin(entry string, members map[string]struct{}) []string {
+	path := []string{entry}
+	visited := map[string]struct{}{entry: {}}
+
+	for current := entry; ; {
+		next := ""
+		for _, successor := range dag.graph.Successors(current) {
+			if _, inside := members[successor]; !inside {
+				continue
+			}
+			if _, seen := visited[successor]; seen {
+				continue
+			}
+			next = successor
+			break
+		}
+		if next == "" {
+			return path
+		}
+		visited[next] = struct{}{}
+		path = append(path, next)
+		current = next
+	}
+}
+
+// shortestRouteWithin returns the shortest path from entry to exit that stays
+// inside members. Every node of a strongly connected component is reachable
+// from every other, so a route always exists.
+func (dag *condensation) shortestRouteWithin(entry, exit string, members map[string]struct{}) []string {
 	// Breadth-first search stays inside the component, so the route never
 	// revisits a node already contributed by an earlier component.
 	previous := map[string]string{entry: ""}

--- a/core/graph/paths.go
+++ b/core/graph/paths.go
@@ -1,0 +1,235 @@
+package graph
+
+// noComponent marks the absence of a component index.
+const noComponent = -1
+
+// ChainFinder answers longest-dependency-chain queries over a directed graph.
+//
+// Finding the longest simple path in a graph that may contain cycles is
+// NP-hard, so a ChainFinder walks the condensation instead: strongly connected
+// components are collapsed to single vertices and the longest path through the
+// resulting DAG is memoized in one linear pass. Each query then expands the
+// component path into a concrete route through the members of every component
+// it crosses, so every chain returned is a real simple path in the graph.
+//
+// Chains are compared by the number of components they cross. Ties are resolved
+// by traversal order, which is derived from the graph's node ordering, so
+// repeated queries over the same graph return the same chain.
+type ChainFinder struct {
+	dag  *condensation
+	best []componentChain
+}
+
+// NewChainFinder builds the condensation of g and memoizes the longest chain
+// reachable from every component. Construction is linear in the graph size;
+// each subsequent query is linear in the length of the chain it returns.
+func NewChainFinder(g DirectedGraph) *ChainFinder {
+	if g == nil || g.NodeCount() == 0 {
+		return &ChainFinder{}
+	}
+
+	dag := newCondensation(g)
+	return &ChainFinder{dag: dag, best: dag.longestChainPerComponent()}
+}
+
+// LongestChainFrom returns the longest chain that starts at nodeID, or nil if
+// the node is not in the graph.
+func (f *ChainFinder) LongestChainFrom(nodeID string) []string {
+	if f.dag == nil {
+		return nil
+	}
+	start, known := f.dag.componentOf[nodeID]
+	if !known {
+		return nil
+	}
+	return f.dag.expand(f.componentPathFrom(start), nodeID)
+}
+
+// LongestChain returns the longest chain anywhere in the graph.
+func (f *ChainFinder) LongestChain() []string {
+	if f.dag == nil {
+		return nil
+	}
+
+	start, depth := noComponent, 0
+	for index, chain := range f.best {
+		if chain.depth > depth {
+			start, depth = index, chain.depth
+		}
+	}
+	if start == noComponent {
+		return nil
+	}
+	return f.dag.expand(f.componentPathFrom(start), "")
+}
+
+func (f *ChainFinder) componentPathFrom(start int) []int {
+	path := make([]int, 0, f.best[start].depth)
+	for index := start; index != noComponent; index = f.best[index].next {
+		path = append(path, index)
+	}
+	return path
+}
+
+// condensation is the DAG of strongly connected components of a graph.
+type condensation struct {
+	graph      DirectedGraph
+	components [][]string
+	// componentOf maps a node ID to the index of its component.
+	componentOf map[string]int
+	// successors lists the component indices each component depends on.
+	successors [][]int
+	// crossing records, for an ordered component pair, one concrete edge
+	// realizing it: crossing[[2]int{from, to}] = [2]string{fromNode, toNode}.
+	crossing map[[2]int][2]string
+}
+
+func newCondensation(g DirectedGraph) *condensation {
+	components := StronglyConnectedComponents(g)
+
+	dag := &condensation{
+		graph:       g,
+		components:  components,
+		componentOf: make(map[string]int, g.NodeCount()),
+		successors:  make([][]int, len(components)),
+		crossing:    make(map[[2]int][2]string),
+	}
+	for index, component := range components {
+		for _, nodeID := range component {
+			dag.componentOf[nodeID] = index
+		}
+	}
+
+	for index, component := range components {
+		seen := make(map[int]struct{})
+		for _, nodeID := range component {
+			for _, successor := range g.Successors(nodeID) {
+				target, known := dag.componentOf[successor]
+				if !known || target == index {
+					continue
+				}
+				if _, duplicate := seen[target]; duplicate {
+					continue
+				}
+				seen[target] = struct{}{}
+				dag.successors[index] = append(dag.successors[index], target)
+				dag.crossing[[2]int{index, target}] = [2]string{nodeID, successor}
+			}
+		}
+	}
+
+	return dag
+}
+
+// componentChain is the best chain reachable from one component: how many
+// components it spans and which component continues it.
+type componentChain struct {
+	depth int
+	next  int
+}
+
+// longestChainPerComponent memoizes, for every component, the longest chain
+// starting there. The condensation is acyclic, so no component is reachable
+// from itself and a single memoized pass suffices.
+func (dag *condensation) longestChainPerComponent() []componentChain {
+	best := make([]componentChain, len(dag.components))
+	resolved := make([]bool, len(dag.components))
+
+	var longestFrom func(index int) componentChain
+	longestFrom = func(index int) componentChain {
+		if resolved[index] {
+			return best[index]
+		}
+		resolved[index] = true
+
+		chain := componentChain{depth: 1, next: noComponent}
+		for _, successor := range dag.successors[index] {
+			if candidate := longestFrom(successor); candidate.depth+1 > chain.depth {
+				chain = componentChain{depth: candidate.depth + 1, next: successor}
+			}
+		}
+
+		best[index] = chain
+		return chain
+	}
+
+	for index := range dag.components {
+		longestFrom(index)
+	}
+	return best
+}
+
+// expand turns a component path into a concrete node path, routing through the
+// members of every component the chain crosses. The path begins at startNode
+// when given, and otherwise at the first component's first member.
+func (dag *condensation) expand(componentPath []int, startNode string) []string {
+	if len(componentPath) == 0 {
+		return nil
+	}
+
+	var path []string
+	entry := startNode
+	for position, index := range componentPath {
+		exit := ""
+		nextEntry := ""
+		if position+1 < len(componentPath) {
+			edge := dag.crossing[[2]int{index, componentPath[position+1]}]
+			exit, nextEntry = edge[0], edge[1]
+		}
+
+		path = append(path, dag.routeWithin(index, entry, exit)...)
+		entry = nextEntry
+	}
+
+	return path
+}
+
+// routeWithin returns a simple path inside one component that starts at entry
+// (or the component's first node when entry is empty) and ends at exit (or at
+// entry itself when exit is empty). Every node of a strongly connected
+// component is reachable from every other, so a route always exists.
+func (dag *condensation) routeWithin(index int, entry, exit string) []string {
+	component := dag.components[index]
+	if entry == "" {
+		entry = component[0]
+	}
+	if exit == "" || exit == entry {
+		return []string{entry}
+	}
+
+	members := make(map[string]struct{}, len(component))
+	for _, nodeID := range component {
+		members[nodeID] = struct{}{}
+	}
+
+	// Breadth-first search stays inside the component, so the route never
+	// revisits a node already contributed by an earlier component.
+	previous := map[string]string{entry: ""}
+	queue := []string{entry}
+	for len(queue) > 0 {
+		if _, reached := previous[exit]; reached {
+			break
+		}
+		current := queue[0]
+		queue = queue[1:]
+		for _, successor := range dag.graph.Successors(current) {
+			if _, inside := members[successor]; !inside {
+				continue
+			}
+			if _, seen := previous[successor]; seen {
+				continue
+			}
+			previous[successor] = current
+			queue = append(queue, successor)
+		}
+	}
+
+	route := []string{}
+	for node := exit; node != ""; node = previous[node] {
+		route = append(route, node)
+	}
+	for left, right := 0, len(route)-1; left < right; left, right = left+1, right-1 {
+		route[left], route[right] = route[right], route[left]
+	}
+	return route
+}

--- a/core/graph/paths_test.go
+++ b/core/graph/paths_test.go
@@ -116,8 +116,48 @@ func TestLongestChainWholeGraphIsOneCycle(t *testing.T) {
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
-	if len(chain) != 1 {
-		t.Errorf("LongestChain = %v, want a single component representative", chain)
+	// A graph that is nothing but a cycle still has depth: the chain must walk
+	// the cycle's members rather than collapse to whichever node it started on.
+	if len(chain) != 3 {
+		t.Errorf("LongestChain = %v, want all three cycle members", chain)
+	}
+}
+
+// TestLongestChainWalksTerminalCycle covers the shape that made chains collapse:
+// the chain ends inside a cycle, so nothing constrains where the route stops.
+func TestLongestChainWalksTerminalCycle(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"entry", "x"},
+		{"x", "y"}, {"y", "x"},
+	})
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if len(chain) != 3 {
+		t.Errorf("LongestChain = %v, want entry plus both cycle members", chain)
+	}
+	if chain[0] != "entry" {
+		t.Errorf("LongestChain = %v, want it to start at entry", chain)
+	}
+}
+
+// TestLongestChainPrefersChainThroughCycle pins the weighting: two chains cross
+// the same number of components, but one of those components is a cycle holding
+// more modules, so it is the deeper dependency chain.
+func TestLongestChainPrefersChainThroughCycle(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"root", "plain"}, {"plain", "leaf"},
+		{"root", "c1"}, {"c1", "c2"}, {"c2", "c3"}, {"c3", "c1"},
+	})
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if len(chain) != 4 {
+		t.Errorf("LongestChain = %v, want root plus all three cycle members", chain)
 	}
 }
 

--- a/core/graph/paths_test.go
+++ b/core/graph/paths_test.go
@@ -1,0 +1,218 @@
+package graph
+
+import (
+	"fmt"
+	"testing"
+)
+
+func chainGraph(edges [][2]string, isolated ...string) *MapGraph {
+	g := NewMapGraph()
+	for _, node := range isolated {
+		g.AddNode(node)
+	}
+	for _, edge := range edges {
+		g.AddEdge(edge[0], edge[1])
+	}
+	return g
+}
+
+// isSimplePath verifies every step follows an edge and no node repeats.
+func isSimplePath(g DirectedGraph, path []string) error {
+	seen := make(map[string]struct{}, len(path))
+	for i, node := range path {
+		if !g.HasNode(node) {
+			return fmt.Errorf("node %q is not in the graph", node)
+		}
+		if _, duplicate := seen[node]; duplicate {
+			return fmt.Errorf("node %q repeats in the path", node)
+		}
+		seen[node] = struct{}{}
+
+		if i == 0 {
+			continue
+		}
+		linked := false
+		for _, successor := range g.Successors(path[i-1]) {
+			if successor == node {
+				linked = true
+				break
+			}
+		}
+		if !linked {
+			return fmt.Errorf("no edge from %q to %q", path[i-1], node)
+		}
+	}
+	return nil
+}
+
+func TestLongestChainEmptyGraph(t *testing.T) {
+	if chain := NewChainFinder(NewMapGraph()).LongestChain(); chain != nil {
+		t.Errorf("LongestChain(empty) = %v, want nil", chain)
+	}
+	if chain := NewChainFinder(nil).LongestChain(); chain != nil {
+		t.Errorf("NewChainFinder(nil).LongestChain() = %v, want nil", chain)
+	}
+}
+
+func TestLongestChainSingleNode(t *testing.T) {
+	chain := NewChainFinder(chainGraph(nil, "only")).LongestChain()
+	if len(chain) != 1 || chain[0] != "only" {
+		t.Errorf("LongestChain = %v, want [only]", chain)
+	}
+}
+
+func TestLongestChainLinearPath(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}, {"b", "c"}, {"c", "d"}})
+
+	chain := NewChainFinder(g).LongestChain()
+	want := []string{"a", "b", "c", "d"}
+	if len(chain) != len(want) {
+		t.Fatalf("LongestChain = %v, want %v", chain, want)
+	}
+	for i := range want {
+		if chain[i] != want[i] {
+			t.Fatalf("LongestChain = %v, want %v", chain, want)
+		}
+	}
+}
+
+func TestLongestChainPrefersDeeperBranch(t *testing.T) {
+	// "a" branches into a short arm and a long arm.
+	g := chainGraph([][2]string{
+		{"a", "short"},
+		{"a", "long1"}, {"long1", "long2"}, {"long2", "long3"},
+	})
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if len(chain) != 4 || chain[0] != "a" || chain[3] != "long3" {
+		t.Errorf("LongestChain = %v, want a→long1→long2→long3", chain)
+	}
+}
+
+func TestLongestChainRoutesThroughCycle(t *testing.T) {
+	// entry → (x ⇄ y ⇄ z cycle) → exit
+	g := chainGraph([][2]string{
+		{"entry", "x"},
+		{"x", "y"}, {"y", "z"}, {"z", "x"},
+		{"z", "exit"},
+	})
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if chain[0] != "entry" || chain[len(chain)-1] != "exit" {
+		t.Errorf("LongestChain = %v, want a chain from entry to exit", chain)
+	}
+}
+
+func TestLongestChainWholeGraphIsOneCycle(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}, {"b", "c"}, {"c", "a"}})
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if len(chain) != 1 {
+		t.Errorf("LongestChain = %v, want a single component representative", chain)
+	}
+}
+
+func TestLongestChainIsDeterministic(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}, {"d", "e"},
+		{"e", "f"}, {"f", "d"}, {"e", "g"},
+	})
+
+	first := NewChainFinder(g).LongestChain()
+	for i := 0; i < 20; i++ {
+		next := NewChainFinder(g).LongestChain()
+		if len(next) != len(first) {
+			t.Fatalf("run %d returned %v, want %v", i, next, first)
+		}
+		for j := range first {
+			if next[j] != first[j] {
+				t.Fatalf("run %d returned %v, want %v", i, next, first)
+			}
+		}
+	}
+}
+
+// TestLongestChainCompletesOnDenseGraph pins the complexity guarantee: an
+// exhaustive simple-path search over this graph would not terminate.
+func TestLongestChainCompletesOnDenseGraph(t *testing.T) {
+	const nodes = 300
+
+	g := NewMapGraph()
+	for i := 0; i < nodes; i++ {
+		for j := i + 1; j < nodes && j < i+8; j++ {
+			g.AddEdge(fmt.Sprintf("n%03d", i), fmt.Sprintf("n%03d", j))
+		}
+	}
+
+	chain := NewChainFinder(g).LongestChain()
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain is not a simple path: %v", err)
+	}
+	if len(chain) < 2 {
+		t.Errorf("LongestChain returned %d nodes, want a multi-node chain", len(chain))
+	}
+}
+
+func TestLongestChainFromStartsAtRequestedNode(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"a", "b"}, {"b", "c"}, {"c", "d"},
+		{"x", "b"},
+	})
+	finder := NewChainFinder(g)
+
+	chain := finder.LongestChainFrom("x")
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if len(chain) == 0 || chain[0] != "x" {
+		t.Fatalf("LongestChainFrom(x) = %v, want a chain starting at x", chain)
+	}
+	if chain[len(chain)-1] != "d" {
+		t.Errorf("LongestChainFrom(x) = %v, want it to reach d", chain)
+	}
+
+	if chain := finder.LongestChainFrom("missing"); chain != nil {
+		t.Errorf("LongestChainFrom(missing) = %v, want nil", chain)
+	}
+}
+
+func TestLongestChainFromInsideCycleStaysSimple(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"x", "y"}, {"y", "z"}, {"z", "x"},
+		{"z", "tail"}, {"tail", "end"},
+	})
+
+	chain := NewChainFinder(g).LongestChainFrom("y")
+	if err := isSimplePath(g, chain); err != nil {
+		t.Fatalf("chain %v is not a simple path: %v", chain, err)
+	}
+	if chain[0] != "y" || chain[len(chain)-1] != "end" {
+		t.Errorf("LongestChainFrom(y) = %v, want a chain from y to end", chain)
+	}
+}
+
+func TestStronglyConnectedComponentsIncludesSingletons(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}, {"b", "a"}, {"b", "c"}})
+
+	components := StronglyConnectedComponents(g)
+	if len(components) != 2 {
+		t.Fatalf("got %d components (%v), want 2", len(components), components)
+	}
+
+	sizes := map[int]int{}
+	for _, component := range components {
+		sizes[len(component)]++
+	}
+	if sizes[1] != 1 || sizes[2] != 1 {
+		t.Errorf("component sizes = %v, want one singleton and one pair", sizes)
+	}
+}

--- a/core/lsh/bench_test.go
+++ b/core/lsh/bench_test.go
@@ -1,0 +1,110 @@
+package lsh
+
+import (
+	"fmt"
+	"strconv"
+	"testing"
+)
+
+// benchFeatures builds a deterministic feature set for one fragment. Fragments
+// share a common vocabulary so signatures collide the way real near-duplicate
+// code fragments do.
+func benchFeatures(fragment, count int) []string {
+	features := make([]string, count)
+	for i := range features {
+		features[i] = "feature-" + strconv.Itoa((fragment+i*7)%(count*4))
+	}
+	return features
+}
+
+func BenchmarkComputeSignature_BySetSize(b *testing.B) {
+	for _, size := range []int{16, 64, 256, 1024} {
+		b.Run(fmt.Sprintf("features=%d", size), func(b *testing.B) {
+			hasher := NewMinHasher(defaultNumHashes)
+			features := benchFeatures(0, size)
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				hasher.ComputeSignature(features)
+			}
+		})
+	}
+}
+
+// BenchmarkLSHIndex_Build measures index construction at fragment counts a
+// large monorepo reaches, where per-insert costs that look negligible at small
+// scale dominate.
+func BenchmarkLSHIndex_Build(b *testing.B) {
+	for _, fragments := range []int{1_000, 10_000, 100_000} {
+		b.Run(fmt.Sprintf("fragments=%d", fragments), func(b *testing.B) {
+			hasher := NewMinHasher(defaultNumHashes)
+			signatures := make([]*MinHashSignature, fragments)
+			ids := make([]string, fragments)
+			for i := range signatures {
+				signatures[i] = hasher.ComputeSignature(benchFeatures(i, 32))
+				ids[i] = strconv.Itoa(i)
+			}
+
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				index := NewLSHIndex(defaultBands, defaultRows)
+				for j, signature := range signatures {
+					if err := index.AddFragment(ids[j], signature); err != nil {
+						b.Fatalf("AddFragment: %v", err)
+					}
+				}
+			}
+		})
+	}
+}
+
+// BenchmarkLSHIndex_DenseBuckets is the pathological case for clone detection:
+// many fragments whose signatures are identical, so they all land in the same
+// buckets.
+func BenchmarkLSHIndex_DenseBuckets(b *testing.B) {
+	const fragments = 20_000
+
+	hasher := NewMinHasher(defaultNumHashes)
+	signature := hasher.ComputeSignature(benchFeatures(0, 32))
+	ids := make([]string, fragments)
+	for i := range ids {
+		ids[i] = strconv.Itoa(i)
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		index := NewLSHIndex(defaultBands, defaultRows)
+		for _, id := range ids {
+			if err := index.AddFragment(id, signature); err != nil {
+				b.Fatalf("AddFragment: %v", err)
+			}
+		}
+	}
+}
+
+func BenchmarkLSHIndex_FindCandidates(b *testing.B) {
+	const fragments = 50_000
+	const maxCandidates = 1024
+
+	hasher := NewMinHasher(defaultNumHashes)
+	index := NewLSHIndex(defaultBands, defaultRows)
+	queries := make([]*MinHashSignature, 0, 64)
+	for i := 0; i < fragments; i++ {
+		signature := hasher.ComputeSignature(benchFeatures(i, 32))
+		if err := index.AddFragment(strconv.Itoa(i), signature); err != nil {
+			b.Fatalf("AddFragment: %v", err)
+		}
+		if len(queries) < cap(queries) {
+			queries = append(queries, signature)
+		}
+	}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		index.FindCandidatesLimit(queries[i%len(queries)], maxCandidates)
+	}
+}

--- a/core/lsh/index.go
+++ b/core/lsh/index.go
@@ -1,9 +1,8 @@
 package lsh
 
 import (
-	"encoding/binary"
 	"fmt"
-	"hash/fnv"
+	"slices"
 )
 
 const (
@@ -11,12 +10,23 @@ const (
 	defaultRows  = 4
 )
 
+// bandKey identifies one band's bucket. The band index and the hash of the
+// band's signature slice together determine the bucket, so a comparable struct
+// serves as the map key directly — no formatted string per band per fragment.
+type bandKey struct {
+	band int
+	hash uint64
+}
+
 // LSHIndex implements MinHash LSH with banding.
 type LSHIndex struct {
 	bands      int
 	rows       int
-	buckets    map[string][]string
+	buckets    map[bandKey][]string
 	signatures map[string]*MinHashSignature
+	// insertKeys is scratch space reused by AddFragment. Queries use their own
+	// buffer so that reading the index stays free of mutation.
+	insertKeys []bandKey
 }
 
 // NewLSHIndex creates an index with banding parameters.
@@ -30,7 +40,7 @@ func NewLSHIndex(bands, rows int) *LSHIndex {
 	return &LSHIndex{
 		bands:      bands,
 		rows:       rows,
-		buckets:    make(map[string][]string),
+		buckets:    make(map[bandKey][]string),
 		signatures: make(map[string]*MinHashSignature),
 	}
 }
@@ -43,8 +53,9 @@ func (idx *LSHIndex) AddFragment(id string, signature *MinHashSignature) error {
 	if id == "" {
 		return fmt.Errorf("empty fragment id")
 	}
+	_, reindexed := idx.signatures[id]
 	idx.signatures[id] = signature
-	idx.addToBuckets(id, signature)
+	idx.addToBuckets(id, signature, reindexed)
 	return nil
 }
 
@@ -68,7 +79,7 @@ func (idx *LSHIndex) FindCandidatesLimit(signature *MinHashSignature, maxCandida
 	}
 	seen := make(map[string]struct{})
 	out := []string{}
-	for _, key := range idx.computeBandKeys(signature) {
+	for _, key := range idx.appendBandKeys(nil, signature) {
 		for _, id := range idx.buckets[key] {
 			if maxCandidates > 0 && len(out) >= maxCandidates {
 				return out
@@ -103,24 +114,24 @@ func (idx *LSHIndex) Rows() int {
 	return idx.rows
 }
 
-func (idx *LSHIndex) addToBuckets(id string, sig *MinHashSignature) {
-	keys := idx.computeBandKeys(sig)
-	for _, k := range keys {
+// addToBuckets files a fragment under each of its band keys. A fragment being
+// indexed for the first time cannot already be in any bucket, so the duplicate
+// scan — linear in bucket size, and buckets grow large when many fragments hash
+// alike — only runs when the same ID is indexed again.
+func (idx *LSHIndex) addToBuckets(id string, sig *MinHashSignature, reindexed bool) {
+	idx.insertKeys = idx.appendBandKeys(idx.insertKeys[:0], sig)
+	for _, k := range idx.insertKeys {
 		cur := idx.buckets[k]
-		exists := false
-		for _, v := range cur {
-			if v == id {
-				exists = true
-				break
-			}
+		if reindexed && slices.Contains(cur, id) {
+			continue
 		}
-		if !exists {
-			idx.buckets[k] = append(cur, id)
-		}
+		idx.buckets[k] = append(cur, id)
 	}
 }
 
-func (idx *LSHIndex) computeBandKeys(sig *MinHashSignature) []string {
+// appendBandKeys appends the band keys of a signature to dst and returns the
+// extended slice, so callers that run repeatedly can reuse one buffer.
+func (idx *LSHIndex) appendBandKeys(dst []bandKey, sig *MinHashSignature) []bandKey {
 	total := len(sig.signatures)
 	r := idx.rows
 	b := idx.bands
@@ -134,22 +145,29 @@ func (idx *LSHIndex) computeBandKeys(sig *MinHashSignature) []string {
 	if b > maxBands {
 		b = maxBands
 	}
-	keys := make([]string, 0, b)
+	if cap(dst) < len(dst)+b {
+		grown := make([]bandKey, len(dst), len(dst)+b)
+		copy(grown, dst)
+		dst = grown
+	}
+
 	for band := 0; band < b; band++ {
 		start := band * r
 		end := start + r
 		if end > total {
 			end = total
 		}
-		part := sig.signatures[start:end]
-		h := fnv.New64a()
-		buf := make([]byte, 8)
-		for _, v := range part {
-			binary.BigEndian.PutUint64(buf, v)
-			_, _ = h.Write(buf)
+
+		// FNV-1a over the big-endian bytes of the band's signature values.
+		h := uint64(fnvOffsetBasis64)
+		for _, v := range sig.signatures[start:end] {
+			for shift := 56; shift >= 0; shift -= 8 {
+				h ^= (v >> uint(shift)) & 0xff
+				h *= fnvPrime64
+			}
 		}
-		key := fmt.Sprintf("b:%d:%016x", band, h.Sum64())
-		keys = append(keys, key)
+		dst = append(dst, bandKey{band: band, hash: h})
 	}
-	return keys
+
+	return dst
 }

--- a/core/lsh/minhash.go
+++ b/core/lsh/minhash.go
@@ -1,7 +1,6 @@
 package lsh
 
 import (
-	"hash/fnv"
 	"math"
 	"math/rand"
 )
@@ -27,13 +26,15 @@ func (s *MinHashSignature) NumHashes() int {
 	return s.numHashes
 }
 
-// HashFunc maps a 64-bit base hash to another 64-bit value.
-type HashFunc func(uint64) uint64
-
 // MinHasher computes MinHash signatures for feature sets.
+//
+// The hash family is stored as coefficient pairs rather than closures: signing
+// one fragment evaluates numHashes × |features| hashes, so an indirect call per
+// evaluation is the difference between a few and a few dozen instructions.
 type MinHasher struct {
-	numHashes     int
-	hashFunctions []HashFunc
+	numHashes int
+	factors   []uint64
+	offsets   []uint64
 }
 
 // NewMinHasher creates a MinHasher with numHashes functions (default 128 if invalid).
@@ -48,48 +49,46 @@ func NewMinHasher(numHashes int) *MinHasher {
 
 func (m *MinHasher) generateHashFunctions() {
 	rng := rand.New(rand.NewSource(hashSeed))
-	a := make([]uint64, m.numHashes)
-	b := make([]uint64, m.numHashes)
+	m.factors = make([]uint64, m.numHashes)
+	m.offsets = make([]uint64, m.numHashes)
 	for i := 0; i < m.numHashes; i++ {
-		a[i] = rng.Uint64() | 1 // odd to avoid trivial cycles
-		b[i] = rng.Uint64()
-	}
-	m.hashFunctions = make([]HashFunc, m.numHashes)
-	for i := 0; i < m.numHashes; i++ {
-		ai, bi := a[i], b[i]
-		m.hashFunctions[i] = func(x uint64) uint64 {
-			return (ai * x) ^ bi + ai + bi
-		}
+		m.factors[i] = rng.Uint64() | 1 // odd to avoid trivial cycles
+		m.offsets[i] = rng.Uint64()
 	}
 }
 
 // ComputeSignature computes the MinHash signature for a set of features.
 func (m *MinHasher) ComputeSignature(features []string) *MinHashSignature {
+	sig := make([]uint64, m.numHashes)
 	if len(features) == 0 {
-		return &MinHashSignature{signatures: make([]uint64, m.numHashes), numHashes: m.numHashes}
+		return &MinHashSignature{signatures: sig, numHashes: m.numHashes}
 	}
+
 	set := make(map[string]struct{}, len(features))
+	base := make([]uint64, 0, len(features))
 	for _, f := range features {
+		if _, duplicate := set[f]; duplicate {
+			continue
+		}
 		set[f] = struct{}{}
-	}
-	base := make([]uint64, 0, len(set))
-	for f := range set {
 		base = append(base, Hash64(f))
 	}
-	sig := make([]uint64, m.numHashes)
-	for i := 0; i < m.numHashes; i++ {
-		sig[i] = math.MaxUint64
-	}
-	for i := 0; i < m.numHashes; i++ {
-		hi := m.hashFunctions[i]
-		minv := uint64(math.MaxUint64)
+
+	// Hash-outer, feature-inner: the running minimum stays in a register for the
+	// whole inner loop, and the constant addend is computed once per hash rather
+	// than once per feature.
+	for i, factor := range m.factors {
+		offset := m.offsets[i]
+		addend := factor + offset
+		minimum := uint64(math.MaxUint64)
 		for _, x := range base {
-			if v := hi(x); v < minv {
-				minv = v
+			if v := ((factor * x) ^ offset) + addend; v < minimum {
+				minimum = v
 			}
 		}
-		sig[i] = minv
+		sig[i] = minimum
 	}
+
 	return &MinHashSignature{signatures: sig, numHashes: m.numHashes}
 }
 
@@ -114,11 +113,22 @@ func (m *MinHasher) EstimateJaccardSimilarity(sig1, sig2 *MinHashSignature) floa
 // NumHashes returns the number of hash functions.
 func (m *MinHasher) NumHashes() int { return m.numHashes }
 
+// FNV-1a 64-bit parameters. Hashing is open-coded rather than routed through
+// hash/fnv so that hashing a string does not allocate a byte slice and a hasher
+// on every call.
+const (
+	fnvOffsetBasis64 = 14695981039346656037
+	fnvPrime64       = 1099511628211
+)
+
 // Hash64 computes a 64-bit FNV-1a hash for a string.
 func Hash64(s string) uint64 {
-	h := fnv.New64a()
-	_, _ = h.Write([]byte(s))
-	return h.Sum64()
+	h := uint64(fnvOffsetBasis64)
+	for i := 0; i < len(s); i++ {
+		h ^= uint64(s[i])
+		h *= fnvPrime64
+	}
+	return h
 }
 
 // MinInt returns the smaller of two ints.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -37,6 +37,11 @@ Two mechanisms keep this tractable:
    estimate and a feature-Jaccard pre-filter before any tree edit distance is
    computed. Only survivors reach APTED.
 
+Candidates are generated and verified in bounded chunks rather than collected up
+front. Candidate count scales with fragments times candidates-per-query, which
+on a large repository is orders of magnitude more pairs than are ever reported,
+so holding them all would cost more memory than the analysis itself.
+
 Fragments larger than 500 nodes take a bounded heuristic path rather than exact
 APTED (`core/apted`: label/shape profile distance, capped key roots), so a
 single very large function cannot dominate a run.
@@ -85,7 +90,11 @@ fragment set, which are both held for the whole run:
   time. Restricting `--select` to fewer analyses reduces peak memory roughly in
   proportion.
 - Clone detection releases each fragment's parser AST as soon as its APTED tree
-  is built, so parse trees do not survive fragment preparation.
+  is built, so parse trees do not survive fragment preparation. This depends on
+  the tree converter not copying parser nodes into `TreeNode.OriginalNode`:
+  parser nodes carry a parent pointer, so retaining one pins the whole file's
+  AST. Clone-only peak memory over the 147k-line corpus is 709 MB with the
+  release effective, 942 MB without.
 
 Memory scales with source size, not with project history or file count.
 
@@ -185,8 +194,19 @@ Complexities below are in fragment count `n`, fragment size `m`, module count
 | Clone detection with LSH | O(n · candidates) verifications | Each verification is one APTED comparison |
 | Clone detection without LSH | O(n²) verifications | Exhaustive; the reason LSH auto-enables |
 | `core/graph` SCC | O(V + E) | Tarjan |
-| `core/graph` longest chain | O(V + E) | Condensation plus memoized DAG traversal — the longest simple path itself is NP-hard, so cycles are collapsed first |
+| `core/graph` longest chain | O(V + E) | Condensation plus memoized DAG traversal — see below |
 
 The last row is worth stating explicitly: dependency-chain reporting must never
 enumerate simple paths. On a real import graph with cycles, exhaustive
 enumeration does not terminate in practical time.
+
+What the chain guarantees, then, is that no other simple path crosses more
+strongly connected components — it is maximal in dependency layers. Components
+are weighted by module count when chains are compared, so a chain through a
+large cycle outranks an equally deep chain through single modules. Within a
+component the route is not guaranteed maximal: the component that ends the chain
+is walked greedily through as many members as it can reach, and components the
+chain passes through are crossed by the shortest route between the edges that
+enter and leave them. Recovering the longest route through a cycle is the
+NP-hard problem again. `MaxDepth` counts the edges of that concrete chain, so it
+is always a depth some real import path achieves.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,192 @@
+# Performance characteristics
+
+How jscan and the shared `core/` algorithms behave as a codebase grows, which
+knobs change that behaviour, and how to reproduce the numbers.
+
+## Where the time goes
+
+A default `jscan analyze` run executes five analyses concurrently:
+
+| Analysis | Dominant cost | Scaling |
+|---|---|---|
+| complexity | parse + CFG construction | linear in source size |
+| deadcode | parse + CFG construction + reachability | linear in source size |
+| cbo | parse + import/dependency extraction | linear in source size |
+| deps | parse + graph construction, SCC, chain search | linear in modules + edges |
+| clone | APTED tree edit distance over fragment pairs | **superlinear** — see below |
+
+Clone detection dominates every other analysis combined on any codebase past a
+few thousand lines. The other four are effectively "parse the files", and their
+throughput tracks parsing speed.
+
+### Clone detection is the one superlinear stage
+
+Clone detection compares code fragments pairwise. Exhaustively that is O(n²) in
+fragment count, with each comparison costing an APTED tree edit distance —
+itself roughly O(m²·keyroots) in fragment size.
+
+Two mechanisms keep this tractable:
+
+1. **LSH candidate generation.** Above 500 fragments (or `lsh.auto_threshold`
+   when a config file sets it), or when the estimated exhaustive pair count
+   exceeds the retained-pair cap, MinHash signatures and a banded LSH index
+   replace the full pairwise sweep with a candidate set. This turns the
+   quadratic sweep into roughly linear candidate generation plus verification of
+   the candidates only.
+2. **Cheap rejection before APTED.** Candidate pairs pass a MinHash similarity
+   estimate and a feature-Jaccard pre-filter before any tree edit distance is
+   computed. Only survivors reach APTED.
+
+Fragments larger than 500 nodes take a bounded heuristic path rather than exact
+APTED (`core/apted`: label/shape profile distance, capped key roots), so a
+single very large function cannot dominate a run.
+
+## Measured throughput
+
+Measured on an Apple M4 (10 cores) against
+[vuejs/core](https://github.com/vuejs/core) `packages/`, 147k lines of
+TypeScript across 452 files, all five analyses enabled, JSON output. Each figure
+is the median of three runs. The machine carried unrelated background load
+during measurement, so treat these as a floor rather than a best case.
+
+| Corpus | Lines | Wall time | Throughput | Peak RSS |
+|---|---|---|---|---|
+| `packages/reactivity/src` | 3.9k | 0.13 s | ~30k LOC/s | 83 MB |
+| `packages/compiler-core/src` | 11k | 0.32 s | ~34k LOC/s | 197 MB |
+| `packages/runtime-core/src` | 21k | 0.47 s | ~45k LOC/s | 300 MB |
+| `packages/` (whole repo) | 147k | 14.8 s | ~10k LOC/s | 1.84 GB |
+
+Throughput drops on the largest corpus because clone detection's candidate set
+grows faster than the source does — the other four analyses stay flat.
+
+Per-analysis figures on the full 147k-line corpus, measured in isolation
+(`BenchmarkPipeline*`, same loaded machine):
+
+| Analysis | Wall time | Throughput |
+|---|---|---|
+| complexity | 0.51 s | 291k LOC/s |
+| cbo | 0.77 s | 192k LOC/s |
+| deadcode | 0.76 s | 194k LOC/s |
+| deps | 0.89 s | 167k LOC/s |
+| clone | 11.6 s | 13k LOC/s |
+
+Clone detection is 90% of a default run. Dropping it with `--select` puts a
+147k-line codebase comfortably under two seconds.
+
+## Memory
+
+Peak resident memory is driven by the parse trees and the clone-detection
+fragment set, which are both held for the whole run:
+
+- Roughly **12–20 MB per 1k lines** of TypeScript at default settings, with the
+  ratio improving as the corpus grows.
+- 147k lines peaks around 1.84 GB; 100k lines fits under 2 GB.
+- Each analysis parses independently, so all five hold parse trees at the same
+  time. Restricting `--select` to fewer analyses reduces peak memory roughly in
+  proportion.
+- Clone detection releases each fragment's parser AST as soon as its APTED tree
+  is built, so parse trees do not survive fragment preparation.
+
+Memory scales with source size, not with project history or file count.
+
+Concurrency trades memory for time: several files are parsed at once, so more
+parse trees are live simultaneously than in a serial run. On small inputs this
+shows up as a higher peak (83 MB rather than 56 MB for a 3.9k-line package)
+against a 5× reduction in wall time.
+
+## Concurrency
+
+Work is parallelized at two levels, both bounded by `runtime.NumCPU()`:
+
+- **Across analyses.** The five analyses run concurrently
+  (`service.ParallelExecutorImpl`).
+- **Within an analysis.** Per-file read, parse, and analysis fan out across
+  workers (`service.analyzeFilesConcurrently`), and clone detection verifies
+  candidate pairs across workers.
+
+Results do not depend on scheduling. Per-file results are collected into
+preallocated per-path slots, and clone pairs are assembled on a single goroutine
+in candidate order, so pair IDs and clone identities are stable. A given input
+produces byte-identical output on every run.
+
+The practical consequence: wall time improves close to linearly with core count
+for the parse-bound analyses, and clone detection's verification stage scales the
+same way. Candidate *generation* (LSH indexing) remains single-threaded.
+
+## Tuning
+
+The single biggest lever is which analyses run at all:
+
+```bash
+jscan analyze --select complexity,deadcode,cbo,deps src/   # drops the dominant cost
+```
+
+The rest live in the TOML config (`.pyscn.toml` or `pyproject.toml`), largest
+effect first:
+
+| Setting | Key | Default | Effect |
+|---|---|---|---|
+| Fragment floor | `analysis.min_lines` | 5 | Raising it cuts fragment count, and comparison work falls with the square of that |
+| Fragment floor | `analysis.min_nodes` | 10 | Same, by AST size instead of line count |
+| LSH acceleration | `lsh.enabled` | `auto` | `false` forces the exhaustive O(n²) sweep — viable only for small trees |
+| LSH auto threshold | `lsh.auto_threshold` | 200 (500 with no config file) | Fragment count at which `auto` switches LSH on |
+| MinHash pre-filter | `lsh.similarity_threshold` | 0.50 | Raising it rejects more candidates before any APTED work |
+| LSH banding | `lsh.bands`, `lsh.rows`, `lsh.hashes` | 32 / 4 / 128 | More bands finds more candidates and costs more; more rows per band is stricter |
+
+Raising `analysis.min_lines` is usually the cheapest large win.
+
+## Reproducing the numbers
+
+End-to-end benchmarks run against a corpus you point them at, and skip when the
+environment variable is unset:
+
+```bash
+cd jscan
+JSCAN_BENCH_CORPUS=/path/to/js-or-ts-repo \
+  go test -run='^$' -bench=BenchmarkPipeline -benchmem -timeout=30m ./service/
+```
+
+Each benchmark reports `LOC/s` alongside the usual `ns/op` and allocation
+counts.
+
+Profiling the same corpus:
+
+```bash
+JSCAN_BENCH_CORPUS=/path/to/repo go test -run='^$' -bench=BenchmarkPipelineClone \
+  -benchtime=1x -cpuprofile=cpu.prof -memprofile=mem.prof -o service.test ./service/
+go tool pprof -http=:8080 service.test cpu.prof
+go tool pprof -sample_index=alloc_space -http=:8081 service.test mem.prof
+```
+
+Algorithm-level benchmarks, which need no corpus:
+
+```bash
+cd core
+go test -run='^$' -bench=. -benchmem ./apted/   # tree edit distance by tree size
+go test -run='^$' -bench=. -benchmem ./lsh/     # MinHash signing, LSH build and query
+```
+
+`core/apted` covers 100–5000 node trees on both the exact and the bounded
+large-tree path; `core/lsh` covers index construction at 1k/10k/100k fragments
+plus the dense-bucket case where many fragments hash alike.
+
+## Algorithmic notes
+
+Complexities below are in fragment count `n`, fragment size `m`, module count
+`V`, and import edge count `E`.
+
+| Component | Complexity | Notes |
+|---|---|---|
+| `core/apted` exact | O(m²·keyroots) per pair | Used below 500 nodes; per-node insert/delete costs are precomputed once per comparison rather than per DP cell |
+| `core/apted` large-tree | O(m) profile + capped DP | Bounded heuristic above 500 nodes, exact APTED above 2000 is not attempted |
+| `core/lsh` MinHash | O(numHashes · features) per fragment | 128 hashes by default |
+| `core/lsh` index build | O(bands) per fragment | Insert is constant-work per band; it does not scan the bucket |
+| `core/lsh` query | O(bands + candidates) | Capped by `maxCandidates` |
+| Clone detection with LSH | O(n · candidates) verifications | Each verification is one APTED comparison |
+| Clone detection without LSH | O(n²) verifications | Exhaustive; the reason LSH auto-enables |
+| `core/graph` SCC | O(V + E) | Tarjan |
+| `core/graph` longest chain | O(V + E) | Condensation plus memoized DAG traversal — the longest simple path itself is NP-hard, so cycles are collapsed first |
+
+The last row is worth stating explicitly: dependency-chain reporting must never
+enumerate simple paths. On a real import graph with cycles, exhaustive
+enumeration does not terminate in practical time.

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -98,10 +98,13 @@ fragment set, which are both held for the whole run:
 
 Memory scales with source size, not with project history or file count.
 
-Concurrency trades memory for time: several files are parsed at once, so more
-parse trees are live simultaneously than in a serial run. On small inputs this
-shows up as a higher peak (83 MB rather than 56 MB for a 3.9k-line package)
-against a 5× reduction in wall time.
+Concurrency trades memory for time, in two ways. Several files are parsed at
+once, so more parse trees are live simultaneously than in a serial run. And
+because per-file results are collected into per-path slots and aggregated after
+the fan-out finishes, every file's findings stay resident until the whole
+analysis is done, where a serial loop could release each file's results as it
+consumed them. On small inputs this shows up as a higher peak (83 MB rather than
+56 MB for a 3.9k-line package) against a 5× reduction in wall time.
 
 ## Concurrency
 
@@ -111,16 +114,24 @@ Work is parallelized at two levels, both bounded by `runtime.NumCPU()`:
   (`service.ParallelExecutorImpl`).
 - **Within an analysis.** Per-file read, parse, and analysis fan out across
   workers (`service.analyzeFilesConcurrently`), and clone detection verifies
-  candidate pairs across workers.
+  LSH candidate pairs across workers.
+
+Clone detection's verification is parallel only on the LSH path. Below the LSH
+auto-threshold the exhaustive sweep still runs on a single goroutine, so a
+project small enough to skip LSH uses one core for the dominant analysis. That
+sweep is quadratic but bounded, and it is fast in absolute terms — the cost
+model and APTED work described above is what made it usable.
 
 Results do not depend on scheduling. Per-file results are collected into
 preallocated per-path slots, and clone pairs are assembled on a single goroutine
 in candidate order, so pair IDs and clone identities are stable. A given input
-produces byte-identical output on every run.
+produces byte-identical output on every run. The one exception is a run that is
+cancelled part-way: workers abandon their remaining candidates wherever they
+happen to be, so partial output is not reproducible.
 
 The practical consequence: wall time improves close to linearly with core count
-for the parse-bound analyses, and clone detection's verification stage scales the
-same way. Candidate *generation* (LSH indexing) remains single-threaded.
+for the parse-bound analyses, and clone detection's LSH verification stage scales
+the same way. Candidate *generation* (LSH indexing) remains single-threaded.
 
 ## Tuning
 
@@ -130,8 +141,10 @@ The single biggest lever is which analyses run at all:
 jscan analyze --select complexity,deadcode,cbo,deps src/   # drops the dominant cost
 ```
 
-The rest live in the TOML config (`.pyscn.toml` or `pyproject.toml`), largest
-effect first:
+The rest live in the config file — jscan reads `jscan.config.json`,
+`.jscanrc.json`, and `.jscan.toml`, and falls back to `.pyscn.toml` or
+`pyproject.toml` for a shared polyscan setup. Keys below are given in their TOML
+form, largest effect first:
 
 | Setting | Key | Default | Effect |
 |---|---|---|---|
@@ -210,3 +223,18 @@ chain passes through are crossed by the shortest route between the edges that
 enter and leave them. Recovering the longest route through a cycle is the
 NP-hard problem again. `MaxDepth` counts the edges of that concrete chain, so it
 is always a depth some real import path achieves.
+
+### `MaxDepth` values changed
+
+Reported `deps` depth moved with this rewrite, and on graphs with cycles it
+moved down. The previous implementation combined memoization with a
+path-dependent cycle cutoff, which both made the result depend on traversal
+order and let a chain count an edge back into a node it had already visited. A
+graph that is one 30-module cycle reported a depth of 30; the longest simple
+path through 30 nodes has 29 edges, which is what it reports now.
+
+`MaxDepth` feeds `DependencyPenalty` in `core/domain/scoring.go`, so the
+dependency score and the overall grade can move with it — by at most 3 points
+out of 100, since the depth penalty is capped there. A project pinned to a
+health-score threshold in CI may therefore see its score shift slightly on the
+first run after upgrading, in either direction.

--- a/jscan/README.md
+++ b/jscan/README.md
@@ -171,7 +171,7 @@ Create a `jscan.config.json` or `.jscanrc.json` in your project root:
 
 ## Documentation
 
-📚 **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)** • **[Contributing](CONTRIBUTING.md)**
+📚 **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)** • **[Performance](../docs/performance.md)** • **[Contributing](CONTRIBUTING.md)**
 
 ## Enterprise Support
 

--- a/jscan/domain/clone.go
+++ b/jscan/domain/clone.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"strings"
 	"time"
 
 	coreclone "github.com/ludo-technologies/polyscan/core/clone"
@@ -115,6 +116,61 @@ func (cp *ClonePair) String() string {
 		cp.Clone1.Location.String(),
 		cp.Clone2.Location.String(),
 		cp.Similarity)
+}
+
+// ClonePairPrecedes orders two clone pairs by descending similarity, falling
+// back to source location so that pairs the similarity cannot separate still
+// come out in the same order on every run.
+//
+// The fallback is not cosmetic. Near-duplicate code produces large runs of
+// pairs at an identical similarity, and the result slice is truncated to
+// MaxClonePairs after sorting, so without a tie-break an unstable comparator
+// would decide which of those equal pairs survive the cut.
+func ClonePairPrecedes(a, b *ClonePair) bool {
+	if a.Similarity != b.Similarity {
+		return a.Similarity > b.Similarity
+	}
+	if order := compareCloneLocations(a.Clone1, b.Clone1); order != 0 {
+		return order < 0
+	}
+	return compareCloneLocations(a.Clone2, b.Clone2) < 0
+}
+
+// compareCloneLocations orders two clones by where they sit in the project,
+// which is unique per clone and independent of analysis scheduling. A clone
+// without a location sorts last so that a missing location cannot make the
+// comparator inconsistent.
+func compareCloneLocations(a, b *Clone) int {
+	locA, locB := cloneLocation(a), cloneLocation(b)
+	if locA == nil && locB == nil {
+		return 0
+	}
+	if locA == nil {
+		return 1
+	}
+	if locB == nil {
+		return -1
+	}
+
+	switch {
+	case locA.FilePath != locB.FilePath:
+		return strings.Compare(locA.FilePath, locB.FilePath)
+	case locA.StartLine != locB.StartLine:
+		return locA.StartLine - locB.StartLine
+	case locA.StartCol != locB.StartCol:
+		return locA.StartCol - locB.StartCol
+	case locA.EndLine != locB.EndLine:
+		return locA.EndLine - locB.EndLine
+	default:
+		return locA.EndCol - locB.EndCol
+	}
+}
+
+func cloneLocation(c *Clone) *CloneLocation {
+	if c == nil {
+		return nil
+	}
+	return c.Location
 }
 
 // CloneGroup represents a group of related clones

--- a/jscan/domain/domain_test.go
+++ b/jscan/domain/domain_test.go
@@ -519,3 +519,44 @@ func TestErrorCodeConstants(t *testing.T) {
 		}
 	}
 }
+
+// TestClonePairPrecedesBreaksTiesOnLocation pins the property the clone result
+// truncation depends on: pairs at an identical similarity must come out in a
+// fixed order, whatever order they were collected in.
+func TestClonePairPrecedesBreaksTiesOnLocation(t *testing.T) {
+	pair := func(file1 string, line1 int, file2 string, line2 int, similarity float64) *ClonePair {
+		return &ClonePair{
+			Clone1:     &Clone{Location: &CloneLocation{FilePath: file1, StartLine: line1}},
+			Clone2:     &Clone{Location: &CloneLocation{FilePath: file2, StartLine: line2}},
+			Similarity: similarity,
+		}
+	}
+
+	stronger, weaker := pair("a.ts", 1, "b.ts", 1, 0.9), pair("a.ts", 1, "b.ts", 1, 0.8)
+	if !ClonePairPrecedes(stronger, weaker) || ClonePairPrecedes(weaker, stronger) {
+		t.Error("a higher similarity must sort first")
+	}
+
+	// Equal similarity: the first clone's location decides, then the second's.
+	early, late := pair("a.ts", 10, "z.ts", 1, 0.85), pair("b.ts", 2, "c.ts", 1, 0.85)
+	if !ClonePairPrecedes(early, late) || ClonePairPrecedes(late, early) {
+		t.Error("equal similarity must fall back to the first clone's file path")
+	}
+
+	sameFirst, sameFirstLater := pair("a.ts", 1, "b.ts", 1, 0.85), pair("a.ts", 1, "b.ts", 9, 0.85)
+	if !ClonePairPrecedes(sameFirst, sameFirstLater) || ClonePairPrecedes(sameFirstLater, sameFirst) {
+		t.Error("a shared first clone must fall back to the second clone's location")
+	}
+
+	// A pair equal on every field precedes neither, or sorting is inconsistent.
+	duplicate := pair("a.ts", 1, "b.ts", 1, 0.85)
+	if ClonePairPrecedes(sameFirst, duplicate) || ClonePairPrecedes(duplicate, sameFirst) {
+		t.Error("identical pairs must not precede each other")
+	}
+
+	// A missing location must not make the comparator inconsistent.
+	located, unlocated := pair("a.ts", 1, "b.ts", 1, 0.85), &ClonePair{Similarity: 0.85}
+	if !ClonePairPrecedes(located, unlocated) || ClonePairPrecedes(unlocated, located) {
+		t.Error("a pair without a location must sort last")
+	}
+}

--- a/jscan/internal/analyzer/apted_cost.go
+++ b/jscan/internal/analyzer/apted_cost.go
@@ -44,6 +44,110 @@ func NewJavaScriptCostModelWithConfig(ignoreLiterals, ignoreIdentifiers bool) *J
 	}
 }
 
+// nodeCategory classifies a node label into the cost tiers this model prices.
+// Labels are looked up rather than prefix-scanned because APTED evaluates the
+// cost model once per node per comparison, across millions of comparisons.
+type nodeCategory int
+
+const (
+	categoryOther nodeCategory = iota
+	categoryStructural
+	categoryControlFlow
+	categoryExpression
+	categoryLiteral
+	categoryIdentifier
+)
+
+// Cost multipliers per category. Structural and control-flow nodes carry the
+// shape of the program, so editing them is priced above the default; expression
+// nodes below it. Literals and identifiers are only discounted when the caller
+// asked for them to be ignored.
+const (
+	structuralMultiplier        = 1.5
+	controlFlowMultiplier       = 1.3
+	expressionMultiplier        = 0.8
+	ignoredLiteralMultiplier    = 0.1
+	ignoredIdentifierMultiplier = 0.2
+	defaultMultiplier           = 1.0
+)
+
+// Label similarity tiers, from identical base type down to no relation.
+const (
+	sameBaseTypeSimilarity = 0.8
+	relatedTypeSimilarity  = 0.5
+	sameCategorySimilarity = 0.3
+	unrelatedSimilarity    = 0.0
+)
+
+// nodeCategories maps a node label's base type to its category. Categories are
+// disjoint and looked up in the order the cost tiers are defined.
+var nodeCategories = buildNodeCategories()
+
+func buildNodeCategories() map[string]nodeCategory {
+	categories := map[string]nodeCategory{}
+	add := func(category nodeCategory, labels ...string) {
+		for _, label := range labels {
+			categories[label] = category
+		}
+	}
+
+	add(categoryStructural,
+		"FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression",
+		"AsyncFunctionDeclaration", "GeneratorFunctionDeclaration",
+		"ClassDeclaration", "ClassExpression", "MethodDefinition",
+		"Program", "Module")
+	add(categoryControlFlow,
+		"IfStatement", "SwitchStatement", "SwitchCase",
+		"ForStatement", "ForInStatement", "ForOfStatement",
+		"WhileStatement", "DoWhileStatement",
+		"TryStatement", "CatchClause", "FinallyClause",
+		"BreakStatement", "ContinueStatement", "ReturnStatement", "ThrowStatement")
+	add(categoryExpression,
+		"BinaryExpression", "UnaryExpression", "LogicalExpression",
+		"ConditionalExpression", "CallExpression", "MemberExpression",
+		"AssignmentExpression", "UpdateExpression", "NewExpression",
+		"ArrayExpression", "ObjectExpression", "SequenceExpression",
+		"AwaitExpression", "YieldExpression", "SpreadElement",
+		"TemplateLiteral")
+	add(categoryLiteral,
+		"StringLiteral", "NumberLiteral", "BooleanLiteral",
+		"NullLiteral", "RegExpLiteral")
+
+	return categories
+}
+
+// parenthesizedCategories maps the base types that are only meaningful when the
+// label carries a parenthesized detail, as produced by TreeConverter.getNodeLabel
+// (for example "Function(name)" or "Identifier(name)").
+var parenthesizedCategories = map[string]nodeCategory{
+	"Function":   categoryStructural,
+	"Class":      categoryStructural,
+	"Literal":    categoryLiteral,
+	"Identifier": categoryIdentifier,
+}
+
+// splitLabel separates a label's base node type from its parenthesized detail.
+func splitLabel(label string) (baseType string, hasDetail bool) {
+	if idx := strings.Index(label, "("); idx >= 0 {
+		return label[:idx], true
+	}
+	return label, false
+}
+
+// categoryOf classifies a full node label.
+func categoryOf(label string) nodeCategory {
+	baseType, hasDetail := splitLabel(label)
+	if category, ok := nodeCategories[baseType]; ok {
+		return category
+	}
+	if hasDetail {
+		if category, ok := parenthesizedCategories[baseType]; ok {
+			return category
+		}
+	}
+	return categoryOther
+}
+
 // Insert returns the cost of inserting a node
 func (c *JavaScriptCostModel) Insert(node *apted.TreeNode) float64 {
 	if node == nil {
@@ -91,114 +195,37 @@ func (c *JavaScriptCostModel) Rename(node1, node2 *apted.TreeNode) float64 {
 
 // getNodeTypeMultiplier returns a cost multiplier based on the node type
 func (c *JavaScriptCostModel) getNodeTypeMultiplier(label string) float64 {
-	// Structural nodes are more expensive to modify
-	if c.isStructuralNode(label) {
-		return 1.5
-	}
-
-	// Control flow nodes are expensive
-	if c.isControlFlowNode(label) {
-		return 1.3
-	}
-
-	// Expression nodes are less expensive
-	if c.isExpressionNode(label) {
-		return 0.8
-	}
-
-	// Literals and identifiers can be very cheap if configured to ignore
-	if c.isLiteralNode(label) && c.IgnoreLiterals {
-		return 0.1
-	}
-
-	if c.isIdentifierNode(label) && c.IgnoreIdentifiers {
-		return 0.2
-	}
-
-	return 1.0 // Default multiplier
-}
-
-// isStructuralNode checks if a node represents a structural element
-func (c *JavaScriptCostModel) isStructuralNode(label string) bool {
-	structuralNodes := []string{
-		"FunctionDeclaration", "FunctionExpression", "ArrowFunctionExpression",
-		"AsyncFunctionDeclaration", "GeneratorFunctionDeclaration",
-		"ClassDeclaration", "ClassExpression", "MethodDefinition",
-		"Program", "Module",
-	}
-
-	for _, nodeType := range structuralNodes {
-		if strings.HasPrefix(label, nodeType) || strings.HasPrefix(label, "Function(") || strings.HasPrefix(label, "Class(") {
-			return true
+	switch categoryOf(label) {
+	case categoryStructural:
+		return structuralMultiplier
+	case categoryControlFlow:
+		return controlFlowMultiplier
+	case categoryExpression:
+		return expressionMultiplier
+	case categoryLiteral:
+		if c.IgnoreLiterals {
+			return ignoredLiteralMultiplier
+		}
+	case categoryIdentifier:
+		if c.IgnoreIdentifiers {
+			return ignoredIdentifierMultiplier
 		}
 	}
 
-	return false
-}
-
-// isControlFlowNode checks if a node represents a control flow element
-func (c *JavaScriptCostModel) isControlFlowNode(label string) bool {
-	controlFlowNodes := []string{
-		"IfStatement", "SwitchStatement", "SwitchCase",
-		"ForStatement", "ForInStatement", "ForOfStatement",
-		"WhileStatement", "DoWhileStatement",
-		"TryStatement", "CatchClause", "FinallyClause",
-		"BreakStatement", "ContinueStatement", "ReturnStatement", "ThrowStatement",
-	}
-
-	for _, nodeType := range controlFlowNodes {
-		if strings.HasPrefix(label, nodeType) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isExpressionNode checks if a node represents an expression
-func (c *JavaScriptCostModel) isExpressionNode(label string) bool {
-	expressionNodes := []string{
-		"BinaryExpression", "UnaryExpression", "LogicalExpression",
-		"ConditionalExpression", "CallExpression", "MemberExpression",
-		"AssignmentExpression", "UpdateExpression", "NewExpression",
-		"ArrayExpression", "ObjectExpression", "SequenceExpression",
-		"AwaitExpression", "YieldExpression", "SpreadElement",
-		"TemplateLiteral",
-	}
-
-	for _, nodeType := range expressionNodes {
-		if strings.HasPrefix(label, nodeType) {
-			return true
-		}
-	}
-
-	return false
-}
-
-// isLiteralNode checks if a node represents a literal value
-func (c *JavaScriptCostModel) isLiteralNode(label string) bool {
-	return strings.HasPrefix(label, "Literal(") ||
-		strings.HasPrefix(label, "StringLiteral") ||
-		strings.HasPrefix(label, "NumberLiteral") ||
-		strings.HasPrefix(label, "BooleanLiteral") ||
-		strings.HasPrefix(label, "NullLiteral") ||
-		strings.HasPrefix(label, "RegExpLiteral")
-}
-
-// isIdentifierNode checks if a node represents an identifier
-func (c *JavaScriptCostModel) isIdentifierNode(label string) bool {
-	return strings.HasPrefix(label, "Identifier(")
+	return defaultMultiplier
 }
 
 // shouldIgnoreDifference determines if the difference between two labels should be ignored
 func (c *JavaScriptCostModel) shouldIgnoreDifference(label1, label2 string) bool {
+	category1, category2 := categoryOf(label1), categoryOf(label2)
+
 	// Ignore literal differences if configured
-	if c.IgnoreLiterals && c.isLiteralNode(label1) && c.isLiteralNode(label2) {
+	if c.IgnoreLiterals && category1 == categoryLiteral && category2 == categoryLiteral {
 		return true
 	}
 
 	// Ignore identifier differences if configured
-	if c.IgnoreIdentifiers && c.isIdentifierNode(label1) && c.isIdentifierNode(label2) {
+	if c.IgnoreIdentifiers && category1 == categoryIdentifier && category2 == categoryIdentifier {
 		return true
 	}
 
@@ -208,38 +235,34 @@ func (c *JavaScriptCostModel) shouldIgnoreDifference(label1, label2 string) bool
 // calculateLabelSimilarity calculates similarity between two node labels
 func (c *JavaScriptCostModel) calculateLabelSimilarity(label1, label2 string) float64 {
 	// Extract base node types (remove parenthetical content)
-	baseType1 := c.extractBaseNodeType(label1)
-	baseType2 := c.extractBaseNodeType(label2)
+	baseType1, _ := splitLabel(label1)
+	baseType2, _ := splitLabel(label2)
 
 	// If base types are identical, high similarity
 	if baseType1 == baseType2 {
-		return 0.8
+		return sameBaseTypeSimilarity
 	}
 
 	// Check for related node types
-	if c.areRelatedNodeTypes(baseType1, baseType2) {
-		return 0.5
+	if areRelatedNodeTypes(baseType1, baseType2) {
+		return relatedTypeSimilarity
 	}
 
 	// Check for same category
-	if c.areSameCategory(baseType1, baseType2) {
-		return 0.3
+	if areSameCategory(baseType1, baseType2) {
+		return sameCategorySimilarity
 	}
 
-	return 0.0 // No similarity
+	return unrelatedSimilarity
 }
 
-// extractBaseNodeType extracts the base node type from a label
-func (c *JavaScriptCostModel) extractBaseNodeType(label string) string {
-	if idx := strings.Index(label, "("); idx != -1 {
-		return label[:idx]
-	}
-	return label
-}
+// relatedNodeTypes pairs node types that express the same construct in
+// different syntactic forms, so renaming between them is cheaper than renaming
+// across unrelated types.
+var relatedNodeTypes = buildRelatedNodeTypes()
 
-// areRelatedNodeTypes checks if two node types are related
-func (c *JavaScriptCostModel) areRelatedNodeTypes(type1, type2 string) bool {
-	relatedPairs := [][2]string{
+func buildRelatedNodeTypes() map[[2]string]struct{} {
+	pairs := [][2]string{
 		{"FunctionDeclaration", "FunctionExpression"},
 		{"FunctionDeclaration", "ArrowFunctionExpression"},
 		{"FunctionExpression", "ArrowFunctionExpression"},
@@ -255,28 +278,33 @@ func (c *JavaScriptCostModel) areRelatedNodeTypes(type1, type2 string) bool {
 		{"IfStatement", "ConditionalExpression"},
 	}
 
-	for _, pair := range relatedPairs {
-		if (type1 == pair[0] && type2 == pair[1]) || (type1 == pair[1] && type2 == pair[0]) {
-			return true
-		}
+	related := make(map[[2]string]struct{}, len(pairs)*2)
+	for _, pair := range pairs {
+		related[pair] = struct{}{}
+		related[[2]string{pair[1], pair[0]}] = struct{}{}
 	}
-
-	return false
+	return related
 }
 
-// areSameCategory checks if two node types belong to the same category
-func (c *JavaScriptCostModel) areSameCategory(type1, type2 string) bool {
-	if c.isStructuralNode(type1) && c.isStructuralNode(type2) {
-		return true
+// areRelatedNodeTypes checks if two node types are related
+func areRelatedNodeTypes(type1, type2 string) bool {
+	_, ok := relatedNodeTypes[[2]string{type1, type2}]
+	return ok
+}
+
+// areSameCategory checks if two node types belong to the same category.
+// Literals and identifiers are excluded: their categories only carry a discount
+// when the caller opted into ignoring them, not a claim of structural kinship.
+func areSameCategory(type1, type2 string) bool {
+	category1, category2 := categoryOf(type1), categoryOf(type2)
+	if category1 != category2 {
+		return false
 	}
 
-	if c.isControlFlowNode(type1) && c.isControlFlowNode(type2) {
+	switch category1 {
+	case categoryStructural, categoryControlFlow, categoryExpression:
 		return true
+	default:
+		return false
 	}
-
-	if c.isExpressionNode(type1) && c.isExpressionNode(type2) {
-		return true
-	}
-
-	return false
 }

--- a/jscan/internal/analyzer/apted_test.go
+++ b/jscan/internal/analyzer/apted_test.go
@@ -88,8 +88,11 @@ func TestTreeConverterConvertAST(t *testing.T) {
 	if tree.Label != "VariableDeclaration(const)" {
 		t.Fatalf("root label = %q", tree.Label)
 	}
-	if tree.OriginalNode != root {
-		t.Fatal("converter did not retain the original parser node")
+	// The converter must not pin the parser node: parser nodes carry a parent
+	// pointer, so retaining one would keep the whole file AST alive for as long
+	// as clone detection holds the converted tree.
+	if tree.OriginalNode != nil {
+		t.Fatal("converter retained the parser node, pinning the source AST")
 	}
 	if len(tree.Children) != 1 || tree.Children[0].Label != "Identifier(answer)" {
 		t.Fatalf("converted children = %#v", tree.Children)

--- a/jscan/internal/analyzer/apted_tree.go
+++ b/jscan/internal/analyzer/apted_tree.go
@@ -28,8 +28,10 @@ func (tc *TreeConverter) ConvertAST(astNode *parser.Node) *apted.TreeNode {
 	treeNode := apted.NewTreeNode(tc.nextID, label)
 	tc.nextID++
 
-	// Store reference to original AST node
-	treeNode.OriginalNode = astNode
+	// TreeNode.OriginalNode is deliberately left empty. Nothing in jscan reads
+	// back the parser node, and because parser nodes carry a parent pointer,
+	// storing one on every converted node would pin whole file ASTs in memory
+	// for as long as clone detection holds the trees.
 
 	for _, child := range parser.OrderedChildren(astNode) {
 		if childNode := tc.ConvertAST(child); childNode != nil {

--- a/jscan/internal/analyzer/clone_detector.go
+++ b/jscan/internal/analyzer/clone_detector.go
@@ -433,12 +433,17 @@ func isCancelled(ctx context.Context) bool {
 	}
 }
 
-// DetectClones detects clones in the given code fragments
+// DetectClones detects clones in the given code fragments.
+//
+// The fragments are consumed, not just read: each one's ASTNode is released
+// once its APTED tree exists, so callers must not read CodeFragment.ASTNode
+// after handing fragments to a detector. See prepareFragments.
 func (cd *CloneDetector) DetectClones(fragments []*CodeFragment) ([]*domain.ClonePair, []*domain.CloneGroup) {
 	return cd.DetectClonesWithContext(context.Background(), fragments)
 }
 
-// DetectClonesWithContext detects clones with context support for cancellation
+// DetectClonesWithContext detects clones with context support for cancellation.
+// It consumes the fragments' ASTNode references; see DetectClones.
 func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments []*CodeFragment) ([]*domain.ClonePair, []*domain.CloneGroup) {
 	cd.fragments = fragments
 	cd.clonePairs = []*domain.ClonePair{}
@@ -487,6 +492,7 @@ func (cd *CloneDetector) DetectClonesWithContext(ctx context.Context, fragments 
 
 // DetectClonesWithLSH runs a two-stage pipeline using LSH for candidate generation,
 // followed by APTED verification on candidates only. Falls back to exhaustive if misconfigured.
+// It consumes the fragments' ASTNode references; see DetectClones.
 func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*CodeFragment) ([]*domain.ClonePair, []*domain.CloneGroup) {
 	// If not enabled, delegate to standard path
 	if cd == nil || !cd.cloneDetectorConfig.UseLSH {
@@ -896,6 +902,12 @@ const candidateChunkSize = 1 << 16
 // worker goroutines, then appends the surviving pairs to pairs on a single
 // goroutine in candidate order. Pair IDs and clone identities therefore do not
 // depend on how the work was scheduled or on how candidates were chunked.
+//
+// That guarantee covers runs that finish. A worker that observes a cancelled
+// context abandons the rest of its stripe while other workers may still be
+// completing theirs, so the partial results of a cancelled run do depend on
+// scheduling. Callers that surface partial output must not present it as
+// reproducible.
 func (cd *CloneDetector) verifyCandidates(ctx context.Context, candidates [][2]int, pairs []*domain.ClonePair) []*domain.ClonePair {
 	if len(candidates) == 0 {
 		return pairs
@@ -1116,9 +1128,12 @@ func (cd *CloneDetector) tryCreateClonePair(i, j int, minSimilarity float64, pai
 
 // limitAndSortClonePairs ensures final results are sorted and limited
 func (cd *CloneDetector) limitAndSortClonePairs(maxPairs int) {
-	// Sort clone pairs by similarity (descending)
+	// Sort clone pairs by similarity (descending), breaking ties on source
+	// location. The truncation below makes the tie-break load-bearing: without
+	// it, which of a run of equally similar pairs survives the cut would depend
+	// on the order candidates happened to be generated in.
 	sort.Slice(cd.clonePairs, func(i, j int) bool {
-		return cd.clonePairs[i].Similarity > cd.clonePairs[j].Similarity
+		return domain.ClonePairPrecedes(cd.clonePairs[i], cd.clonePairs[j])
 	})
 
 	// Limit the number of pairs to prevent memory issues

--- a/jscan/internal/analyzer/clone_detector.go
+++ b/jscan/internal/analyzer/clone_detector.go
@@ -2,11 +2,13 @@ package analyzer
 
 import (
 	"bytes"
+	"container/heap"
 	"context"
 	"fmt"
 	"math"
 	"runtime"
 	"sort"
+	"sync"
 
 	"github.com/ludo-technologies/polyscan/core/apted"
 	coreclone "github.com/ludo-technologies/polyscan/core/clone"
@@ -160,6 +162,10 @@ type CloneDetector struct {
 	// Embed config fields (private to maintain encapsulation)
 	cloneDetectorConfig CloneDetectorConfig
 
+	// costModel is retained so per-worker analyzers can be created during
+	// concurrent verification; APTED analyzers own mutable scratch buffers and
+	// cannot be shared, while the cost model is read-only.
+	costModel        apted.CostModel
 	analyzer         *apted.APTEDAnalyzer
 	converter        *TreeConverter
 	textualAnalyzer  *coreclone.TextualSimilarityAnalyzer
@@ -208,6 +214,7 @@ func NewCloneDetector(config *CloneDetectorConfig) *CloneDetector {
 
 	return &CloneDetector{
 		cloneDetectorConfig: *config,
+		costModel:           costModel,
 		analyzer:            analyzer,
 		converter:           NewTreeConverter(),
 		textualAnalyzer:     textualAnalyzer,
@@ -412,6 +419,10 @@ func (cd *CloneDetector) shouldIncludeFragment(fragment *CodeFragment) bool {
 	return true
 }
 
+// cancellationCheckInterval is how many comparisons run between context checks.
+// Checking a context is cheap but not free, and comparisons are short.
+const cancellationCheckInterval = 10
+
 // isCancelled checks if the context is cancelled
 func isCancelled(ctx context.Context) bool {
 	select {
@@ -537,14 +548,14 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		minhashThreshold = 1
 	}
 
+	// Stage 3a: collect the candidate pairs that survive the cheap filters.
 	seenPairs := make(map[[2]int]struct{})
-	pairID := 0
+	var candidates [][2]int
 	for _, r := range records {
 		if isCancelled(ctx) {
 			break
 		}
-		cands := lsh.FindCandidates(r.sig)
-		for _, j := range cands {
+		for _, j := range lsh.FindCandidates(r.sig) {
 			i := r.idx
 			if j == i || j < 0 || i < 0 {
 				continue
@@ -565,26 +576,21 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 			if cd.isOverlappingLocation(f1.Location, f2.Location) {
 				continue
 			}
-
-			// MinHash similarity pre-filter
-			sig1 := sigByIndex[a]
-			sig2 := sigByIndex[b]
-			est := hasher.EstimateJaccardSimilarity(sig1, sig2)
-			if est < minhashThreshold {
-				continue
-			}
-
-			// APTED verification
 			if f1.TreeNode == nil || f2.TreeNode == nil {
 				continue
 			}
-			pair := cd.compareFragments(f1, f2, pairID)
-			if pair != nil && cd.isSignificantClone(pair) {
-				cd.clonePairs = append(cd.clonePairs, pair)
-				pairID++
+
+			// MinHash similarity pre-filter
+			if hasher.EstimateJaccardSimilarity(sigByIndex[a], sigByIndex[b]) < minhashThreshold {
+				continue
 			}
+
+			candidates = append(candidates, key)
 		}
 	}
+
+	// Stage 3b: APTED verification, the expensive stage, across workers.
+	cd.clonePairs = cd.verifyCandidates(ctx, candidates)
 
 	// Finalize results
 	cd.limitAndSortClonePairs(cd.cloneDetectorConfig.MaxClonePairs)
@@ -618,6 +624,11 @@ func (cd *CloneDetector) prepareFragments() {
 		if fragment.TreeNode == nil {
 			continue
 		}
+		// Nothing downstream reads the parser AST once the APTED tree exists,
+		// and fragments hold it for the whole run. Releasing it here lets the
+		// parse trees of already-converted files be collected while later
+		// files are still being prepared.
+		fragment.ASTNode = nil
 		apted.PrepareTreeForAPTED(fragment.TreeNode)
 		features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
 		fragment.Features = features
@@ -662,14 +673,13 @@ func (cd *CloneDetector) detectClonePairsWithContext(ctx context.Context) {
 // detectClonePairsStandardWithContext uses standard approach with context
 func (cd *CloneDetector) detectClonePairsStandardWithContext(ctx context.Context) {
 	n := len(cd.fragments)
-	const checkInterval = 10 // Check context every 10 comparisons
 
 	pairID := 0
 	for i := 0; i < n; i++ {
 		for j := i + 1; j < n; j++ {
 
-			// Check for cancellation periodically (every 10 comparisons)
-			if (i*n+j)%checkInterval == 0 && isCancelled(ctx) {
+			// Check for cancellation periodically
+			if (i*n+j)%cancellationCheckInterval == 0 && isCancelled(ctx) {
 				return
 			}
 			fragment1 := cd.fragments[i]
@@ -702,16 +712,30 @@ func (cd *CloneDetector) detectClonePairsWithBatchingContext(ctx context.Context
 		batchSize = 100
 	}
 
-	// Priority queue to keep only the best pairs
-	topPairs := make([]*domain.ClonePair, 0, maxPairs)
+	// Keep only the best pairs, in a heap ordered by ascending similarity so the
+	// weakest pair — the one a new pair has to beat — is always at the root.
+	topPairs := &weakestFirstPairs{pairs: make([]*domain.ClonePair, 0, maxPairs)}
 	minSimilarity := cd.cloneDetectorConfig.Type4Threshold // Use the lowest threshold as minimum
 
 	pairID := 0
+	record := func(pair *domain.ClonePair) {
+		if pair == nil {
+			return
+		}
+		topPairs.push(pair, maxPairs)
+		pairID++
+		// Once the heap is full, only pairs stronger than its weakest member can
+		// still make the cut, so raise the bar for later comparisons.
+		if topPairs.Len() >= maxPairs {
+			minSimilarity = topPairs.weakest().Similarity
+		}
+	}
+
 	// Process in batches to limit memory usage
 	for batchStart := 0; batchStart < n; batchStart += batchSize {
 		// Check for cancellation at batch start
 		if isCancelled(ctx) {
-			cd.clonePairs = topPairs
+			cd.clonePairs = topPairs.pairs
 			return
 		}
 		batchEnd := batchStart + batchSize
@@ -723,86 +747,179 @@ func (cd *CloneDetector) detectClonePairsWithBatchingContext(ctx context.Context
 		for i := batchStart; i < batchEnd; i++ {
 			// Compare with fragments in current batch
 			for j := i + 1; j < batchEnd; j++ {
-				if pair := cd.tryCreateClonePair(i, j, minSimilarity, pairID); pair != nil {
-					topPairs = cd.addPairWithLimit(topPairs, pair, maxPairs)
-					pairID++
-					// Update minimum similarity threshold
-					if len(topPairs) >= maxPairs {
-						minSimilarity = topPairs[len(topPairs)-1].Similarity
-					}
-				}
+				record(cd.tryCreateClonePair(i, j, minSimilarity, pairID))
 			}
 
 			// Compare with all previous fragments
 			for j := 0; j < batchStart; j++ {
-				if pair := cd.tryCreateClonePair(i, j, minSimilarity, pairID); pair != nil {
-					topPairs = cd.addPairWithLimit(topPairs, pair, maxPairs)
-					pairID++
-					// Update minimum similarity threshold
-					if len(topPairs) >= maxPairs {
-						minSimilarity = topPairs[len(topPairs)-1].Similarity
-					}
-				}
+				record(cd.tryCreateClonePair(i, j, minSimilarity, pairID))
 			}
-		}
-
-		// Periodic garbage collection hint for large batches
-		if batchStart%5000 == 0 {
-			// Force garbage collection to prevent memory buildup
-			runtime.GC()
 		}
 	}
 
 	// Replace clone pairs with the best ones found
-	cd.clonePairs = topPairs
+	cd.clonePairs = topPairs.pairs
 }
 
-// compareFragments compares two fragments and returns a clone pair if similar.
+// weakestFirstPairs is a bounded min-heap of clone pairs keyed on similarity.
+// Keeping the top N pairs by re-sorting on every insert costs O(N log N) per
+// accepted pair; a heap makes it O(log N).
+type weakestFirstPairs struct {
+	pairs []*domain.ClonePair
+}
+
+func (h *weakestFirstPairs) Len() int { return len(h.pairs) }
+
+func (h *weakestFirstPairs) Less(i, j int) bool {
+	return h.pairs[i].Similarity < h.pairs[j].Similarity
+}
+
+func (h *weakestFirstPairs) Swap(i, j int) { h.pairs[i], h.pairs[j] = h.pairs[j], h.pairs[i] }
+
+func (h *weakestFirstPairs) Push(x any) { h.pairs = append(h.pairs, x.(*domain.ClonePair)) }
+
+func (h *weakestFirstPairs) Pop() any {
+	last := len(h.pairs) - 1
+	pair := h.pairs[last]
+	h.pairs = h.pairs[:last]
+	return pair
+}
+
+// weakest returns the lowest-similarity pair currently retained.
+func (h *weakestFirstPairs) weakest() *domain.ClonePair { return h.pairs[0] }
+
+// push adds a pair, evicting the weakest one when the heap is already at limit
+// and the newcomer is stronger.
+func (h *weakestFirstPairs) push(pair *domain.ClonePair, limit int) {
+	if len(h.pairs) < limit {
+		heap.Push(h, pair)
+		return
+	}
+	if pair.Similarity > h.weakest().Similarity {
+		h.pairs[0] = pair
+		heap.Fix(h, 0)
+	}
+}
+
+// clonePairMeasurement is what comparing two fragments yields, before the
+// detector assigns clone identities and pair IDs. Keeping measurement separate
+// from that bookkeeping is what lets comparisons run concurrently.
+type clonePairMeasurement struct {
+	distance   float64
+	similarity float64
+	cloneType  domain.CloneType
+	confidence float64
+}
+
+// measureFragments compares two fragments with the given APTED analyzer and
+// reports whether they form a clone pair. It touches no detector state, so
+// callers may run it concurrently as long as each has its own analyzer.
 // Uses a Jaccard pre-filter on pre-computed features to minimize expensive APTED calls.
-func (cd *CloneDetector) compareFragments(fragment1, fragment2 *CodeFragment, pairID int) *domain.ClonePair {
+func (cd *CloneDetector) measureFragments(analyzer *apted.APTEDAnalyzer, fragment1, fragment2 *CodeFragment) (clonePairMeasurement, bool) {
 	if fragment1.TreeNode == nil || fragment2.TreeNode == nil {
-		return nil
+		return clonePairMeasurement{}, false
 	}
 
 	// Early filtering check
 	coreFragment1, coreFragment2 := toCoreFragment(fragment1, 0), toCoreFragment(fragment2, 1)
 	if !coreclone.ShouldCompareFragments(coreFragment1, coreFragment2) {
-		return nil
+		return clonePairMeasurement{}, false
 	}
 
 	// Jaccard pre-filter: reject clear non-clones before expensive APTED work.
 	// Only used for rejection — all non-rejected pairs proceed to APTED-based
 	// classification for accurate clone typing and distance computation.
 	if !cd.pairClassifier.PassesJaccardPreFilter(coreFragment1, coreFragment2) {
-		return nil
+		return clonePairMeasurement{}, false
 	}
 
 	// Compute edit distance and similarity using APTED algorithm
-	distance, similarity := cd.analyzer.ComputeDistanceAndSimilarity(fragment1.TreeNode, fragment2.TreeNode)
+	distance, similarity := analyzer.ComputeDistanceAndSimilarity(fragment1.TreeNode, fragment2.TreeNode)
 
 	// Determine clone type with textual/syntactic gating
 	coreType, similarity := cd.pairClassifier.ClassifyPair(coreFragment1, coreFragment2, similarity)
 	cloneType := domain.CloneType(coreType)
 	if cloneType == 0 {
-		return nil // Not a significant clone
+		return clonePairMeasurement{}, false // Not a significant clone
 	}
 
-	// Calculate confidence based on fragment size and similarity
-	confidence := coreclone.CalculateConfidence(coreFragment1, coreFragment2, similarity)
+	return clonePairMeasurement{
+		distance:   distance,
+		similarity: similarity,
+		cloneType:  cloneType,
+		// Calculate confidence based on fragment size and similarity
+		confidence: coreclone.CalculateConfidence(coreFragment1, coreFragment2, similarity),
+	}, true
+}
 
-	// Create domain Clone objects (shared per fragment across pairs)
-	clone1 := cd.fragmentToClone(fragment1)
-	clone2 := cd.fragmentToClone(fragment2)
+// compareFragments compares two fragments and returns a clone pair if similar.
+func (cd *CloneDetector) compareFragments(fragment1, fragment2 *CodeFragment, pairID int) *domain.ClonePair {
+	measurement, ok := cd.measureFragments(cd.analyzer, fragment1, fragment2)
+	if !ok {
+		return nil
+	}
+	return cd.buildClonePair(measurement, fragment1, fragment2, pairID)
+}
 
+// buildClonePair attaches clone identities to a measurement. The same fragment
+// always maps to the same clone, so this must run on a single goroutine.
+func (cd *CloneDetector) buildClonePair(measurement clonePairMeasurement, fragment1, fragment2 *CodeFragment, pairID int) *domain.ClonePair {
 	return &domain.ClonePair{
 		ID:         pairID,
-		Clone1:     clone1,
-		Clone2:     clone2,
-		Similarity: similarity,
-		Distance:   distance,
-		Type:       cloneType,
-		Confidence: confidence,
+		Clone1:     cd.fragmentToClone(fragment1),
+		Clone2:     cd.fragmentToClone(fragment2),
+		Similarity: measurement.similarity,
+		Distance:   measurement.distance,
+		Type:       measurement.cloneType,
+		Confidence: measurement.confidence,
 	}
+}
+
+// verifyCandidates runs APTED verification over candidate fragment pairs across
+// worker goroutines, then assembles the surviving pairs on a single goroutine in
+// candidate order. Pair IDs and clone identities therefore do not depend on how
+// the work was scheduled.
+func (cd *CloneDetector) verifyCandidates(ctx context.Context, candidates [][2]int) []*domain.ClonePair {
+	measurements := make([]clonePairMeasurement, len(candidates))
+	accepted := make([]bool, len(candidates))
+
+	workers := runtime.NumCPU()
+	if workers > len(candidates) {
+		workers = len(candidates)
+	}
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			// Each worker needs its own analyzer: APTED reuses scratch buffers
+			// across comparisons.
+			analyzer := apted.NewAPTEDAnalyzerWithNormalization(cd.costModel, apted.NormalizeByMax)
+			for index := offset; index < len(candidates); index += workers {
+				if index%cancellationCheckInterval == 0 && isCancelled(ctx) {
+					return
+				}
+				pair := candidates[index]
+				measurements[index], accepted[index] = cd.measureFragments(
+					analyzer, cd.fragments[pair[0]], cd.fragments[pair[1]])
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	pairs := make([]*domain.ClonePair, 0, len(candidates))
+	for index, candidate := range candidates {
+		if !accepted[index] {
+			continue
+		}
+		fragment1, fragment2 := cd.fragments[candidate[0]], cd.fragments[candidate[1]]
+		pair := cd.buildClonePair(measurements[index], fragment1, fragment2, len(pairs))
+		if cd.isSignificantClone(pair) {
+			pairs = append(pairs, pair)
+		}
+	}
+	return pairs
 }
 
 // fragmentToClone converts a CodeFragment to a domain.Clone.
@@ -975,31 +1092,6 @@ func (cd *CloneDetector) tryCreateClonePair(i, j int, minSimilarity float64, pai
 		return pair
 	}
 	return nil
-}
-
-// addPairWithLimit adds a pair to the collection while maintaining size limit
-func (cd *CloneDetector) addPairWithLimit(pairs []*domain.ClonePair, newPair *domain.ClonePair, maxPairs int) []*domain.ClonePair {
-	// If under limit, just add
-	if len(pairs) < maxPairs {
-		pairs = append(pairs, newPair)
-		// Keep sorted by similarity (descending)
-		sort.Slice(pairs, func(i, j int) bool {
-			return pairs[i].Similarity > pairs[j].Similarity
-		})
-		return pairs
-	}
-
-	// If at limit, check if new pair is better than the worst
-	if newPair.Similarity > pairs[len(pairs)-1].Similarity {
-		// Replace worst pair
-		pairs[len(pairs)-1] = newPair
-		// Re-sort to maintain order
-		sort.Slice(pairs, func(i, j int) bool {
-			return pairs[i].Similarity > pairs[j].Similarity
-		})
-	}
-
-	return pairs
 }
 
 // limitAndSortClonePairs ensures final results are sorted and limited

--- a/jscan/internal/analyzer/clone_detector.go
+++ b/jscan/internal/analyzer/clone_detector.go
@@ -548,9 +548,15 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 		minhashThreshold = 1
 	}
 
-	// Stage 3a: collect the candidate pairs that survive the cheap filters.
+	// Stage 3: generate candidate pairs that survive the cheap filters and
+	// verify them a chunk at a time. Candidate count grows with fragments times
+	// candidates-per-query, which on a large repository runs to orders of
+	// magnitude more pairs than are ever reported, so they are never all held
+	// at once. Chunks are verified in generation order, which is what keeps
+	// pair IDs and clone identities independent of the chunk size.
 	seenPairs := make(map[[2]int]struct{})
-	var candidates [][2]int
+	chunk := make([][2]int, 0, candidateChunkSize)
+
 	for _, r := range records {
 		if isCancelled(ctx) {
 			break
@@ -585,12 +591,15 @@ func (cd *CloneDetector) DetectClonesWithLSH(ctx context.Context, fragments []*C
 				continue
 			}
 
-			candidates = append(candidates, key)
+			chunk = append(chunk, key)
+			if len(chunk) == candidateChunkSize {
+				// APTED verification, the expensive stage, across workers.
+				cd.clonePairs = cd.verifyCandidates(ctx, chunk, cd.clonePairs)
+				chunk = chunk[:0]
+			}
 		}
 	}
-
-	// Stage 3b: APTED verification, the expensive stage, across workers.
-	cd.clonePairs = cd.verifyCandidates(ctx, candidates)
+	cd.clonePairs = cd.verifyCandidates(ctx, chunk, cd.clonePairs)
 
 	// Finalize results
 	cd.limitAndSortClonePairs(cd.cloneDetectorConfig.MaxClonePairs)
@@ -625,9 +634,11 @@ func (cd *CloneDetector) prepareFragments() {
 			continue
 		}
 		// Nothing downstream reads the parser AST once the APTED tree exists,
-		// and fragments hold it for the whole run. Releasing it here lets the
-		// parse trees of already-converted files be collected while later
-		// files are still being prepared.
+		// and fragments hold it for the whole run. Dropping the last reference
+		// lets the parse trees of already-converted files be collected while
+		// later files are still being prepared. The converter deliberately does
+		// not copy parser nodes into TreeNode.OriginalNode, so this really is
+		// the last reference — see TreeConverter.ConvertAST.
 		fragment.ASTNode = nil
 		apted.PrepareTreeForAPTED(fragment.TreeNode)
 		features, _ := cd.featureExtractor.ExtractFeatures(fragment.TreeNode)
@@ -875,11 +886,21 @@ func (cd *CloneDetector) buildClonePair(measurement clonePairMeasurement, fragme
 	}
 }
 
+// candidateChunkSize bounds how many candidate pairs are verified at once.
+// Large enough that every worker has substantial work per chunk, small enough
+// that the per-candidate bookkeeping stays a few megabytes however many
+// candidates the index produces.
+const candidateChunkSize = 1 << 16
+
 // verifyCandidates runs APTED verification over candidate fragment pairs across
-// worker goroutines, then assembles the surviving pairs on a single goroutine in
-// candidate order. Pair IDs and clone identities therefore do not depend on how
-// the work was scheduled.
-func (cd *CloneDetector) verifyCandidates(ctx context.Context, candidates [][2]int) []*domain.ClonePair {
+// worker goroutines, then appends the surviving pairs to pairs on a single
+// goroutine in candidate order. Pair IDs and clone identities therefore do not
+// depend on how the work was scheduled or on how candidates were chunked.
+func (cd *CloneDetector) verifyCandidates(ctx context.Context, candidates [][2]int, pairs []*domain.ClonePair) []*domain.ClonePair {
+	if len(candidates) == 0 {
+		return pairs
+	}
+
 	measurements := make([]clonePairMeasurement, len(candidates))
 	accepted := make([]bool, len(candidates))
 
@@ -908,7 +929,6 @@ func (cd *CloneDetector) verifyCandidates(ctx context.Context, candidates [][2]i
 	}
 	wg.Wait()
 
-	pairs := make([]*domain.ClonePair, 0, len(candidates))
 	for index, candidate := range candidates {
 		if !accepted[index] {
 			continue

--- a/jscan/internal/analyzer/clone_detector_test.go
+++ b/jscan/internal/analyzer/clone_detector_test.go
@@ -3,6 +3,7 @@ package analyzer
 import (
 	"context"
 	"regexp"
+	"sort"
 	"testing"
 
 	coreclone "github.com/ludo-technologies/polyscan/core/clone"
@@ -495,5 +496,41 @@ func TestHelperFunctions(t *testing.T) {
 	}
 	if maxInt(5, 3) != 5 {
 		t.Error("maxInt(5, 3) should be 5")
+	}
+}
+
+// TestWeakestFirstPairsKeepsStrongest pins the bounded top-N behaviour the
+// batching path relies on: once at capacity, only stronger pairs get in, and
+// they displace the weakest retained pair.
+func TestWeakestFirstPairsKeepsStrongest(t *testing.T) {
+	const limit = 3
+
+	similarities := []float64{0.50, 0.95, 0.60, 0.99, 0.10, 0.70}
+	top := &weakestFirstPairs{}
+	for i, similarity := range similarities {
+		top.push(&domain.ClonePair{ID: i, Similarity: similarity}, limit)
+		if top.Len() > limit {
+			t.Fatalf("heap grew to %d, want at most %d", top.Len(), limit)
+		}
+	}
+
+	retained := make([]float64, 0, top.Len())
+	for _, pair := range top.pairs {
+		retained = append(retained, pair.Similarity)
+	}
+	sort.Float64s(retained)
+
+	want := []float64{0.70, 0.95, 0.99}
+	if len(retained) != len(want) {
+		t.Fatalf("retained %v, want %v", retained, want)
+	}
+	for i := range want {
+		if retained[i] != want[i] {
+			t.Fatalf("retained %v, want %v", retained, want)
+		}
+	}
+
+	if weakest := top.weakest().Similarity; weakest != 0.70 {
+		t.Errorf("weakest() = %v, want 0.70", weakest)
 	}
 }

--- a/jscan/internal/analyzer/coupling_metrics.go
+++ b/jscan/internal/analyzer/coupling_metrics.go
@@ -322,8 +322,19 @@ func (c *CouplingMetricsCalculator) CalculateMaxDepth(graph *domain.DependencyGr
 	if graph == nil || graph.NodeCount() == 0 {
 		return 0
 	}
+	return c.CalculateMaxDepthFrom(coregraph.NewChainFinder(graph))
+}
 
-	chain := coregraph.NewChainFinder(graph).LongestChain()
+// CalculateMaxDepthFrom is CalculateMaxDepth against a chain finder the caller
+// already built. Building one condenses the whole graph, so a caller that also
+// reports the longest chains should build a single finder and share it rather
+// than paying for two SCC passes over the same import graph.
+func (c *CouplingMetricsCalculator) CalculateMaxDepthFrom(finder *coregraph.ChainFinder) int {
+	if finder == nil {
+		return 0
+	}
+
+	chain := finder.LongestChain()
 	if len(chain) == 0 {
 		return 0
 	}

--- a/jscan/internal/analyzer/coupling_metrics.go
+++ b/jscan/internal/analyzer/coupling_metrics.go
@@ -123,7 +123,16 @@ func (c *CouplingMetricsCalculator) CalculateCouplingAnalysis(graph *domain.Depe
 	var zoneOfUselessness []string
 	var mainSequence []string
 
-	for nodeID, m := range metrics {
+	// Walk modules in a fixed order: floating-point sums are order-dependent, so
+	// map iteration order would otherwise perturb the averages below.
+	nodeIDs := make([]string, 0, len(metrics))
+	for nodeID := range metrics {
+		nodeIDs = append(nodeIDs, nodeID)
+	}
+	sort.Strings(nodeIDs)
+
+	for _, nodeID := range nodeIDs {
+		m := metrics[nodeID]
 		coupling := m.AfferentCoupling + m.EfferentCoupling
 		totalCoupling += float64(coupling)
 		totalInstability += m.Instability
@@ -302,55 +311,21 @@ func (c *CouplingMetricsCalculator) CalculateTransitiveDependencies(nodeID strin
 	return result
 }
 
-// CalculateMaxDepth calculates the maximum dependency depth in the graph
+// CalculateMaxDepth calculates the maximum dependency depth in the graph,
+// measured in edges along the longest dependency chain.
+//
+// The chain comes from core/graph's condensation-based finder: cycles are
+// collapsed before the search, so the depth is well defined even when modules
+// import each other, and it is the same chain the report shows under
+// LongestChains.
 func (c *CouplingMetricsCalculator) CalculateMaxDepth(graph *domain.DependencyGraph) int {
 	if graph == nil || graph.NodeCount() == 0 {
 		return 0
 	}
 
-	maxDepth := 0
-	memo := make(map[string]int)
-
-	var calculateDepth func(nodeID string, visited map[string]bool) int
-	calculateDepth = func(nodeID string, visited map[string]bool) int {
-		if depth, ok := memo[nodeID]; ok {
-			return depth
-		}
-
-		if visited[nodeID] {
-			return 0 // Cycle detected, don't count
-		}
-
-		visited[nodeID] = true
-		defer func() { visited[nodeID] = false }()
-
-		edges := graph.GetOutgoingEdges(nodeID)
-		if len(edges) == 0 {
-			memo[nodeID] = 0
-			return 0
-		}
-
-		maxChildDepth := 0
-		for _, edge := range edges {
-			if graph.GetNode(edge.To) != nil {
-				childDepth := calculateDepth(edge.To, visited)
-				if childDepth > maxChildDepth {
-					maxChildDepth = childDepth
-				}
-			}
-		}
-
-		depth := maxChildDepth + 1
-		memo[nodeID] = depth
-		return depth
+	chain := coregraph.NewChainFinder(graph).LongestChain()
+	if len(chain) == 0 {
+		return 0
 	}
-
-	for nodeID := range graph.Nodes {
-		depth := calculateDepth(nodeID, make(map[string]bool))
-		if depth > maxDepth {
-			maxDepth = depth
-		}
-	}
-
-	return maxDepth
+	return len(chain) - 1
 }

--- a/jscan/internal/analyzer/unused_code.go
+++ b/jscan/internal/analyzer/unused_code.go
@@ -461,7 +461,7 @@ func DetectOrphanFiles(allModuleInfos map[string]*domain.ModuleInfo, graph *Impo
 
 	// Files not reachable and not test/config files are orphans
 	var findings []*DeadCodeFinding
-	for filePath := range allModuleInfos {
+	for _, filePath := range sortedModulePaths(allModuleInfos) {
 		if reachable[filePath] {
 			continue
 		}

--- a/jscan/internal/analyzer/unused_code.go
+++ b/jscan/internal/analyzer/unused_code.go
@@ -231,7 +231,8 @@ func DetectUnusedExports(allModuleInfos map[string]*domain.ModuleInfo, graph *Im
 
 	var findings []*DeadCodeFinding
 
-	for filePath, info := range allModuleInfos {
+	for _, filePath := range sortedModulePaths(allModuleInfos) {
+		info := allModuleInfos[filePath]
 		// Skip entry-point files whose exports are meant to be public
 		if isEntryPointFile(filePath) {
 			continue
@@ -490,7 +491,8 @@ func DetectUnusedExportedFunctions(allModuleInfos map[string]*domain.ModuleInfo,
 
 	var findings []*DeadCodeFinding
 
-	for filePath, info := range allModuleInfos {
+	for _, filePath := range sortedModulePaths(allModuleInfos) {
+		info := allModuleInfos[filePath]
 		if isEntryPointFile(filePath) {
 			continue
 		}
@@ -679,4 +681,15 @@ func resolveAliasImportPaths(source string, idx *suffixIndex) []string {
 	}
 	sort.Strings(result)
 	return result
+}
+
+// sortedModulePaths returns the analyzed module paths in a fixed order, so
+// findings collected across modules do not depend on Go's map iteration order.
+func sortedModulePaths(allModuleInfos map[string]*domain.ModuleInfo) []string {
+	paths := make([]string, 0, len(allModuleInfos))
+	for filePath := range allModuleInfos {
+		paths = append(paths, filePath)
+	}
+	sort.Strings(paths)
+	return paths
 }

--- a/jscan/service/cbo_service.go
+++ b/jscan/service/cbo_service.go
@@ -58,26 +58,25 @@ func (s *CBOServiceImpl) Analyze(ctx context.Context, req domain.CBORequest) (*d
 
 	cboAnalyzer := analyzer.NewCBOAnalyzer(&config)
 
-	for _, filePath := range req.Paths {
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("CBO analysis cancelled: %w", ctx.Err())
-		default:
-		}
+	results := analyzeFilesConcurrently(ctx, req.Paths, nil,
+		func(ctx context.Context, filePath string) fileAnalysis[*domain.ClassCoupling] {
+			classCoupling, fileWarnings, fileErrors := s.analyzeFile(ctx, cboAnalyzer, filePath)
+			return fileAnalysis[*domain.ClassCoupling]{value: classCoupling, warnings: fileWarnings, errors: fileErrors}
+		})
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("CBO analysis cancelled: %w", ctx.Err())
+	}
 
-		// Analyze single file
-		classCoupling, fileWarnings, fileErrors := s.analyzeFile(ctx, cboAnalyzer, filePath)
-
-		if len(fileErrors) > 0 {
-			errors = append(errors, fileErrors...)
+	for _, result := range results {
+		if len(result.errors) > 0 {
+			errors = append(errors, result.errors...)
 			continue
 		}
 
-		if classCoupling != nil {
-			allClasses = append(allClasses, *classCoupling)
+		if result.value != nil {
+			allClasses = append(allClasses, *result.value)
 		}
-		warnings = append(warnings, fileWarnings...)
+		warnings = append(warnings, result.warnings...)
 		filesProcessed++
 	}
 

--- a/jscan/service/clone_service.go
+++ b/jscan/service/clone_service.go
@@ -198,9 +198,10 @@ func (s *CloneServiceImpl) DetectClones(ctx context.Context, req *domain.CloneRe
 	statistics.TotalFragments = len(allFragments)
 	statistics.NodesAnalyzed = nodesAnalyzed
 
-	// Sort clone pairs by similarity (descending)
+	// Sort clone pairs by similarity (descending), breaking ties on source
+	// location so equally similar pairs keep the same order on every run.
 	sort.Slice(clonePairs, func(i, j int) bool {
-		return clonePairs[i].Similarity > clonePairs[j].Similarity
+		return domain.ClonePairPrecedes(clonePairs[i], clonePairs[j])
 	})
 
 	// Extract unique clones represented by either pairs or groups.

--- a/jscan/service/clone_service.go
+++ b/jscan/service/clone_service.go
@@ -33,6 +33,44 @@ func NewCloneServiceWithDefaults() *CloneServiceImpl {
 	}
 }
 
+// extractedFragments is one file's clone-detection input plus the size counters
+// the statistics block reports.
+type extractedFragments struct {
+	fragments []*analyzer.CodeFragment
+	lines     int
+	nodes     int
+}
+
+// extractFileFragments reads, parses, and extracts clone fragments from one
+// file. Fragment extraction only reads the detector's configuration, so this is
+// safe to run for several files at once.
+func extractFileFragments(detector *analyzer.CloneDetector, filePath string) fileAnalysis[*extractedFragments] {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileAnalysis[*extractedFragments]{
+			errors: []string{fmt.Sprintf("[%s] Failed to read file: %v", filePath, err)},
+		}
+	}
+
+	ast, err := parser.ParseForLanguage(filePath, content)
+	if err != nil {
+		return fileAnalysis[*extractedFragments]{
+			errors: []string{fmt.Sprintf("[%s] Failed to parse: %v", filePath, err)},
+		}
+	}
+
+	extracted := &extractedFragments{
+		// Source content is carried along for Type-1 textual gating.
+		fragments: detector.ExtractFragmentsWithSource(ast.Body, filePath, content),
+		lines:     countLines(content),
+	}
+	for _, node := range ast.Body {
+		extracted.nodes += countASTNodes(node)
+	}
+
+	return fileAnalysis[*extractedFragments]{value: extracted}
+}
+
 // DetectClones performs clone detection on the given request
 func (s *CloneServiceImpl) DetectClones(ctx context.Context, req *domain.CloneRequest) (*domain.CloneResponse, error) {
 	startTime := time.Now()
@@ -88,37 +126,24 @@ func (s *CloneServiceImpl) DetectClones(ctx context.Context, req *domain.CloneRe
 	nodesAnalyzed := 0
 	var errors []string
 
-	for _, filePath := range req.Paths {
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("clone detection cancelled: %w", ctx.Err())
-		default:
-		}
+	results := analyzeFilesConcurrently(ctx, req.Paths, nil,
+		func(_ context.Context, filePath string) fileAnalysis[*extractedFragments] {
+			return extractFileFragments(detector, filePath)
+		})
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("clone detection cancelled: %w", ctx.Err())
+	}
 
-		// Read file
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("[%s] Failed to read file: %v", filePath, err))
+	for _, result := range results {
+		errors = append(errors, result.errors...)
+		if result.value == nil {
 			continue
 		}
 
-		// Parse file
-		ast, err := parser.ParseForLanguage(filePath, content)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("[%s] Failed to parse: %v", filePath, err))
-			continue
-		}
-
-		// Extract fragments from the AST with source content for Type-1 textual gating
-		fragments := detector.ExtractFragmentsWithSource(ast.Body, filePath, content)
-		allFragments = append(allFragments, fragments...)
-
+		allFragments = append(allFragments, result.value.fragments...)
 		filesAnalyzed++
-		linesAnalyzed += countLines(content)
-		for _, node := range ast.Body {
-			nodesAnalyzed += countASTNodes(node)
-		}
+		linesAnalyzed += result.value.lines
+		nodesAnalyzed += result.value.nodes
 	}
 
 	if len(allFragments) == 0 {

--- a/jscan/service/complexity_service.go
+++ b/jscan/service/complexity_service.go
@@ -49,27 +49,24 @@ func (s *ComplexityServiceImpl) Analyze(ctx context.Context, req domain.Complexi
 	}
 	defer task.Complete()
 
-	for _, filePath := range req.Paths {
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("complexity analysis cancelled: %w", ctx.Err())
-		default:
-		}
+	results := analyzeFilesConcurrently(ctx, req.Paths, task,
+		func(ctx context.Context, filePath string) fileAnalysis[[]domain.FunctionComplexity] {
+			functions, fileWarnings, fileErrors := s.analyzeFile(ctx, filePath, req)
+			return fileAnalysis[[]domain.FunctionComplexity]{value: functions, warnings: fileWarnings, errors: fileErrors}
+		})
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("complexity analysis cancelled: %w", ctx.Err())
+	}
 
-		// Analyze single file
-		functions, fileWarnings, fileErrors := s.analyzeFile(ctx, filePath, req)
-
-		if len(fileErrors) > 0 {
-			errors = append(errors, fileErrors...)
-			task.Increment(1)
+	for _, result := range results {
+		if len(result.errors) > 0 {
+			errors = append(errors, result.errors...)
 			continue // Skip this file but continue with others
 		}
 
-		allFunctions = append(allFunctions, functions...)
-		warnings = append(warnings, fileWarnings...)
+		allFunctions = append(allFunctions, result.value...)
+		warnings = append(warnings, result.warnings...)
 		filesProcessed++
-		task.Increment(1)
 	}
 
 	if len(allFunctions) == 0 {
@@ -201,28 +198,48 @@ func (s *ComplexityServiceImpl) sortFunctions(functions []domain.FunctionComplex
 	sorted := make([]domain.FunctionComplexity, len(functions))
 	copy(sorted, functions)
 
+	// Every comparator falls back to source location so that functions the
+	// primary criterion cannot separate still come out in the same order on
+	// every run.
 	switch sortBy {
-	case domain.SortByComplexity:
-		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.Complexity > sorted[j].Metrics.Complexity
-		})
 	case domain.SortByName:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Name < sorted[j].Name
+			if sorted[i].Name != sorted[j].Name {
+				return sorted[i].Name < sorted[j].Name
+			}
+			return functionPrecedes(sorted[i], sorted[j])
 		})
 	case domain.SortByRisk:
 		riskOrder := map[domain.RiskLevel]int{domain.RiskLevelHigh: 0, domain.RiskLevelMedium: 1, domain.RiskLevelLow: 2}
 		sort.Slice(sorted, func(i, j int) bool {
-			return riskOrder[sorted[i].RiskLevel] < riskOrder[sorted[j].RiskLevel]
+			if riskOrder[sorted[i].RiskLevel] != riskOrder[sorted[j].RiskLevel] {
+				return riskOrder[sorted[i].RiskLevel] < riskOrder[sorted[j].RiskLevel]
+			}
+			return functionPrecedes(sorted[i], sorted[j])
 		})
 	default:
-		// Default: sort by complexity descending
+		// Default and domain.SortByComplexity: complexity descending.
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.Complexity > sorted[j].Metrics.Complexity
+			if sorted[i].Metrics.Complexity != sorted[j].Metrics.Complexity {
+				return sorted[i].Metrics.Complexity > sorted[j].Metrics.Complexity
+			}
+			return functionPrecedes(sorted[i], sorted[j])
 		})
 	}
 
 	return sorted
+}
+
+// functionPrecedes orders two functions by where they appear in the project,
+// which is unique per function and independent of analysis scheduling.
+func functionPrecedes(a, b domain.FunctionComplexity) bool {
+	if a.FilePath != b.FilePath {
+		return a.FilePath < b.FilePath
+	}
+	if a.StartLine != b.StartLine {
+		return a.StartLine < b.StartLine
+	}
+	return a.Name < b.Name
 }
 
 // generateSummary generates a summary of the complexity analysis.

--- a/jscan/service/dead_code_aggregate.go
+++ b/jscan/service/dead_code_aggregate.go
@@ -368,19 +368,29 @@ func AnalyzeDeadCodeWithTask(ctx context.Context, req domain.DeadCodeRequest, ta
 		addFileLevelFinding(f)
 	}
 
+	// Every comparator falls back to file path, which is unique per entry, so
+	// files the primary criterion cannot separate keep the same order on every
+	// run regardless of the order findings were collected in.
 	sort.Slice(files, func(i, j int) bool {
 		switch sortBy {
 		case domain.DeadCodeSortByFile:
 			return files[i].FilePath < files[j].FilePath
 		case domain.DeadCodeSortByLine:
-			return firstDeadCodeLine(files[i]) < firstDeadCodeLine(files[j])
+			if firstDeadCodeLine(files[i]) != firstDeadCodeLine(files[j]) {
+				return firstDeadCodeLine(files[i]) < firstDeadCodeLine(files[j])
+			}
 		case domain.DeadCodeSortByFunction:
-			return firstDeadCodeFunction(files[i]) < firstDeadCodeFunction(files[j])
+			if firstDeadCodeFunction(files[i]) != firstDeadCodeFunction(files[j]) {
+				return firstDeadCodeFunction(files[i]) < firstDeadCodeFunction(files[j])
+			}
 		case domain.DeadCodeSortBySeverity:
 			fallthrough
 		default:
-			return fileMaxSeverity(files[i]) > fileMaxSeverity(files[j])
+			if fileMaxSeverity(files[i]) != fileMaxSeverity(files[j]) {
+				return fileMaxSeverity(files[i]) > fileMaxSeverity(files[j])
+			}
 		}
+		return files[i].FilePath < files[j].FilePath
 	})
 
 	findingsByReason := make(map[string]int)

--- a/jscan/service/dead_code_aggregate.go
+++ b/jscan/service/dead_code_aggregate.go
@@ -13,6 +13,59 @@ import (
 	"github.com/ludo-technologies/polyscan/jscan/internal/version"
 )
 
+// scannedFile is everything dead code analysis derives from one file on its
+// own, before findings are aggregated across the project.
+type scannedFile struct {
+	deadCode      map[string]*analyzer.DeadCodeResult
+	moduleInfo    *domain.ModuleInfo
+	unusedImports []*analyzer.DeadCodeFinding
+}
+
+// scanFileForDeadCode reads, parses, and analyzes one file. The module analyzer
+// only reads its configuration, so several files can be scanned at once.
+func scanFileForDeadCode(moduleAnalyzer *analyzer.ModuleAnalyzer, filePath string) fileAnalysis[*scannedFile] {
+	content, err := os.ReadFile(filePath)
+	if err != nil {
+		return fileAnalysis[*scannedFile]{
+			errors: []string{fmt.Sprintf("[%s] failed to read file: %v", filePath, err)},
+		}
+	}
+
+	ast, err := parser.ParseForLanguage(filePath, content)
+	if err != nil {
+		return fileAnalysis[*scannedFile]{
+			errors: []string{fmt.Sprintf("[%s] failed to parse file: %v", filePath, err)},
+		}
+	}
+
+	cfgs, err := analyzer.NewCFGBuilder().BuildAll(ast)
+	if err != nil {
+		return fileAnalysis[*scannedFile]{
+			errors: []string{fmt.Sprintf("[%s] failed to build CFG: %v", filePath, err)},
+		}
+	}
+
+	scan := fileAnalysis[*scannedFile]{
+		value: &scannedFile{deadCode: analyzer.DetectAll(cfgs, filePath)},
+	}
+	if len(cfgs) == 0 {
+		scan.warnings = append(scan.warnings, fmt.Sprintf("[%s] no functions found in file", filePath))
+	}
+
+	moduleInfo, moduleErr := moduleAnalyzer.AnalyzeFile(ast, filePath)
+	if moduleErr != nil {
+		scan.warnings = append(scan.warnings, fmt.Sprintf("[%s] module analysis warning: %v", filePath, moduleErr))
+	} else {
+		// Only a cleanly analyzed module joins the project-wide import graph.
+		scan.value.moduleInfo = moduleInfo
+	}
+	if moduleInfo != nil {
+		scan.value.unusedImports = analyzer.DetectUnusedImports(ast, moduleInfo, filePath)
+	}
+
+	return scan
+}
+
 // AnalyzeDeadCode runs dead code analysis using the shared aggregation path.
 func AnalyzeDeadCode(ctx context.Context, req domain.DeadCodeRequest) (*domain.DeadCodeResponse, error) {
 	return AnalyzeDeadCodeWithTask(ctx, req, nil)
@@ -87,53 +140,27 @@ func AnalyzeDeadCodeWithTask(ctx context.Context, req domain.DeadCodeRequest, ta
 		totalFindings++
 	}
 
-	for _, filePath := range req.Paths {
-		incrementTask := func() {
-			if task != nil {
-				task.Increment(1)
-			}
-		}
+	scanned := analyzeFilesConcurrently(ctx, req.Paths, task,
+		func(_ context.Context, filePath string) fileAnalysis[*scannedFile] {
+			return scanFileForDeadCode(moduleAnalyzer, filePath)
+		})
+	if ctx.Err() != nil {
+		return nil, fmt.Errorf("dead code analysis cancelled: %w", ctx.Err())
+	}
 
-		select {
-		case <-ctx.Done():
-			return nil, fmt.Errorf("dead code analysis cancelled: %w", ctx.Err())
-		default:
-		}
+	for index, scan := range scanned {
+		filePath := req.Paths[index]
+		warnings = append(warnings, scan.warnings...)
+		errors = append(errors, scan.errors...)
 
 		analyzedFiles[filePath] = true
-
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("[%s] failed to read file: %v", filePath, err))
-			incrementTask()
+		if scan.value == nil {
 			continue
 		}
 
-		ast, err := parser.ParseForLanguage(filePath, content)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("[%s] failed to parse file: %v", filePath, err))
-			incrementTask()
-			continue
-		}
-
-		builder := analyzer.NewCFGBuilder()
-		cfgs, err := builder.BuildAll(ast)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("[%s] failed to build CFG: %v", filePath, err))
-			incrementTask()
-			continue
-		}
-
-		if len(cfgs) == 0 {
-			warnings = append(warnings, fmt.Sprintf("[%s] no functions found in file", filePath))
-		}
-
-		results := analyzer.DetectAll(cfgs, filePath)
-
-		moduleInfo, moduleErr := moduleAnalyzer.AnalyzeFile(ast, filePath)
-		if moduleErr != nil {
-			warnings = append(warnings, fmt.Sprintf("[%s] module analysis warning: %v", filePath, moduleErr))
-		} else if moduleInfo != nil {
+		results := scan.value.deadCode
+		moduleInfo := scan.value.moduleInfo
+		if moduleInfo != nil {
 			allModuleInfos[filePath] = moduleInfo
 		}
 
@@ -143,40 +170,46 @@ func AnalyzeDeadCodeWithTask(ctx context.Context, req domain.DeadCodeRequest, ta
 		fileDeadBlocks := 0
 		fileTotalBlocks := 0
 
-		if moduleInfo != nil {
-			unusedImports := analyzer.DetectUnusedImports(ast, moduleInfo, filePath)
-			for _, finding := range unusedImports {
-				f := domain.DeadCodeFinding{
-					Location: domain.DeadCodeLocation{
-						FilePath:  filePath,
-						StartLine: finding.StartLine,
-						EndLine:   finding.EndLine,
-					},
-					Reason:      string(finding.Reason),
-					Severity:    domain.DeadCodeSeverity(finding.Severity),
-					Description: finding.Description,
-				}
-				if !f.Severity.IsAtLeast(minSeverity) {
-					continue
-				}
-				fileLevelFindings = append(fileLevelFindings, f)
-
-				switch f.Severity {
-				case domain.DeadCodeSeverityCritical:
-					criticalFindings++
-				case domain.DeadCodeSeverityWarning:
-					warningFindings++
-				case domain.DeadCodeSeverityInfo:
-					infoFindings++
-				}
-				totalFindings++
+		for _, finding := range scan.value.unusedImports {
+			f := domain.DeadCodeFinding{
+				Location: domain.DeadCodeLocation{
+					FilePath:  filePath,
+					StartLine: finding.StartLine,
+					EndLine:   finding.EndLine,
+				},
+				Reason:      string(finding.Reason),
+				Severity:    domain.DeadCodeSeverity(finding.Severity),
+				Description: finding.Description,
 			}
+			if !f.Severity.IsAtLeast(minSeverity) {
+				continue
+			}
+			fileLevelFindings = append(fileLevelFindings, f)
+
+			switch f.Severity {
+			case domain.DeadCodeSeverityCritical:
+				criticalFindings++
+			case domain.DeadCodeSeverityWarning:
+				warningFindings++
+			case domain.DeadCodeSeverityInfo:
+				infoFindings++
+			}
+			totalFindings++
 		}
 
-		for funcName, result := range results {
+		// Detection results are keyed by function name; walk them in sorted
+		// order so the report does not depend on Go's map iteration order.
+		funcNames := make([]string, 0, len(results))
+		for funcName := range results {
+			funcNames = append(funcNames, funcName)
+		}
+		sort.Strings(funcNames)
+
+		for _, funcName := range funcNames {
 			if funcName == domain.ModuleFunctionName {
 				continue
 			}
+			result := results[funcName]
 
 			fileTotalFunctions++
 			totalFunctions++
@@ -260,7 +293,6 @@ func AnalyzeDeadCodeWithTask(ctx context.Context, req domain.DeadCodeRequest, ta
 
 		totalBlocks += fileTotalBlocks
 		deadBlocks += fileDeadBlocks
-		incrementTask()
 	}
 
 	graph := analyzer.BuildImportGraph(allModuleInfos, analyzedFiles)

--- a/jscan/service/dependency_graph_service.go
+++ b/jscan/service/dependency_graph_service.go
@@ -7,6 +7,7 @@ import (
 	"sort"
 	"time"
 
+	coregraph "github.com/ludo-technologies/polyscan/core/graph"
 	"github.com/ludo-technologies/polyscan/jscan/domain"
 	"github.com/ludo-technologies/polyscan/jscan/internal/analyzer"
 	"github.com/ludo-technologies/polyscan/jscan/internal/parser"
@@ -130,36 +131,44 @@ func (s *DependencyGraphServiceImpl) Analyze(ctx context.Context, req domain.Dep
 
 // parseFiles parses all input files and returns their ASTs
 func (s *DependencyGraphServiceImpl) parseFiles(ctx context.Context, paths []string) (map[string]*parser.Node, []string, []string) {
-	asts := make(map[string]*parser.Node)
+	asts := make(map[string]*parser.Node, len(paths))
 	var warnings []string
 	var errors []string
 
-	p := parser.NewParser()
-	defer p.Close()
+	results := analyzeFilesConcurrently(ctx, paths, nil,
+		func(_ context.Context, filePath string) fileAnalysis[*parser.Node] {
+			content, err := os.ReadFile(filePath)
+			if err != nil {
+				return fileAnalysis[*parser.Node]{
+					errors: []string{fmt.Sprintf("Failed to read %s: %v", filePath, err)},
+				}
+			}
 
-	for _, filePath := range paths {
-		// Check context cancellation
-		select {
-		case <-ctx.Done():
-			return asts, warnings, append(errors, fmt.Sprintf("Parsing cancelled: %v", ctx.Err()))
-		default:
+			// Each call builds its own parser: tree-sitter parsers are not safe
+			// for concurrent use.
+			p := parser.NewParser()
+			defer p.Close()
+
+			ast, err := p.ParseString(string(content))
+			if err != nil {
+				return fileAnalysis[*parser.Node]{
+					warnings: []string{fmt.Sprintf("Failed to parse %s: %v", filePath, err)},
+				}
+			}
+
+			return fileAnalysis[*parser.Node]{value: ast}
+		})
+
+	for index, result := range results {
+		warnings = append(warnings, result.warnings...)
+		errors = append(errors, result.errors...)
+		if result.value != nil {
+			asts[paths[index]] = result.value
 		}
+	}
 
-		// Read file
-		content, err := os.ReadFile(filePath)
-		if err != nil {
-			errors = append(errors, fmt.Sprintf("Failed to read %s: %v", filePath, err))
-			continue
-		}
-
-		// Parse file
-		ast, err := p.ParseString(string(content))
-		if err != nil {
-			warnings = append(warnings, fmt.Sprintf("Failed to parse %s: %v", filePath, err))
-			continue
-		}
-
-		asts[filePath] = ast
+	if ctx.Err() != nil {
+		errors = append(errors, fmt.Sprintf("Parsing cancelled: %v", ctx.Err()))
 	}
 
 	return asts, warnings, errors
@@ -219,73 +228,52 @@ func (s *DependencyGraphServiceImpl) buildAnalysisResult(
 	}
 }
 
-// findLongestChains finds the longest dependency chains in the graph
+// maxReportedChains caps how many dependency chains the report carries.
+const maxReportedChains = 5
+
+// findLongestChains finds the longest dependency chains in the graph, one per
+// entry-point module. Chains come from core/graph's condensation-based finder,
+// which is linear in the graph size — an exhaustive simple-path search would be
+// exponential on the cyclic import graphs real projects produce.
 func (s *DependencyGraphServiceImpl) findLongestChains(graph *domain.DependencyGraph, maxDepth int) []domain.DependencyPath {
 	if maxDepth == 0 {
 		return nil
 	}
 
-	var chains []domain.DependencyPath
-	visited := make(map[string]bool)
+	finder := coregraph.NewChainFinder(graph)
 
-	// Find chains starting from entry points
-	for nodeID, node := range graph.Nodes {
-		if node.IsEntryPoint {
-			chain := s.findLongestChainFrom(nodeID, graph, visited)
-			if len(chain) > 1 {
-				chains = append(chains, domain.DependencyPath{
-					From:   chain[0],
-					To:     chain[len(chain)-1],
-					Path:   chain,
-					Length: len(chain) - 1,
-				})
-			}
+	var chains []domain.DependencyPath
+	for _, nodeID := range graph.NodeIDs() {
+		node := graph.GetNode(nodeID)
+		if node == nil || !node.IsEntryPoint {
+			continue
+		}
+
+		chain := finder.LongestChainFrom(nodeID)
+		if len(chain) > 1 {
+			chains = append(chains, domain.DependencyPath{
+				From:   chain[0],
+				To:     chain[len(chain)-1],
+				Path:   chain,
+				Length: len(chain) - 1,
+			})
 		}
 	}
 
-	// Sort by length (descending)
+	// Sort by length (descending), then by starting module so equal-length
+	// chains keep a stable order across runs.
 	sort.Slice(chains, func(i, j int) bool {
-		return chains[i].Length > chains[j].Length
+		if chains[i].Length != chains[j].Length {
+			return chains[i].Length > chains[j].Length
+		}
+		return chains[i].From < chains[j].From
 	})
 
-	// Return top 5 chains
-	if len(chains) > 5 {
-		chains = chains[:5]
+	if len(chains) > maxReportedChains {
+		chains = chains[:maxReportedChains]
 	}
 
 	return chains
-}
-
-// findLongestChainFrom finds the longest chain starting from a node
-func (s *DependencyGraphServiceImpl) findLongestChainFrom(nodeID string, graph *domain.DependencyGraph, globalVisited map[string]bool) []string {
-	visited := make(map[string]bool)
-	var longestPath []string
-
-	var dfs func(current string, path []string)
-	dfs = func(current string, path []string) {
-		if visited[current] {
-			return
-		}
-		visited[current] = true
-		path = append(path, current)
-
-		if len(path) > len(longestPath) {
-			longestPath = make([]string, len(path))
-			copy(longestPath, path)
-		}
-
-		edges := graph.GetOutgoingEdges(current)
-		for _, edge := range edges {
-			if graph.GetNode(edge.To) != nil && !visited[edge.To] {
-				dfs(edge.To, path)
-			}
-		}
-
-		visited[current] = false
-	}
-
-	dfs(nodeID, nil)
-	return longestPath
 }
 
 // AnalyzeSingleFile analyzes a single file and returns its dependency information

--- a/jscan/service/dependency_graph_service.go
+++ b/jscan/service/dependency_graph_service.go
@@ -113,11 +113,13 @@ func (s *DependencyGraphServiceImpl) Analyze(ctx context.Context, req domain.Dep
 	moduleMetrics := couplingCalc.CalculateMetrics(graph)
 	couplingAnalysis := couplingCalc.CalculateCouplingAnalysis(graph, moduleMetrics)
 
-	// Calculate max depth
-	maxDepth := couplingCalc.CalculateMaxDepth(graph)
+	// The max depth and the reported chains are the same search over the same
+	// condensation, so build the finder once and let both read from it.
+	chainFinder := coregraph.NewChainFinder(graph)
+	maxDepth := couplingCalc.CalculateMaxDepthFrom(chainFinder)
 
 	// Build analysis result
-	analysis := s.buildAnalysisResult(graph, circularDeps, couplingAnalysis, moduleMetrics, maxDepth)
+	analysis := s.buildAnalysisResult(graph, circularDeps, couplingAnalysis, moduleMetrics, maxDepth, chainFinder)
 
 	return &domain.DependencyGraphResponse{
 		Graph:       graph,
@@ -181,6 +183,7 @@ func (s *DependencyGraphServiceImpl) buildAnalysisResult(
 	couplingAnalysis *domain.CouplingAnalysis,
 	moduleMetrics map[string]*domain.ModuleDependencyMetrics,
 	maxDepth int,
+	chainFinder *coregraph.ChainFinder,
 ) *domain.DependencyAnalysisResult {
 	// Find root and leaf modules
 	var rootModules []string
@@ -212,7 +215,7 @@ func (s *DependencyGraphServiceImpl) buildAnalysisResult(
 	}
 
 	// Find longest dependency chains
-	longestChains := s.findLongestChains(graph, maxDepth)
+	longestChains := s.findLongestChains(graph, chainFinder, maxDepth)
 
 	return &domain.DependencyAnalysisResult{
 		TotalModules:         graph.NodeCount(),
@@ -232,15 +235,13 @@ func (s *DependencyGraphServiceImpl) buildAnalysisResult(
 const maxReportedChains = 5
 
 // findLongestChains finds the longest dependency chains in the graph, one per
-// entry-point module. Chains come from core/graph's condensation-based finder,
+// entry-point module. Chains come from the caller's condensation-based finder,
 // which is linear in the graph size — an exhaustive simple-path search would be
 // exponential on the cyclic import graphs real projects produce.
-func (s *DependencyGraphServiceImpl) findLongestChains(graph *domain.DependencyGraph, maxDepth int) []domain.DependencyPath {
-	if maxDepth == 0 {
+func (s *DependencyGraphServiceImpl) findLongestChains(graph *domain.DependencyGraph, finder *coregraph.ChainFinder, maxDepth int) []domain.DependencyPath {
+	if maxDepth == 0 || finder == nil {
 		return nil
 	}
-
-	finder := coregraph.NewChainFinder(graph)
 
 	var chains []domain.DependencyPath
 	for _, nodeID := range graph.NodeIDs() {

--- a/jscan/service/file_fanout.go
+++ b/jscan/service/file_fanout.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"context"
+	"runtime"
+	"sync"
+
+	"github.com/ludo-technologies/polyscan/jscan/domain"
+)
+
+// fileAnalysis is one file's contribution to a multi-file analysis.
+type fileAnalysis[T any] struct {
+	value    T
+	warnings []string
+	errors   []string
+}
+
+// analyzeFilesConcurrently applies analyze to every path across worker
+// goroutines and returns the results in path order.
+//
+// Reading and parsing a file is independent per file and is where multi-file
+// analyses spend most of their time, so this is where concurrency pays. Results
+// are written to a preallocated slot per path rather than appended, so the
+// output never depends on how work was scheduled.
+//
+// analyze must not share mutable state between calls — in particular each call
+// needs its own tree-sitter parser, which is not safe for concurrent use.
+// A cancelled context stops the remaining work; already-finished results are
+// still returned, and callers check ctx themselves to decide how to report it.
+func analyzeFilesConcurrently[T any](
+	ctx context.Context,
+	paths []string,
+	progress domain.TaskProgress,
+	analyze func(context.Context, string) fileAnalysis[T],
+) []fileAnalysis[T] {
+	results := make([]fileAnalysis[T], len(paths))
+	if len(paths) == 0 {
+		return results
+	}
+
+	workers := runtime.NumCPU()
+	if workers > len(paths) {
+		workers = len(paths)
+	}
+
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			for index := offset; index < len(paths); index += workers {
+				select {
+				case <-ctx.Done():
+					return
+				default:
+				}
+
+				results[index] = analyze(ctx, paths[index])
+				if progress != nil {
+					progress.Increment(1)
+				}
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	return results
+}

--- a/jscan/service/pipeline_bench_test.go
+++ b/jscan/service/pipeline_bench_test.go
@@ -1,0 +1,171 @@
+package service
+
+import (
+	"context"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/jscan/domain"
+	"github.com/ludo-technologies/polyscan/jscan/internal/config"
+)
+
+// corpusEnvVar names the directory holding the JavaScript/TypeScript corpus the
+// pipeline benchmarks run against. Benchmarks skip when it is unset so `go test
+// -bench=.` stays fast for everyone who has not opted in.
+//
+//	JSCAN_BENCH_CORPUS=/path/to/repo go test -run='^$' -bench=BenchmarkPipeline \
+//	    -benchmem -cpuprofile=cpu.prof ./service/
+const corpusEnvVar = "JSCAN_BENCH_CORPUS"
+
+var benchSourceExtensions = []string{".js", ".jsx", ".mjs", ".cjs", ".ts", ".tsx", ".mts", ".cts"}
+
+// benchCorpusPaths collects every analyzable source file under the corpus
+// directory, sorted so repeated runs analyze the files in the same order.
+func benchCorpusPaths(b *testing.B) []string {
+	b.Helper()
+
+	root := os.Getenv(corpusEnvVar)
+	if root == "" {
+		b.Skipf("set %s to a JavaScript/TypeScript source tree to run this benchmark", corpusEnvVar)
+	}
+
+	var paths []string
+	err := filepath.WalkDir(root, func(path string, entry os.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if entry.IsDir() {
+			if entry.Name() == "node_modules" || strings.HasPrefix(entry.Name(), ".") {
+				return filepath.SkipDir
+			}
+			return nil
+		}
+		ext := strings.ToLower(filepath.Ext(path))
+		for _, candidate := range benchSourceExtensions {
+			if ext == candidate {
+				paths = append(paths, path)
+				return nil
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		b.Fatalf("walking corpus %s: %v", root, err)
+	}
+	if len(paths) == 0 {
+		b.Fatalf("no JavaScript/TypeScript files found under %s", root)
+	}
+
+	sort.Strings(paths)
+	return paths
+}
+
+// reportThroughput records lines-of-source per second, the metric the
+// performance targets in docs/performance.md are stated in.
+func reportThroughput(b *testing.B, paths []string) {
+	b.Helper()
+
+	lines := 0
+	for _, path := range paths {
+		content, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		lines += countLines(content)
+	}
+	b.ReportMetric(float64(lines*b.N)/b.Elapsed().Seconds(), "LOC/s")
+}
+
+func BenchmarkPipelineClone(b *testing.B) {
+	paths := benchCorpusPaths(b)
+	service := NewCloneServiceWithDefaults()
+
+	req := domain.DefaultCloneRequest()
+	req.Paths = paths
+	req.OutputWriter = io.Discard
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := service.DetectClones(context.Background(), req); err != nil {
+			b.Fatalf("clone detection failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportThroughput(b, paths)
+}
+
+func BenchmarkPipelineComplexity(b *testing.B) {
+	paths := benchCorpusPaths(b)
+	service := NewComplexityService(&config.DefaultConfig().Complexity)
+
+	req := domain.ComplexityRequest{Paths: paths, OutputWriter: io.Discard}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := service.Analyze(context.Background(), req); err != nil {
+			b.Fatalf("complexity analysis failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportThroughput(b, paths)
+}
+
+func BenchmarkPipelineDeadCode(b *testing.B) {
+	paths := benchCorpusPaths(b)
+	service := NewDeadCodeService()
+
+	req := domain.DeadCodeRequest{Paths: paths, OutputWriter: io.Discard}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := service.Analyze(context.Background(), req); err != nil {
+			b.Fatalf("dead code analysis failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportThroughput(b, paths)
+}
+
+func BenchmarkPipelineDeps(b *testing.B) {
+	paths := benchCorpusPaths(b)
+	service := NewDependencyGraphServiceWithDefaults()
+
+	req := domain.DefaultDependencyGraphRequest()
+	req.Paths = paths
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := service.Analyze(context.Background(), *req); err != nil {
+			b.Fatalf("dependency analysis failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportThroughput(b, paths)
+}
+
+func BenchmarkPipelineCBO(b *testing.B) {
+	paths := benchCorpusPaths(b)
+	service := NewCBOServiceWithDefaults()
+
+	req := domain.DefaultCBORequest()
+	req.Paths = paths
+	req.OutputWriter = io.Discard
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := service.Analyze(context.Background(), *req); err != nil {
+			b.Fatalf("CBO analysis failed: %v", err)
+		}
+	}
+	b.StopTimer()
+	reportThroughput(b, paths)
+}


### PR DESCRIPTION
Closes #25.

Measured against [vuejs/core](https://github.com/vuejs/core) `packages/` — 147k lines of TypeScript across 452 files — on an Apple M4 (10 cores), all five analyses enabled. Before this change the full repository did not finish in 45 minutes, and a single 21k-line package did not finish in 10.

| Corpus | Before | After | Peak RSS |
|---|---|---|---|
| 3.9k LOC | 0.73 s | 0.13 s | 83 MB |
| 11k LOC | 5.75 s | 0.32 s | 197 MB |
| 21k LOC | did not finish (>10 min) | 0.47 s | 300 MB |
| 147k LOC | did not finish (>45 min) | 14.8 s | 1.84 GB |

Medians of three interleaved runs; the machine carried unrelated background load, so these are a floor. Against the issue's targets: 10k+ LOC/s met at every size measured (30–45k below ~20k LOC), <2 GB at 100k LOC met, and a 10k-line project finishes in 0.3 s against the 30 s target.

## What was wrong

**Dependency-chain reporting enumerated simple paths.** `findLongestChains` ran a backtracking DFS over every path from every entry point — the NP-hard longest-path problem. On an import graph with cycles it does not terminate in practical time, and this alone was why a 21k-line package hung. `core/graph` gains a `ChainFinder` that collapses strongly connected components, memoizes the longest path through the resulting DAG in one linear pass, and expands each component it crosses via BFS, so every chain returned is still a real simple path. O(V+E).

**APTED evaluated the cost model inside its DP loops.** 83% of clone-detection time was `strings.HasPrefix` scanning. Insert/delete costs depend only on the node, so they are now computed once per comparison rather than once per DP cell; `math.Min` in the innermost loop becomes a plain comparison (equivalent for finite non-negative costs). jscan's JavaScript cost model scanned up to 30 string prefixes per call and now uses a lookup table. Clone detection on an 11k-line package: 5.9 s → 0.28 s.

**Per-file work was serial.** The four services that walk files now share one helper fanning out over `runtime.NumCPU()` workers, collecting into per-path slots. Clone detection verifies candidate pairs across workers — each with its own APTED analyzer, since those own mutable scratch buffers — and assembles pairs on a single goroutine in candidate order, so pair IDs and clone identities never depend on scheduling.

**MinHash and the LSH index did not scale.** Inserting a fragment scanned each destination bucket linearly for duplicates (quadratic when many fragments hash alike), and every band key went through `fmt.Sprintf` over a freshly allocated hasher. Buckets are now keyed by a comparable struct, the duplicate scan runs only on genuine reindex, hashing is open-coded, and signing stores hash coefficients rather than closures.

| `core/lsh` | Before | After |
|---|---|---|
| index build, 100k fragments | 13.35 s | 0.29 s |
| dense buckets (20k identical) | 5.40 s | 0.075 s |

**`addPairWithLimit` re-sorted the whole result slice on every accepted pair** — O(N log N) per pair with N up to 10000. Replaced with a bounded min-heap.

## Determinism (adjacent fix, please read)

Output was **already nondeterministic before this branch** — two runs of the unmodified binary disagree on `dead_code`. Causes: map iteration order, sort comparators leaving ties unordered, and float summation order. Parallelizing would have made this look like a regression introduced here, so it is fixed rather than inherited. Analysis output is now byte-identical across runs.

That includes `CalculateMaxDepth`, which combined memoization with a path-dependent cycle cutoff and returned 12 or 16 for the same input depending on traversal order. It now uses the same chain finder, so `MaxDepth` agrees with the longest chain the report shows. **This changes reported `deps` values** — previously arbitrary, now stable. It is the one behavioural change in the PR.

## Verification

- Clone and CBO output byte-identical to the pre-change binary over the corpus, on both the LSH and the exhaustive path.
- The MinHash rewrite was checked against the original implementation by differential test. It caught a real bug: Go gives `^` the same precedence as `+`, so `(a*x) ^ b + a + b` groups as `((a*x)^b)+a+b`, not `(a*x)^(b+a+b)`.
- The cost-model rewrite was checked the same way, exhaustively over label pairs and both ignore flags.
- `go test ./...` green in both modules; `-race` clean, including a race-enabled binary over the real corpus.

## Added

- `jscan/service/pipeline_bench_test.go` — drives the whole pipeline over a corpus named by `JSCAN_BENCH_CORPUS`, skips when unset, reports `LOC/s`.
- `core/apted/bench_test.go` — 100–5000 node trees, exact and bounded paths.
- `core/lsh/bench_test.go` — index build at 1k/10k/100k fragments plus dense buckets.
- `docs/performance.md` — measurements, scaling behaviour, tuning knobs, and how to reproduce everything above. Linked from both READMEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
