### PR TITLE
docs: build the jscan documentation site

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,76 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  pull_request:
+    paths:
+      - 'website/**'
+      - '.github/workflows/docs.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: pages-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: website/requirements.txt
+
+      - name: Install dependencies
+        working-directory: website
+        run: pip install -r requirements.txt
+
+      # --strict turns a broken internal link into a build failure.
+      - name: Build (strict)
+        working-directory: website
+        run: mkdocs build --strict
+
+  deploy:
+    needs: build
+    if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+          cache-dependency-path: website/requirements.txt
+
+      - name: Install dependencies
+        working-directory: website
+        run: pip install -r requirements.txt
+
+      - name: Configure git
+        run: |
+          git config --global user.name "github-actions[bot]"
+          git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Deploy to gh-pages
+        working-directory: website
+        run: mkdocs gh-deploy --force --clean --verbose

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ go get github.com/ludo-technologies/polyscan/core
 |-----------|-------------|
 | [`core/`](core/) | Language-agnostic analysis algorithms as a standalone Go module |
 | [`jscan/`](jscan/) | JavaScript/TypeScript code quality analyzer and standalone Go module |
+| [`website/`](website/) | Source of the jscan documentation site at [jscan.codescan.dev](https://jscan.codescan.dev/) |
 
 jscan moved here from its former standalone repository, [ludo-technologies/jscan](https://github.com/ludo-technologies/jscan); releases up to v0.9.0 live there, and newer releases ship from this monorepo under the same npm package name [`jscan`](https://www.npmjs.com/package/jscan). [pyscn](https://github.com/ludo-technologies/pyscn) remains an independent repository and consumes `core/` as a Go module dependency.
 
@@ -95,7 +96,11 @@ Each module is tagged with a directory prefix, e.g. `core/v0.2.1`, `jscan/v0.9.1
 
 ## Documentation
 
-📖 **[pyscn documentation site](https://docs.codescan.dev/)** • **[jscan README](jscan/README.md)** • **[core README](core/README.md)** • **[Performance](docs/performance.md)**
+📖 **[jscan documentation site](https://jscan.codescan.dev/)** • **[pyscn documentation site](https://docs.codescan.dev/)**
+
+**[jscan README](jscan/README.md)** • **[core README](core/README.md)** • **[Performance](docs/performance.md)**
+
+The jscan site is built with MkDocs Material from [`website/`](website/) and deploys to GitHub Pages on every push to `main`.
 
 For contributors: **[Contributing](CONTRIBUTING.md)** • **[Code of Conduct](CODE_OF_CONDUCT.md)** • **[Security](SECURITY.md)**
 

--- a/jscan/CONTRIBUTING.md
+++ b/jscan/CONTRIBUTING.md
@@ -6,17 +6,20 @@ Thank you for your interest in contributing to jscan! This document provides gui
 
 ### Prerequisites
 
-- **Go 1.24+** - [Download Go](https://go.dev/dl/)
+- **Go 1.24.6+** - [Download Go](https://go.dev/dl/)
+- **A C compiler** - required because jscan parses with tree-sitter through cgo
 - **golangci-lint** - [Install instructions](https://golangci-lint.run/welcome/install/)
 - **Make** - Available by default on macOS and Linux
 
 ### Getting Started
 
+jscan lives in the [polyscan monorepo](https://github.com/ludo-technologies/polyscan) under `jscan/`. The standalone `jscan` repository was retired.
+
 1. Fork the repository on GitHub
-2. Clone your fork:
+2. Clone your fork and enter the `jscan` directory:
    ```bash
-   git clone https://github.com/<your-username>/jscan.git
-   cd jscan
+   git clone https://github.com/<your-username>/polyscan.git
+   cd polyscan/jscan
    ```
 3. Install dependencies:
    ```bash

--- a/jscan/README.md
+++ b/jscan/README.md
@@ -171,7 +171,11 @@ Create a `jscan.config.json` or `.jscanrc.json` in your project root:
 
 ## Documentation
 
-📚 **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)** • **[Performance](../docs/performance.md)** • **[Contributing](CONTRIBUTING.md)**
+📚 **[jscan.codescan.dev](https://jscan.codescan.dev/)** — installation, CLI reference, configuration, output formats, and CI/CD integration.
+
+Start with the [quick start](https://jscan.codescan.dev/getting-started/quick-start/), then the [CLI reference](https://jscan.codescan.dev/cli/) and the [configuration guide](https://jscan.codescan.dev/configuration/).
+
+For contributors: **[Development Guide](docs/DEVELOPMENT.md)** • **[Architecture](docs/ARCHITECTURE.md)** • **[Testing](docs/TESTING.md)** • **[Performance](../docs/performance.md)** • **[Contributing](CONTRIBUTING.md)**
 
 ## Enterprise Support
 

--- a/jscan/app/doc.go
+++ b/jscan/app/doc.go
@@ -1,0 +1,30 @@
+// Package app holds reusable use cases that sit between the CLI and the
+// service layer.
+//
+// The use cases here bundle the steps a command would otherwise repeat:
+// collecting files, building a domain request, invoking a service, and
+// formatting the result. AnalyzeUseCase covers the full pipeline, while
+// ComplexityUseCase and DeadCodeUseCase cover a single analysis each.
+//
+// Not every command routes through this package. Handlers in cmd/jscan call
+// services directly when doing so makes the concurrency clearer, which is why
+// the analyze command runs its five analyses itself rather than through
+// AnalyzeUseCase.
+//
+// FileHelper is the piece every command does share. Its CollectJSFiles walks
+// the given paths and returns the JavaScript and TypeScript files to analyze.
+// Two behaviors of that walk are worth knowing, because both silently reduce
+// the input:
+//
+//   - A .gitignore at the root of the walked directory is honored. Only that
+//     one file is read, not nested ones and not the repository root's when a
+//     subdirectory was passed.
+//   - Exclude patterns are applied to directories by exact name or glob, but to
+//     files by glob on the base name OR by plain substring match against the
+//     whole path. The substring rule is broad: the default pattern "out"
+//     removes src/routes/api.ts and src/layout/Header.tsx, and "dist" removes
+//     src/utils/distance.ts.
+//
+// The include patterns parameter is accepted for interface compatibility and
+// ignored. The set of analyzed extensions is fixed in isJSFile.
+package app

--- a/jscan/cmd/jscan/main.go
+++ b/jscan/cmd/jscan/main.go
@@ -1,3 +1,16 @@
+// Command jscan is a code quality analyzer for JavaScript and TypeScript.
+//
+// It provides five subcommands. analyze runs the full analysis and writes a
+// report, check enforces thresholds and sets an exit code for continuous
+// integration, deps inspects and exports the module dependency graph, init
+// writes a configuration file, and version prints build information.
+//
+// Only check varies its exit code by result: 0 when every check passes, 1 when
+// a threshold is violated, and 2 when the analysis could not run. It signals
+// those through CheckExitError, which main unwraps so that the process exits
+// with the right code without cobra printing usage over the report.
+//
+// Full documentation is at https://jscan.codescan.dev/.
 package main
 
 import (

--- a/jscan/docs/DEVELOPMENT.md
+++ b/jscan/docs/DEVELOPMENT.md
@@ -2,15 +2,16 @@
 
 ## Prerequisites
 
-- **Go 1.24+** - [Download](https://go.dev/dl/)
+- **Go 1.24.6+** - [Download](https://go.dev/dl/)
+- **A C compiler** - required because tree-sitter is reached through cgo
 - **golangci-lint** - Required for linting (`make lint`)
 
 ## Getting Started
 
 ```bash
-# Clone the repository
+# Clone the monorepo and enter the jscan module
 git clone https://github.com/ludo-technologies/polyscan.git
-cd jscan
+cd polyscan/jscan
 
 # Download dependencies
 go mod download
@@ -34,7 +35,7 @@ make build
 | `make install` | Build and install the binary via `go install` |
 | `make run` | Build and run against `testdata/javascript/simple/` |
 | `make version` | Print version, commit, and build date |
-| `make build-all` | Cross-compile for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64 |
+| `make build-all` | Attempt builds for linux/amd64, linux/arm64, darwin/amd64, darwin/arm64, windows/amd64. See the note below |
 | `make deps` | Download and verify module dependencies |
 | `make tidy` | Tidy `go.mod` and `go.sum` |
 
@@ -66,3 +67,31 @@ The build injects version metadata via linker flags (`-ldflags`):
 - `Commit` - from `git rev-parse --short HEAD`
 - `Date` - build date
 - `BuiltBy` - set to `make` when built via Makefile
+
+The release workflow injects only `Version`, so a released binary reports
+`unknown` for the commit and date and `source` as its builder.
+
+## Cross-compilation does not work
+
+tree-sitter is a C library reached through cgo, so setting `GOOS` and `GOARCH`
+only succeeds for the platform you are already on. `make build-all` will fail
+for the other targets.
+
+This is why `.github/workflows/jscan-release.yml` builds each target on its own
+runner rather than cross-compiling from one. Note that there is no Intel macOS
+target: the release matrix covers linux/amd64, linux/arm64, darwin/arm64, and
+windows/amd64.
+
+## Documentation site
+
+The user-facing documentation at [jscan.codescan.dev](https://jscan.codescan.dev/)
+is built with MkDocs Material from `website/` at the repository root.
+
+```bash
+cd ../website
+pip install -r requirements.txt
+mkdocs serve
+```
+
+CI builds it with `mkdocs build --strict`, so a broken internal link fails the
+build.

--- a/jscan/domain/doc.go
+++ b/jscan/domain/doc.go
@@ -1,0 +1,27 @@
+// Package domain holds jscan's models and the interfaces its services
+// implement. It is the innermost layer: every other package may import it,
+// and it imports none of them.
+//
+// The types here fall into three groups.
+//
+// Request and response pairs describe one analysis each. ComplexityRequest and
+// ComplexityResponse, DeadCodeRequest and DeadCodeResponse, CloneRequest and
+// CloneResponse, CBORequest and CBOResponse, and DependencyGraphRequest and
+// DependencyGraphResponse follow the same shape: the request carries paths and
+// thresholds, and the response carries findings, a summary, and any warnings or
+// errors gathered along the way. A failure analyzing one file is reported in
+// those slices rather than returned as an error, so a single unparsable file
+// never costs the caller the whole run.
+//
+// AnalyzeSummary aggregates all five into the health score. Its
+// CalculateHealthScore method applies the penalty model from
+// polyscan/core/domain, which pyscn shares, so a grade means the same thing in
+// both analyzers.
+//
+// Adapters connect the language-neutral algorithms in polyscan/core to jscan's
+// own types. Clone satisfies core/clone.GroupableItem through ItemID and
+// ItemLocation so that the shared grouping strategies can operate on JavaScript
+// fragments, and DependencyGraph satisfies core/graph.DirectedGraph through
+// NodeIDs, Successors, and Predecessors so that Tarjan cycle detection and the
+// Martin coupling metrics can run over the module graph.
+package domain

--- a/jscan/internal/analyzer/doc.go
+++ b/jscan/internal/analyzer/doc.go
@@ -1,0 +1,56 @@
+// Package analyzer holds jscan's analysis engines. Everything that inspects
+// parsed JavaScript or TypeScript and produces a finding lives here.
+//
+// The language-neutral algorithms are imported from polyscan/core and shared
+// with pyscn. What stays in this package is the JavaScript and TypeScript
+// knowledge those algorithms need: how the language's statements affect control
+// flow, how its modules resolve, and what its syntax costs in a tree
+// comparison.
+//
+// # Control flow
+//
+// CFGBuilder turns a parsed function into a core/cfg.CFG. The shared package
+// then computes reachability, McCabe complexity, and dead code over that graph,
+// while javaScriptCFGClassifier supplies the language-specific answers about
+// which statements terminate a block and which are no-ops.
+//
+// One consequence of the current builder is worth knowing: a switch statement
+// produces a single branch regardless of how many cases it has, so a four-case
+// switch scores 2 where an equivalent chain of four if statements scores 5.
+//
+// # Dead code
+//
+// Two independent passes feed the dead code results. dead_code.go and
+// reachability.go find statements unreachable within one function, all of which
+// are reported as critical. unused_code.go compares imports against exports
+// across every file in the run to find unused imports, unused exports, and
+// orphan files. That second pass can only see the files it was given, which is
+// why analyzing a subdirectory reports its exports as unused.
+//
+// unused_code.go also carries the framework exemptions. Next.js App Router
+// convention files keep their default export and the framework's reserved
+// export names without being reported.
+//
+// # Clone detection
+//
+// clone_detector.go finds duplicate code in two stages. MinHash fingerprints
+// and locality-sensitive hashing from core/lsh narrow the candidate pairs,
+// after which APTED tree edit distance from core/apted compares the survivors.
+// The kernels are shared; apted_tree.go contributes the parser-to-tree
+// converter, apted_cost.go the JavaScript cost model, and javascript_comments.go
+// the comment stripper that core/clone injects.
+//
+// # Modules and coupling
+//
+// module_analyzer.go resolves ECMAScript and CommonJS imports and exports, and
+// dependency_graph.go assembles them into the module graph. Note that
+// TypeScript path aliases such as "@/lib/util" are not resolved: each becomes a
+// module node of its own rather than pointing at the file it refers to, which
+// inflates module counts and hides cycles that pass through an alias.
+//
+// cbo.go measures coupling. Despite the name it produces one entry per file
+// rather than per class, named after the module.
+// circular_detector.go enriches core/graph's Tarjan results, excluding dynamic
+// imports because those do not create a load-time cycle, and
+// coupling_metrics.go layers the Martin metrics on top.
+package analyzer

--- a/jscan/internal/config/doc.go
+++ b/jscan/internal/config/doc.go
@@ -1,0 +1,47 @@
+// Package config loads, validates, and generates jscan configuration.
+//
+// LoadConfigWithTarget is the entry point every command uses. Given an explicit
+// path it loads exactly that file; given none it searches, starting at the
+// analyzed path and walking upward to the filesystem root before falling back
+// to the current directory, the XDG config directory, ~/.config/jscan, the home
+// directory, and finally the JSCAN_CONFIG and PYSCN_CONFIG variables. Searching
+// upward from the target rather than the working directory is what lets a
+// monorepo package carry its own configuration. The pyscn-prefixed filenames
+// and variables are accepted for backward compatibility.
+//
+// Viper supplies the parsing, so JSON, YAML, and TOML are all accepted and the
+// format follows the file extension.
+//
+// Validate enforces the constraints on every group, and an invalid value fails
+// the whole run.
+//
+// # Applied and unapplied settings
+//
+// Config models more than the commands currently consume. Validation covers the
+// whole struct, but only these fields reach behavior:
+//
+//   - Complexity.LowThreshold and Complexity.MediumThreshold, in analyze and check
+//   - Complexity.MaxComplexity, in check only, as the default for --max-complexity
+//   - Output.MinComplexity, in analyze only
+//   - Analysis.ExcludePatterns, in analyze, check, and deps
+//
+// Everything else is parsed, validated, and then ignored, including all of
+// DeadCode, Clones, SystemAnalysis, Dependencies, Architecture, ModuleAnalysis,
+// Analysis.IncludePatterns, Analysis.Recursive, Analysis.FollowSymlinks,
+// Complexity.Enabled, and Complexity.ReportUnchanged.
+//
+// The helper methods AssessRiskLevel, ShouldReport, ShouldDetectDeadCode,
+// GetMinSeverityLevel, and HasAnyDetectionEnabled exist for those unapplied
+// settings and have no callers outside tests. Anything wiring a setting up
+// should use them rather than reimplementing the checks.
+//
+// # Templates
+//
+// GetFullConfigTemplate and GetMinimalConfigTemplate produce the files written
+// by jscan init, combining a ProjectType preset that selects file patterns with
+// a Strictness preset that selects complexity thresholds. Both emit plain JSON
+// with no comments.
+//
+// Note that the generated exclude list is shorter than DefaultConfig's, so
+// writing a configuration file narrows what jscan skips rather than widening it.
+package config

--- a/jscan/internal/constants/doc.go
+++ b/jscan/internal/constants/doc.go
@@ -1,0 +1,13 @@
+// Package constants holds the tuning values shared across the analyzers.
+//
+// Clone detection is the main consumer. DefaultCloneMinLines and
+// DefaultCloneMinNodes set the floor on fragment size, which keeps short
+// boilerplate such as getters and one-line handlers out of the results. The
+// DefaultTypeNCloneThreshold values set the similarity required for each clone
+// type, and DefaultLSHAutoThreshold is the fragment count above which
+// locality-sensitive hashing switches on automatically.
+//
+// These are defaults rather than settings. The clones group in the
+// configuration file is parsed but not applied, so changing a value here
+// changes the behavior for every run.
+package constants

--- a/jscan/internal/parser/doc.go
+++ b/jscan/internal/parser/doc.go
@@ -1,0 +1,24 @@
+// Package parser wraps tree-sitter and turns JavaScript and TypeScript source
+// into the syntax tree the analyzers work on.
+//
+// tree-sitter is error tolerant, so a file with a syntax error still yields a
+// usable tree rather than nothing. That is what lets jscan analyze a codebase
+// mid-refactor. It also means no type information is available anywhere in
+// jscan: nothing here invokes tsc or reads tsconfig.json, so every finding
+// comes from syntax alone.
+//
+// The parser handles .js, .jsx, .mjs, .cjs, .ts, .tsx, .mts, and .cts. Vue
+// single-file components are not supported, so the script block inside a .vue
+// file is never parsed.
+//
+// Node is jscan's own syntax tree node, built from the tree-sitter parse tree
+// rather than wrapping it. It carries the children, source location, parent
+// link, and the declaration fields the analyzers need, such as Name, Params,
+// and Body. Its Type is a NodeType, whose values are jscan's own names for the
+// constructs the analyzers match on, for example NodeIfStatement and
+// NodeReturnStatement, rather than the underlying tree-sitter node kinds.
+//
+// Because tree-sitter is a C library reached through cgo, this package is the
+// reason jscan cannot be cross-compiled and the reason building from source
+// needs a C compiler.
+package parser

--- a/jscan/internal/reporter/doc.go
+++ b/jscan/internal/reporter/doc.go
@@ -1,0 +1,12 @@
+// Package reporter formats complexity results for text, JSON, CSV, and HTML
+// output.
+//
+// Nothing in jscan currently imports this package. The CLI formats its output
+// through service.OutputFormatterImpl instead, so the code here runs only under
+// its own tests. It is kept because it is the only caller of
+// config.ComplexityConfig.ExceedsMaxComplexity, which is the intended home for
+// max-complexity reporting in analyze rather than only in check.
+//
+// Treat this as unwired rather than as a second supported path: changing the
+// report format here will not change what any command prints.
+package reporter

--- a/jscan/internal/version/doc.go
+++ b/jscan/internal/version/doc.go
@@ -1,0 +1,11 @@
+// Package version carries the build metadata reported by jscan version.
+//
+// All four variables are set through linker flags at build time and hold
+// placeholders otherwise: Version defaults to "dev", Commit and Date to
+// "unknown", and BuiltBy to "source".
+//
+// The Makefile populates all four. The release workflow sets only Version, so
+// an official release binary still reports "unknown" for the commit and date
+// and "source" as its builder. Anything that reads those fields should treat
+// them as unpopulated rather than as evidence about how the binary was built.
+package version

--- a/jscan/service/doc.go
+++ b/jscan/service/doc.go
@@ -1,0 +1,28 @@
+// Package service orchestrates the analyzers and turns their results into
+// output. It sits between the CLI in cmd/jscan and the engines in
+// internal/analyzer.
+//
+// Each analysis has a service that owns its pipeline: ComplexityServiceImpl,
+// the dead code functions in dead_code_service.go and dead_code_aggregate.go,
+// CloneServiceImpl, CBOServiceImpl, and DependencyGraphServiceImpl. They all
+// take a domain request, fan the work out across files, and return a domain
+// response. A file that fails to parse contributes a warning or an error to the
+// response rather than aborting the run.
+//
+// Dead code detection is split in two because the two halves need different
+// inputs. Per-function unreachable code comes from each file's control flow
+// graph on its own, while unused imports, unused exports, and orphan files can
+// only be decided once every file in the run has been read. That cross-file
+// pass is why analyzing a subdirectory reports its exports as unused: the
+// importers were never part of the input.
+//
+// Output is handled by OutputFormatterImpl for text, JSON, YAML, CSV, and HTML,
+// and by DOTFormatter for Graphviz. Note that the CLI reaches only the text,
+// JSON, HTML, and DOT paths today; analyze maps any --format value other than
+// json or text to HTML, leaving the YAML and CSV writers unreachable.
+//
+// BuildAnalyzeSummary combines the five responses into a domain.AnalyzeSummary
+// and computes the health score. Because a nil response is treated as an
+// analysis that did not run, and a category that did not run contributes no
+// penalty, summaries built from different --select values are not comparable.
+package service

--- a/website/.gitignore
+++ b/website/.gitignore
@@ -1,0 +1,4 @@
+site/
+.cache/
+__pycache__/
+*.pyc

--- a/website/docs/CNAME
+++ b/website/docs/CNAME
@@ -1,0 +1,1 @@
+jscan.codescan.dev

--- a/website/docs/assets/icon.svg
+++ b/website/docs/assets/icon.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none">
+  <path d="M7 9C7 7.34315 8.34315 6 10 6H14C15.6569 6 17 7.34315 17 9V13C17 14.6569 15.6569 16 14 16H10C8.34315 16 7 17.3431 7 19V20" stroke="#3178c6" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"/>
+  <circle cx="17" cy="19" r="2" fill="#f7df1e"/>
+</svg>

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -1,0 +1,168 @@
+# jscan analyze
+
+Runs the full analysis and produces a report. This is the command you reach for when you want to understand a codebase rather than gate a pull request.
+
+```bash
+jscan analyze [path...]
+```
+
+`analyze` always exits with code 0 when the analysis itself succeeds, no matter how poor the results are. Use [`jscan check`](check.md) when you need a command that fails.
+
+## Synopsis
+
+```bash
+jscan analyze src/                                    # All analyses, HTML report
+jscan analyze --select complexity,deadcode src/       # Two analyses only
+jscan analyze --json src/                             # JSON to standard output
+jscan analyze --text src/                             # Text to standard output
+jscan analyze --no-open src/                          # HTML report, no browser
+jscan analyze -o reports/quality.html src/            # Custom output path
+jscan analyze -c config/strict.json src/              # Explicit config file
+jscan analyze src/ test/ scripts/build.ts             # Several paths at once
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--select` | `-s` | `complexity,deadcode,clone,cbo,deps` | Comma-separated list of analyses to run |
+| `--format` | `-f` | `html` | Output format. Accepts `html`, `json`, or `text` |
+| `--json` | | `false` | Shorthand for `--format json` |
+| `--text` | | `false` | Shorthand for `--format text` |
+| `--html` | | `false` | Shorthand for `--format html`, which is already the default |
+| `--no-open` | | `false` | Write the HTML report without opening a browser |
+| `--output` | `-o` | `jscan-report.html` | Path for the HTML report file |
+| `--config` | `-c` | discovered | Path to a configuration file |
+
+!!! warning "Only three formats are recognized"
+
+    `--format` silently falls back to HTML for any value other than `json` or `text`. Passing `--format csv` or `--format yaml` produces an HTML report rather than an error, so check the flag spelling if you receive HTML unexpectedly.
+
+If both `--json` and `--text` are given, JSON wins.
+
+## Output behavior
+
+The format determines where results go and what else is printed.
+
+=== "HTML (default)"
+
+    jscan writes the report to `jscan-report.html` in the current directory, prints the absolute path, and opens the file in your default browser. The browser step is skipped when `--no-open` is set and also when jscan detects that it is running inside an SSH session. A short score summary follows on standard output.
+
+=== "JSON"
+
+    The full result document goes to standard output. The score summary goes to standard error, so that redirecting standard output to a file keeps the JSON valid. Progress bars are suppressed. The [JSON schema page](../output/json-schema.md) documents every field.
+
+=== "Text"
+
+    The full human-readable report goes to standard output, ending with the health score breakdown. No separate summary is printed to standard error, because the text report already contains one.
+
+## The five analyses
+
+### Complexity {#complexity}
+
+Measures the cyclomatic complexity of every function, which counts the number of linearly independent paths through it. jscan builds a control flow graph for each function and derives the count from the graph, so the number reflects real branching rather than a text heuristic.
+
+Starting from a baseline of 1, each of the following adds 1: an `if` or `else if`, a loop, a `catch`, a ternary, and each `&&`, `||`, or `??` operator. Optional chaining with `?.` adds nothing.
+
+!!! warning "`switch` is counted as a single branch"
+
+    A `switch` statement adds 1 no matter how many cases it contains. A four-case switch scores 2, while the same logic written as four `if` statements scores 5. The `switch_cases` field in the JSON output is always 0.
+
+    Code built around large switch statements, such as reducers and state machines, is therefore scored more leniently than equivalent code written with `if`. A low score on a large switch is not evidence that it is simple.
+
+Functions are assigned a risk level from two thresholds, both configurable:
+
+| Risk | Condition | Default range |
+| --- | --- | --- |
+| Low | complexity ≤ `low_threshold` | 1 to 9 |
+| Medium | `low_threshold` < complexity ≤ `medium_threshold` | 10 to 19 |
+| High | complexity > `medium_threshold` | 20 and above |
+
+Functions below `output.min_complexity` are dropped from the report entirely. The default is 1, which keeps everything.
+
+### Dead code {#dead-code}
+
+Finds code that cannot run and code that nothing uses. jscan detects two distinct kinds of problem.
+
+Unreachable statements come from the control flow graph. Any basic block that cannot be reached from the function entry is dead. This covers statements after `return`, `break`, `continue`, and `throw`, and branches whose condition can never hold.
+
+Unused declarations come from a cross-file pass that resolves imports and exports across every analyzed file. An exported function that no analyzed file imports is reported, as are unused imports and files that nothing references.
+
+Every finding carries a reason code and a severity. The full set is:
+
+| Reason code | Severity | What it means |
+| --- | --- | --- |
+| `unreachable_after_return` | Critical | A statement follows a `return` in the same block |
+| `unreachable_after_throw` | Critical | A statement follows a `throw` |
+| `unreachable_after_break` | Critical | A statement follows a `break` |
+| `unreachable_after_continue` | Critical | A statement follows a `continue` |
+| `unreachable_after_infinite_loop` | Critical | A statement follows a loop that never exits |
+| `unreachable_branch` | Critical | A branch whose condition can never hold |
+| `unused_import` | Warning | An imported name is never used in the importing file |
+| `unused_exported_function` | Warning | An exported function or class is imported by no analyzed file |
+| `orphan_file` | Warning | A file that no analyzed file imports |
+| `unused_export` | Info | An exported value other than a function is imported by no analyzed file |
+
+The six critical reasons come from the control flow graph. The four remaining ones come from the cross-file import and export pass.
+
+!!! note "Cross-file findings depend on the paths you pass"
+
+    The unused-export check can only see the files included in the run. Analyzing `src/components/` alone reports every export in it as unused, because the importers in the rest of `src/` were never read. Pass the whole source root when you care about this finding.
+
+### Duplicate code {#clone}
+
+Finds fragments that repeat. jscan compares abstract syntax trees rather than raw text, using the APTED tree edit distance algorithm, so it still matches code whose variables have been renamed or whose statements have moved. To keep the comparison affordable on large codebases, jscan first narrows the candidate set with MinHash fingerprints and locality-sensitive hashing, then runs the expensive tree comparison only on surviving pairs.
+
+Clones are graded into four types:
+
+| Type | Description | Default threshold | Enabled by default |
+| --- | --- | --- | --- |
+| Type 1 | Identical apart from whitespace and comments | 0.85 | Yes |
+| Type 2 | Identical after renaming identifiers and literals | 0.75 | Yes |
+| Type 3 | Copies with statements added, removed, or changed | 0.70 | No |
+| Type 4 | Different code that computes the same thing | 0.65 | Yes |
+
+Type 3 is off by default because near-miss matches produce a high false positive rate in day-to-day use.
+
+A fragment must be at least 10 lines and 20 syntax tree nodes to be considered, which keeps short boilerplate such as getters out of the results.
+
+### Coupling between objects {#cbo}
+
+Counts how many other types each unit depends on, across four kinds of dependency: imports, `new` expressions, TypeScript type annotations, and method calls on other objects.
+
+!!! info "In jscan this metric is per file, not per class"
+
+    Despite the name, jscan produces one coupling entry per source file, named after the module. The terminal output and the JSON field names still say "classes", which they inherit from the shared metric definition. Read every count as a per-module count.
+
+| Risk | Condition |
+| --- | --- |
+| Low | CBO ≤ 3 |
+| Medium | 3 < CBO ≤ 7 |
+| High | CBO > 7 |
+
+### Dependencies {#deps}
+
+Builds the module import graph, resolving both ECMAScript modules and CommonJS `require` calls. From the graph jscan derives the circular imports, the maximum dependency depth, and the Martin coupling metrics for each module.
+
+Circular imports are found with Tarjan's strongly connected components algorithm. Dynamic imports are excluded from the cycle check, because a dynamic import does not create a load-time cycle.
+
+For a graph you can look at rather than a summary, use [`jscan deps`](deps.md).
+
+## Performance notes
+
+The five analyses run concurrently in separate goroutines, so the wall clock time is set by the slowest one rather than by the sum. Clone detection is normally the slowest, followed by dead code detection.
+
+Dropping the analyses you do not need is the most effective way to speed up a run:
+
+```bash
+# Roughly half the work of a full run on most projects
+jscan analyze --select complexity,deadcode src/
+```
+
+The progress bar shown during an interactive run is driven by an elapsed-time estimate rather than by real progress, so it may sit near the end for a while on an unusually large repository. It is not stuck.
+
+## See also
+
+- [`jscan check`](check.md) for a command that fails on threshold violations
+- [Output formats](../output/index.md) for the shape of each report
+- [Configuration reference](../configuration/reference.md) for the keys that change these thresholds

--- a/website/docs/cli/check.md
+++ b/website/docs/cli/check.md
@@ -1,0 +1,159 @@
+# jscan check
+
+Runs a subset of the analyses against thresholds and sets a process exit code. This is the command to put in a continuous integration pipeline.
+
+```bash
+jscan check [path...]
+```
+
+## Exit codes
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Every check passed |
+| 1 | At least one threshold was violated |
+| 2 | The analysis could not run, for example because a path does not exist or no source file was found |
+
+Distinguishing 1 from 2 matters in a pipeline. Exit code 1 means jscan worked and your code did not meet the bar. Exit code 2 means jscan itself could not do its job, which usually points at a wrong path or a misconfigured job.
+
+## Synopsis
+
+```bash
+jscan check src/                                # Defaults
+jscan check --max-complexity 10 src/            # Fail above complexity 10
+jscan check --allow-dead-code src/              # Report dead code without failing
+jscan check --allow-circular-deps src/          # Tolerate circular imports
+jscan check --max-cycles 3 src/                 # Tolerate up to three cycles
+jscan check --select complexity,deps src/       # Skip dead code detection
+jscan check --json src/                         # Machine-readable result
+jscan check --verbose src/                      # Show locations and a summary
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--max-complexity` | | `10` | Fail when any function exceeds this cyclomatic complexity |
+| `--allow-dead-code` | | `false` | Report dead code findings without failing |
+| `--allow-circular-deps` | | `false` | Report circular imports without failing |
+| `--max-cycles` | | `0` | Number of dependency cycles tolerated before failing |
+| `--select` | `-s` | `complexity,deadcode,deps` | Analyses to run |
+| `--verbose` | `-v` | `false` | Print file locations and a summary block |
+| `--json` | | `false` | Emit the result as JSON on standard output |
+| `--config` | `-c` | discovered | Path to a configuration file |
+
+`--select` accepts only `complexity`, `deadcode`, and `deps`. Clone detection and coupling analysis are not available in `check`, because both are too slow for a gate. Run them through [`jscan analyze`](analyze.md) instead.
+
+When you do not pass `--max-complexity` on the command line, jscan uses `complexity.max_complexity` from the configuration file if that value is greater than 0. An explicit flag always wins over the file.
+
+## The default gate is strict
+
+Running `jscan check` with no flags fails on **any** dead code finding, including warnings. The threshold is zero findings, not zero critical findings.
+
+```console
+$ jscan check src/
+FAIL: Quality check failed
+  Violations: 2
+  [ERROR] deadcode: Found 1 critical dead code issues
+  [WARN] deadcode: Found 2 warning-level dead code issues
+```
+
+The warning that dominates real projects is `unused_exported_function`, which fires whenever an exported function is not imported by another analyzed file. In a library package that is the normal state of every public export, since the importers live in other repositories entirely. The same happens when you analyze one subdirectory of a larger application.
+
+Most projects should therefore start permissive and tighten over time:
+
+```bash
+# A reasonable starting point
+jscan check --allow-dead-code --max-complexity 15 src/
+```
+
+Once the obvious problems are fixed, drop `--allow-dead-code` and lower `--max-complexity` toward 10.
+
+## What each check does
+
+### Complexity
+
+Every function is compared against `--max-complexity`. Each function above the limit produces its own violation, so the count in the output is a count of functions rather than of files.
+
+```text
+[ERROR] complexity: Function 'handleRequest' has complexity 24
+       at src/server/router.ts:88
+```
+
+The location line appears only with `--verbose`.
+
+### Dead code
+
+Unless `--allow-dead-code` is set, any finding at all fails the check. jscan emits at most two violations here, one aggregating the critical findings and one aggregating the warnings, each carrying a count rather than a per-finding entry. Use [`jscan analyze`](analyze.md) when you need the individual locations.
+
+Findings at info severity are counted in the totals but do not produce a violation of their own.
+
+### Dependencies
+
+Circular imports fail the check when their count exceeds `--max-cycles`, which defaults to 0. Setting `--allow-circular-deps` disables the check regardless of `--max-cycles`.
+
+With `--verbose`, each individual cycle is listed after the summary violation, one line per cycle, with the module path that forms it.
+
+## Verbose output
+
+`--verbose` changes both the passing and the failing output. On success it reports what was checked:
+
+```console
+$ jscan check --verbose --allow-dead-code src/
+PASS: All quality checks passed
+  Files analyzed: 2
+  Duration: 3ms
+  Complexity: checked (max: 10)
+  Dead code: checked
+  Dependencies: checked
+```
+
+On failure it adds the source location of each violation and a closing summary with the totals.
+
+## JSON output
+
+`--json` writes a single document to standard output and suppresses the progress display. The exit code is unchanged, so the pipeline still fails on a violation.
+
+```json
+{
+  "passed": false,
+  "exit_code": 1,
+  "violations": [
+    {
+      "category": "deadcode",
+      "rule": "no-dead-code",
+      "severity": "error",
+      "message": "Found 1 critical dead code issues",
+      "actual": "1",
+      "threshold": "0"
+    }
+  ],
+  "summary": {
+    "files_analyzed": 2,
+    "total_violations": 1,
+    "complexity_checked": true,
+    "deadcode_checked": true,
+    "deps_checked": true,
+    "high_complexity_functions": 0,
+    "dead_code_findings": 3,
+    "circular_dependencies": 0
+  },
+  "duration_ms": 2,
+  "generated_at": "2026-08-04T16:20:56+09:00",
+  "version": "0.4.1"
+}
+```
+
+Violations carry a `location` field as well when the check that produced them knows one, which today means the complexity check.
+
+| Category | Rule | Raised when |
+| --- | --- | --- |
+| `complexity` | `max-complexity` | A function exceeds the complexity limit |
+| `deadcode` | `no-dead-code` | Dead code was found and `--allow-dead-code` is unset |
+| `deps` | `max-cycles` | Cycle count exceeds `--max-cycles` |
+| `deps` | `circular-dependency` | One entry per cycle, added only with `--verbose` |
+
+## See also
+
+- [CI/CD integration](../integrations/ci-cd.md) for complete pipeline configurations
+- [`jscan analyze`](analyze.md) for the detailed findings behind a failure

--- a/website/docs/cli/deps.md
+++ b/website/docs/cli/deps.md
@@ -1,0 +1,125 @@
+# jscan deps
+
+Builds the module dependency graph and writes it as text, JSON, or Graphviz DOT.
+
+```bash
+jscan deps [path...]
+```
+
+## Synopsis
+
+```bash
+jscan deps src/                                 # Text summary
+jscan deps --dot src/ > deps.dot                # DOT to a file
+jscan deps --dot src/ | dot -Tsvg -o deps.svg   # Render directly
+jscan deps --format json src/                   # JSON for further processing
+jscan deps --dot --min-coupling 5 src/          # Only the busiest modules
+jscan deps --dot --rank-dir LR src/             # Left to right layout
+jscan deps --include-external src/              # Include node_modules packages
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--format` | `-f` | `text` | Output format. Accepts `text`, `json`, or `dot` |
+| `--dot` | | `false` | Shorthand for `--format dot` |
+| `--output` | `-o` | standard output | Write to this file instead |
+| `--include-external` | | `false` | Include packages resolved into `node_modules` |
+| `--include-types` | | `true` | Include TypeScript type-only imports as edges |
+| `--no-cycles` | | `false` | Skip cycle detection, and stop grouping cycles in DOT output |
+| `--max-depth` | | `0` | Limit the depth rendered in DOT output. 0 means unlimited |
+| `--min-coupling` | | `0` | Render only nodes whose coupling is at least this value |
+| `--no-legend` | | `false` | Omit the legend from DOT output |
+| `--rank-dir` | | `TB` | DOT layout direction. Accepts `TB`, `LR`, `BT`, or `RL` |
+| `--config` | `-c` | discovered | Path to a configuration file |
+
+`--max-depth`, `--min-coupling`, `--no-legend`, and `--rank-dir` affect DOT rendering only. They are accepted but ignored for text and JSON output.
+
+## Text output
+
+The default format prints a summary of the graph rather than the graph itself:
+
+```console
+$ jscan deps src/
+Analyzing 2 files...
+
+=== Dependency Graph Analysis ===
+
+Generated: 2026-08-04T16:20:46+09:00
+Version: 0.4.1
+
+Summary:
+  Total modules: 2
+  Total dependencies: 1
+  Root modules (entry points): 1
+  Leaf modules (no dependencies): 1
+  Max depth: 1
+
+Coupling Analysis:
+  Average coupling: 1.00
+  Average instability: 0.50
+  Highly coupled modules: 0
+  Stable modules: 1
+
+Entry Points:
+  - /home/you/project/src/report.js
+
+Analysis completed in 1ms
+```
+
+A root module is one that nothing imports, which usually means an application entry point or a file only your tests reach. A leaf module imports nothing else in the analyzed set. Max depth is the length of the longest import chain.
+
+## DOT output
+
+`--dot` writes a Graphviz document. Render it with the `dot` program, which comes with a Graphviz installation:
+
+```bash
+jscan deps src/ --dot | dot -Tsvg -o deps.svg
+jscan deps src/ --dot | dot -Tpng -o deps.png
+```
+
+Each node is colored by risk level and carries a tooltip with its coupling numbers:
+
+| Color | Meaning |
+| --- | --- |
+| Green | Low risk |
+| Yellow | Medium risk |
+| Red | High risk |
+
+The tooltip shows the module's role, its afferent coupling `Ca`, its efferent coupling `Ce`, and its instability. Those terms are defined on the [dependency graph guide](../guides/dependency-graph.md).
+
+Unless `--no-cycles` is passed, modules that form a circular import are grouped into a visual cluster, which makes cycles easy to spot in a large graph.
+
+Large graphs become unreadable quickly. Two flags help:
+
+```bash
+# Drop the leaves and keep the hubs
+jscan deps src/ --dot --min-coupling 5 | dot -Tsvg -o hubs.svg
+
+# Wide graphs usually read better horizontally
+jscan deps src/ --dot --rank-dir LR | dot -Tsvg -o deps.svg
+```
+
+## JSON output
+
+`--format json` emits the full graph together with the analysis results, which suits scripting and dashboards:
+
+```bash
+# List every module involved in a circular import
+jscan deps src/ --format json \
+  | jq -r '.analysis.circular_dependencies.circular_dependencies[].description'
+```
+
+The document contains a `graph` object with the nodes and edges, and an `analysis` object holding the cycle detection results, the depth calculation, and the coupling metrics.
+
+## External and type-only dependencies
+
+By default the graph contains only your own modules. Packages from `node_modules` are left out, which keeps the picture about your architecture rather than about your dependency tree. Pass `--include-external` when you want to see which third-party packages each module pulls in.
+
+TypeScript type-only imports, written as `import type { Foo } from "./foo"`, are included by default because they still express a design dependency. They disappear at compile time, so pass `--include-types=false` if you want the graph to reflect only what exists at runtime.
+
+## See also
+
+- [Reading the dependency graph](../guides/dependency-graph.md) for what the metrics mean
+- [`jscan check`](check.md) for failing a build on circular imports

--- a/website/docs/cli/index.md
+++ b/website/docs/cli/index.md
@@ -1,0 +1,66 @@
+# CLI Reference
+
+jscan exposes five commands. Every command accepts one or more paths, and every path may be a file or a directory.
+
+| Command | Purpose | Fails the build? |
+| --- | --- | --- |
+| [`analyze`](analyze.md) | Run the full analysis and produce a report | No |
+| [`check`](check.md) | Enforce quality thresholds for continuous integration | Yes, exit code 1 or 2 |
+| [`deps`](deps.md) | Inspect and export the module dependency graph | No |
+| [`init`](init.md) | Write a configuration file | No |
+| [`version`](version.md) | Print version information | No |
+
+```console
+$ jscan --help
+jscan is a high-performance static analyzer for JavaScript and TypeScript code.
+It provides complexity analysis, dead code detection, and more.
+
+Usage:
+  jscan [command]
+
+Available Commands:
+  analyze     Analyze JavaScript/TypeScript files
+  check       Fast quality check for CI/CD pipelines
+  completion  Generate the autocompletion script for the specified shell
+  deps        Analyze and visualize module dependencies
+  help        Help about any command
+  init        Generate a jscan configuration file
+  version     Print version information
+
+Flags:
+  -h, --help      help for jscan
+  -v, --version   version for jscan
+
+Use "jscan [command] --help" for more information about a command.
+```
+
+## Which files jscan reads
+
+Every command that takes a path walks the directory tree and collects files with these extensions:
+
+`.js` &nbsp; `.jsx` &nbsp; `.mjs` &nbsp; `.cjs` &nbsp; `.ts` &nbsp; `.tsx` &nbsp; `.mts` &nbsp; `.cts`
+
+The walk always recurses into subdirectories and never follows symbolic links. Directories and filename patterns listed under `analysis.exclude_patterns` in the configuration file are skipped. That list defaults to dependency directories such as `node_modules`, build outputs such as `dist` and `.next`, cache directories, and minified or bundled files. The full default list appears in the [configuration reference](../configuration/reference.md#analysisexclude_patterns).
+
+If no matching file is found, the command stops with the error `no JavaScript/TypeScript files found`.
+
+## Shell completion
+
+Cobra, the command line framework jscan is built on, generates completion scripts:
+
+```bash
+# bash
+jscan completion bash > /etc/bash_completion.d/jscan
+
+# zsh
+jscan completion zsh > "${fpath[1]}/_jscan"
+
+# fish
+jscan completion fish > ~/.config/fish/completions/jscan.fish
+```
+
+Run `jscan completion --help` for the PowerShell instructions and for notes on loading the script for the current session only.
+
+## Configuration file discovery
+
+Commands other than `version` look for a configuration file before they run. When you do not pass `--config`, jscan searches upward from the analyzed path toward the filesystem root, then falls back to several well-known locations. The [configuration guide](../configuration/index.md#how-jscan-finds-your-config-file) documents the search order and the accepted filenames.

--- a/website/docs/cli/init.md
+++ b/website/docs/cli/init.md
@@ -1,0 +1,126 @@
+# jscan init
+
+Writes a configuration file so you do not have to repeat flags on every run.
+
+```bash
+jscan init
+```
+
+By default this creates `jscan.config.json` in the current directory. The command refuses to overwrite an existing file unless you pass `--force`.
+
+## Synopsis
+
+```bash
+jscan init                        # Write jscan.config.json here
+jscan init --config custom.json   # Write to another path
+jscan init --force                # Overwrite an existing file
+jscan init --minimal              # Write only the essential keys
+jscan init --interactive          # Answer a few questions first
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--config` | `-c` | `jscan.config.json` | Path of the file to write |
+| `--force` | `-f` | `false` | Overwrite the file if it already exists |
+| `--minimal` | | `false` | Write a shorter file with essential keys only |
+| `--interactive` | `-i` | `false` | Ask about the project type and strictness first |
+
+The parent directory must already exist. `jscan init --config config/jscan.json` fails if there is no `config` directory.
+
+## Interactive setup
+
+`--interactive` asks two questions and then writes a file tuned to the answers.
+
+The first question is the project type, which decides the include and exclude patterns:
+
+| Choice | Adds to the excluded paths | Notable include patterns |
+| --- | --- | --- |
+| Generic JavaScript/TypeScript | `node_modules`, `dist`, `build` | `.js`, `.ts`, `.jsx`, `.tsx` |
+| React or Next.js | also `.next` and `coverage` | same as generic |
+| Vue or Nuxt | also `.nuxt` and `coverage` | same as generic, plus `.vue` |
+| Node.js backend | also `test`, `tests`, `__tests__` | `.js`, `.ts`, `.mjs`, `.cjs` |
+
+The second question is how strict the complexity thresholds should be:
+
+| Choice | `low_threshold` | `medium_threshold` | `max_complexity` |
+| --- | --- | --- | --- |
+| Relaxed | 15 | 30 | 0, meaning no limit |
+| Standard | 10 | 20 | 0, meaning no limit |
+| Strict | 5 | 10 | 15 |
+
+Finally it asks where to write the file, offering the current directory.
+
+!!! note "The Vue preset lists a pattern jscan cannot use yet"
+
+    Choosing Vue or Nuxt adds `**/*.vue` to `analysis.include_patterns`. jscan does not parse single-file components today, and it does not read `include_patterns` at all, so the entry has no effect. Vue support is on the roadmap. The `.js` and `.ts` files in a Vue project are analyzed normally.
+
+## The generated file
+
+Without `--interactive`, `jscan init` writes the generic project preset at standard strictness:
+
+```json
+{
+  "complexity": {
+    "enabled": true,
+    "low_threshold": 10,
+    "medium_threshold": 20,
+    "max_complexity": 0,
+    "report_unchanged": false
+  },
+  "dead_code": {
+    "enabled": true,
+    "min_severity": "warning",
+    "show_context": false,
+    "context_lines": 3,
+    "sort_by": "severity",
+    "detect_after_return": true,
+    "detect_after_break": true,
+    "detect_after_continue": true,
+    "detect_after_throw": true,
+    "detect_unreachable_branches": true,
+    "ignore_patterns": []
+  },
+  "output": {
+    "format": "text",
+    "show_details": true,
+    "sort_by": "complexity",
+    "min_complexity": 1
+  },
+  "analysis": {
+    "include_patterns": [
+      "**/*.js",
+      "**/*.ts",
+      "**/*.jsx",
+      "**/*.tsx"
+    ],
+    "exclude_patterns": [
+      "node_modules",
+      "dist",
+      "build",
+      "*.min.js",
+      "*.bundle.js"
+    ],
+    "recursive": true,
+    "follow_symlinks": false
+  }
+}
+```
+
+`--minimal` writes a much shorter file with the complexity thresholds, the dead code severity floor, and the file patterns.
+
+!!! warning "The generated file is wider than what jscan reads"
+
+    Both templates include keys that jscan parses and validates but does not yet act on, such as everything under `dead_code`. The [configuration guide](../configuration/index.md#which-keys-take-effect-today) lists exactly which keys change behavior. Nothing in the generated file is invalid, but do not assume that editing `dead_code.min_severity` changes the output.
+
+    In particular, note that the generated `exclude_patterns` is **shorter** than the built-in default. Writing a configuration file therefore narrows what jscan skips. If you do not need custom patterns, delete the key and let the default apply.
+
+## Which filenames jscan looks for
+
+You do not have to use `jscan.config.json`. jscan searches for several names, and `.jscanrc.json` is the common alternative. The [configuration guide](../configuration/index.md#how-jscan-finds-your-config-file) lists the full set and the directories searched.
+
+## See also
+
+- [Configuration reference](../configuration/reference.md) for every key
+- [Configuration examples](../configuration/examples.md) for files tuned to particular project shapes

--- a/website/docs/cli/version.md
+++ b/website/docs/cli/version.md
@@ -1,0 +1,36 @@
+# jscan version
+
+Prints version information.
+
+```bash
+jscan version
+```
+
+```console
+$ jscan version
+jscan version 0.4.1
+```
+
+## Flags
+
+| Flag | Short | Default | Description |
+| --- | --- | --- | --- |
+| `--verbose` | `-v` | `false` | Also print the commit, build date, and builder |
+
+```console
+$ jscan version --verbose
+0.4.1 (commit: unknown, built: unknown, by: source)
+```
+
+The release pipeline injects only the version number through linker flags, so the other three fields keep their placeholder values even on an official release build. Treat `commit`, `built`, and `by` as unpopulated rather than as a sign that something went wrong with your install.
+
+A binary you compiled yourself reports `dev` as its version, for the same reason. That is the expected output of `go build` without the release flags.
+
+## The root flag
+
+`jscan --version` prints the same short string as `jscan version` and exists because Cobra provides it automatically.
+
+```console
+$ jscan --version
+jscan version 0.4.1
+```

--- a/website/docs/configuration/examples.md
+++ b/website/docs/configuration/examples.md
@@ -1,0 +1,218 @@
+# Configuration Examples
+
+Complete configuration files for common project shapes. Each one is valid as written, and each notes which parts actually change jscan's behavior today.
+
+Remember two rules while reading these:
+
+- `analysis.exclude_patterns` **replaces** the default list rather than adding to it.
+- Short entries in that list also match as substrings of a file's full path, so `out` removes `src/routes/` and `src/layout/`. Every example below therefore avoids the short entries. The [reference](reference.md#analysisexclude_patterns) explains this in full.
+
+## Starting point for any project
+
+The smallest file worth writing. It sets complexity thresholds a little more forgiving than the built-in defaults, and it fixes the exclude list so that no source directory is dropped by accident.
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 10,
+    "medium_threshold": 20
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "coverage",
+      ".git",
+      "*.min.js",
+      "*.bundle.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+Run it against your source directory rather than the repository root, so that build output stays out of the analysis without needing a pattern for it:
+
+```bash
+jscan analyze src/
+```
+
+## React or Next.js application
+
+Next.js projects keep generated output in `.next` and often have a `src/app` or `src/pages` tree full of route files. The route directories are exactly the ones the default exclude list damages, so the custom list matters here.
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 12,
+    "medium_threshold": 24
+  },
+  "output": {
+    "min_complexity": 3
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      ".next",
+      ".vercel",
+      ".turbo",
+      "coverage",
+      ".git",
+      "*.min.js",
+      "*.bundle.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+The thresholds are raised because component code accumulates conditional rendering, which counts toward cyclomatic complexity without being genuinely hard to read. `min_complexity` of 3 hides the trivial components so that the report is about the parts worth looking at.
+
+Next.js reserves several export names that nothing in your code imports. jscan recognizes them and does not report them as unused, but only inside App Router convention files, meaning a file under a path containing `/app/` and named `page`, `layout`, `template`, `loading`, `error`, `not-found`, `default`, or `route`. In those files the default export is exempt, along with `metadata`, `generateMetadata`, `viewport`, `generateViewport`, `generateStaticParams`, `dynamic`, `dynamicParams`, `revalidate`, `fetchCache`, `runtime`, `preferredRegion`, and `maxDuration`. In `route` files the HTTP verb exports such as `GET` and `POST` are exempt as well.
+
+!!! note "This exemption is easy to lose"
+
+    A file named `layout.tsx` contains the letters `out`, so the default `exclude_patterns` drops it before the exemption is ever consulted. The custom list above avoids that, which is another reason not to keep the default list in a Next.js project.
+
+## Node.js backend service
+
+Backend code is a better fit for stricter thresholds, and the express-style `routes` directory needs the same care as above.
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 8,
+    "medium_threshold": 15,
+    "max_complexity": 20
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "coverage",
+      ".git",
+      "*.min.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+`max_complexity` is read only by `jscan check`, where it supplies the default for `--max-complexity`. With this file in place, the gate becomes:
+
+```bash
+jscan check src/          # Fails above complexity 20
+```
+
+## Library or published package
+
+A library's public exports are consumed by other repositories, so jscan will always report them as unused. The gate has to allow dead code, which makes the configuration file itself fairly plain.
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 8,
+    "medium_threshold": 16,
+    "max_complexity": 20
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "coverage",
+      ".git",
+      "*.map"
+    ]
+  }
+}
+```
+
+```bash
+# The unused-export warnings are expected here
+jscan check --allow-dead-code src/
+```
+
+You still get value from the dead code analysis in `jscan analyze`, where the critical findings, which are genuinely unreachable statements, are worth acting on even though the warnings are not.
+
+## Monorepo
+
+There is no workspace-aware mode. Run jscan once per package, and give each package its own file so that thresholds can differ between a strict core library and a looser internal tool.
+
+```text
+repo/
+├── jscan.config.json          ← fallback for packages without their own
+└── packages/
+    ├── core/
+    │   ├── jscan.config.json  ← stricter
+    │   └── src/
+    └── web/
+        ├── jscan.config.json  ← looser
+        └── src/
+```
+
+Because discovery walks upward from the analyzed path, `jscan analyze packages/core/src` finds `packages/core/jscan.config.json` first and falls back to the repository root file only when the package has none.
+
+```bash
+# Analyze each package separately
+for pkg in packages/*/; do
+  echo "== $pkg"
+  jscan check "$pkg/src" || exit 1
+done
+```
+
+Analyzing packages separately has one consequence worth understanding. The unused-export check can only see the files in the current run, so anything `packages/web` imports from `packages/core` is reported as an unused export while `core` is analyzed alone. Run `jscan analyze packages/` to see the whole picture, and the per-package runs to gate each package.
+
+## Legacy codebase you are improving gradually
+
+When the current state is far from where you want it, set thresholds you can actually pass today and tighten them over time.
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 20,
+    "medium_threshold": 40,
+    "max_complexity": 60
+  },
+  "output": {
+    "min_complexity": 15
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "coverage",
+      ".git",
+      "legacy/generated",
+      "*.min.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+The high `min_complexity` keeps the report focused on the worst functions rather than producing thousands of lines nobody reads. Lower `max_complexity` by five every time the build passes comfortably, and the gate will ratchet the codebase in the right direction without ever blocking work.
+
+Note that `legacy/generated` is long enough not to over-match, which is what makes it safe to include. Prefer specific multi-segment paths over short names for this reason.
+
+## YAML instead of JSON
+
+The loader accepts YAML when the filename ends in `.yaml` or `.yml`. The keys are identical.
+
+```yaml title="jscan.yaml"
+complexity:
+  low_threshold: 10
+  medium_threshold: 20
+  max_complexity: 25
+
+output:
+  min_complexity: 2
+
+analysis:
+  exclude_patterns:
+    - node_modules
+    - coverage
+    - .git
+    - "*.min.js"
+    - "*.map"
+```
+
+## See also
+
+- [Configuration reference](reference.md) for every key and its validation rules
+- [CI/CD integration](../integrations/ci-cd.md) for using these files in a pipeline

--- a/website/docs/configuration/index.md
+++ b/website/docs/configuration/index.md
@@ -1,0 +1,143 @@
+# Configuration
+
+jscan runs without any configuration at all. A configuration file is for the cases where the defaults do not suit your project, most often because you want different complexity thresholds or a different set of skipped directories.
+
+Create one with [`jscan init`](../cli/init.md), or write it by hand.
+
+## How jscan finds your config file
+
+When you pass `--config`, jscan loads exactly that file and fails if it cannot be read. When you do not, jscan searches, and the first file it finds wins.
+
+The search runs in this order:
+
+1. **Upward from the analyzed path.** Starting at the directory you asked jscan to analyze, it checks that directory, then its parent, and so on to the filesystem root. If you passed a file rather than a directory, the search starts from the file's directory.
+2. **The current working directory.**
+3. **`$XDG_CONFIG_HOME/jscan/`**, then `$XDG_CONFIG_HOME/pyscn/`, if that variable is set.
+4. **`~/.config/jscan/`**, then `~/.config/pyscn/`.
+5. **Your home directory.**
+6. **The path in `$JSCAN_CONFIG`**, then the path in `$PYSCN_CONFIG`, if either is set and points at a file that exists.
+
+Searching upward from the target rather than from the current directory means that analyzing `packages/api/src` from the repository root still picks up `packages/api/jscan.config.json`.
+
+### Accepted filenames
+
+Within each directory, jscan checks these names in order:
+
+```text
+jscan.config.json
+.jscanrc.json
+jscan.yaml
+jscan.yml
+.jscan.toml
+.jscan.yml
+jscan.json
+.jscan.json
+```
+
+It then checks the equivalent `pyscn` names, which are accepted for backward compatibility from when jscan shared its configuration loader with pyscn. Prefer a `jscan` name in new projects.
+
+### Supported file formats
+
+The loader reads JSON, YAML, and TOML. The format is chosen from the file extension, so `.jscanrc.json` must contain JSON and `jscan.yaml` must contain YAML. JSON is the most common choice because it needs no extra tooling in a JavaScript project.
+
+```bash
+# Confirm which file was used
+jscan analyze --config ./jscan.config.json src/
+```
+
+Passing `--config` to `analyze` makes it print `Using config: <path>` before the results, which is the quickest way to confirm that a file is being read at all. The `check` and `deps` commands accept `--config` but print no such line.
+
+## Which keys take effect today
+
+This is the part worth reading carefully. jscan validates the whole configuration schema, but the commands act on only part of it. Setting a key from the second table below is accepted, and validated, and then ignored.
+
+### Keys that change behavior
+
+| Key | Affects | What it does |
+| --- | --- | --- |
+| `complexity.low_threshold` | `analyze`, `check` | Upper bound of the low risk band |
+| `complexity.medium_threshold` | `analyze`, `check` | Upper bound of the medium risk band |
+| `complexity.max_complexity` | `check` | Default for `--max-complexity`, used only when the flag is absent and the value is above 0 |
+| `output.min_complexity` | `analyze` | Functions below this complexity are left out of the report |
+| `analysis.exclude_patterns` | `analyze`, `check`, `deps` | Directories and filename patterns to skip |
+
+### Keys that are parsed but not yet applied
+
+| Key group | Status |
+| --- | --- |
+| `dead_code.*` | Dead code detection runs with fixed settings. Severity floor, sorting, context lines, the per-reason detection switches, and `ignore_patterns` have no effect. |
+| `clones.*` | Clone detection runs with the built-in defaults. |
+| `output.format` | The format comes from the `--format` flag only. |
+| `output.show_details`, `output.sort_by`, `output.directory` | Not read by any command. |
+| `analysis.include_patterns` | The set of analyzed extensions is fixed. See below. |
+| `analysis.recursive`, `analysis.follow_symlinks` | The walk is always recursive and never follows symbolic links. |
+| `complexity.enabled`, `complexity.report_unchanged` | Not read by any command. |
+| `system_analysis.*`, `dependencies.*`, `architecture.*`, `module_analysis.*` | Reserved for features that are not yet implemented. All default to disabled. |
+
+This is documented rather than hidden because a configuration key that quietly does nothing is worse than one that does not exist. If a setting you need is in the second table, use the equivalent command line flag where one exists, and otherwise track the gap in the [issue tracker](https://github.com/ludo-technologies/polyscan/issues).
+
+### Why `include_patterns` does not work
+
+jscan collects files by extension, using a fixed list: `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.mts`, and `.cts`. The collector then removes anything matching `analysis.exclude_patterns`. It never consults `include_patterns`.
+
+The practical consequence is that you cannot narrow the analysis by writing `include_patterns`. Narrow it by passing a more specific path, or by adding to `exclude_patterns`:
+
+```bash
+# Instead of an include pattern, pass the path you mean
+jscan analyze src/components/
+```
+
+## jscan also reads your `.gitignore`
+
+Before applying `exclude_patterns`, jscan looks for a `.gitignore` file in the directory you asked it to analyze, and skips anything that file ignores. This is usually what you want, since build output and local artifacts are normally ignored by git as well.
+
+Two details are worth knowing:
+
+- Only the `.gitignore` at the root of the analyzed path is read. Running `jscan analyze src/` uses `src/.gitignore` and does **not** read the repository's top-level `.gitignore`. Running `jscan analyze .` from the repository root does read it.
+- Global and nested gitignore files are not consulted, and neither is `.git/info/exclude`.
+
+If a file you expected in the report is missing, check both your `.gitignore` and the `exclude_patterns` behavior described in the [reference](reference.md#analysisexclude_patterns).
+
+## A minimal useful file
+
+Most projects need only this much:
+
+```json
+{
+  "complexity": {
+    "low_threshold": 10,
+    "medium_threshold": 20
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "dist",
+      "build",
+      ".next",
+      "coverage",
+      "*.min.js",
+      "**/*.generated.ts"
+    ]
+  }
+}
+```
+
+!!! warning "Writing `exclude_patterns` replaces the default list"
+
+    The value you provide is not merged with the built-in defaults. It replaces them. The default list is long and covers dependency directories, build outputs, framework caches, and minified files, so a short custom list will make jscan analyze things you probably did not intend to analyze, such as `dist`. Copy the [full default list](reference.md#analysisexclude_patterns) as your starting point and add to it.
+
+## Validation
+
+The configuration is validated on load, and an invalid file stops the command with a message naming the offending key:
+
+```console
+$ jscan analyze --config bad.json src/
+Error: failed to load configuration: invalid configuration: complexity.medium_threshold (5) must be > low_threshold (10)
+```
+
+The rules enforced are listed with each key in the [reference](reference.md).
+
+## Next
+
+- [Configuration reference](reference.md) documents every key, its type, and its default.
+- [Configuration examples](examples.md) has complete files for several kinds of project.

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -1,0 +1,297 @@
+# Configuration Reference
+
+Every key jscan accepts, with its type, its default, and whether it currently changes anything.
+
+Keys marked :material-check-circle:{ title="Applied" } **Applied** affect the analysis. Keys marked :material-minus-circle:{ title="Not applied" } **Not applied** are parsed and validated, then ignored. The [configuration guide](index.md#which-keys-take-effect-today) explains why that distinction exists.
+
+All examples use JSON. YAML and TOML files accept the same keys with the same names.
+
+---
+
+## `complexity`
+
+Controls cyclomatic complexity analysis.
+
+### `complexity.low_threshold`
+
+:material-check-circle: **Applied** &nbsp;&middot;&nbsp; integer &nbsp;&middot;&nbsp; default `9`
+
+Upper bound of the low risk band, inclusive. A function at or below this value is reported as low risk.
+
+Must be at least 1.
+
+### `complexity.medium_threshold`
+
+:material-check-circle: **Applied** &nbsp;&middot;&nbsp; integer &nbsp;&middot;&nbsp; default `19`
+
+Upper bound of the medium risk band, inclusive. Functions above it are high risk.
+
+Must be greater than `low_threshold`.
+
+### `complexity.max_complexity`
+
+:material-check-circle: **Applied by `check` only** &nbsp;&middot;&nbsp; integer &nbsp;&middot;&nbsp; default `0`
+
+Supplies the default for `jscan check --max-complexity`. It is used only when the flag is absent from the command line and this value is greater than 0. `jscan analyze` ignores it.
+
+Must be either 0, meaning no limit, or greater than `medium_threshold`.
+
+```json
+{
+  "complexity": {
+    "low_threshold": 10,
+    "medium_threshold": 20,
+    "max_complexity": 25
+  }
+}
+```
+
+### `complexity.enabled`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; boolean &nbsp;&middot;&nbsp; default `true`
+
+Intended to switch complexity analysis off. No command reads it. Use `--select` to choose analyses instead.
+
+### `complexity.report_unchanged`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; boolean &nbsp;&middot;&nbsp; default `true`
+
+Intended to hide functions whose complexity is exactly 1. No command reads it. Set `output.min_complexity` to 2 for the same effect.
+
+---
+
+## `output`
+
+### `output.min_complexity`
+
+:material-check-circle: **Applied by `analyze` only** &nbsp;&middot;&nbsp; integer &nbsp;&middot;&nbsp; default `1`
+
+Functions below this complexity are excluded from the report. The default of 1 keeps every function, since no function scores lower than 1.
+
+Must be at least 1.
+
+Raising it is the most effective way to shorten the report on a large codebase:
+
+```json
+{
+  "output": {
+    "min_complexity": 5
+  }
+}
+```
+
+When this filter removes functions, the text and JSON output disclose both counts, reported as `12 reported / 340 parsed`, so a filtered report never looks like a complete one.
+
+### `output.format`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; string &nbsp;&middot;&nbsp; default `"text"`
+
+Validated against `text`, `json`, `yaml`, `csv`, and `html`, then ignored. The output format comes from the `--format` flag. An invalid value here still fails the whole run, so keep it to one of the five.
+
+### `output.show_details`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; boolean &nbsp;&middot;&nbsp; default `false`
+
+### `output.sort_by`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; string &nbsp;&middot;&nbsp; default `"complexity"`
+
+Validated against `name`, `complexity`, and `risk`, then ignored. Reports are always sorted by complexity, descending.
+
+### `output.directory`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; string &nbsp;&middot;&nbsp; default `""`
+
+Use `jscan analyze --output <path>` to choose where the HTML report goes.
+
+---
+
+## `analysis`
+
+### `analysis.exclude_patterns`
+
+:material-check-circle: **Applied** &nbsp;&middot;&nbsp; array of strings
+
+Directory names and filename patterns to skip. A value here **replaces** the default list rather than extending it.
+
+The default is:
+
+```json
+{
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "bower_components",
+      "jspm_packages",
+      "vendor",
+      "assets",
+      "overrides",
+      "third_party",
+      "third-party",
+      "extern",
+      "external",
+      "dist",
+      "build",
+      "out",
+      ".output",
+      ".next",
+      ".nuxt",
+      ".vercel",
+      ".cache",
+      ".turbo",
+      "coverage",
+      ".git",
+      "*.min.js",
+      "*.min.mjs",
+      "*.min.cjs",
+      "*.bundle.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+Matching happens in two places, with different rules.
+
+A **directory** is skipped when its own name equals a pattern exactly, or matches it as a glob. This behaves the way you would expect: `dist` skips any directory named `dist` at any depth, and nothing else.
+
+A **file** is skipped when its filename matches a pattern as a glob, **or when the pattern appears anywhere in the file's full path as a plain substring**. That second rule is far broader than it looks, and it is the cause of the problem described next.
+
+!!! danger "Short patterns silently exclude files you meant to analyze"
+
+    Because file matching falls back to a substring test on the whole path, a short pattern in the list removes every file whose path merely contains those characters. Two entries in the default list cause this in ordinary projects:
+
+    - `out` matches `src/layout/Header.tsx`, `src/checkout/Cart.ts`, and `src/routes/api.ts`, because `layout`, `checkout`, and `routes` all contain the letters `out`.
+    - `dist` matches `src/utils/distance.ts` and anything else containing `dist`.
+
+    The files are dropped during collection, so nothing in the output mentions them. The only visible symptom is that the `Analyzing N files...` count is lower than you expect.
+
+    Verify what jscan actually read before trusting a clean report:
+
+    ```console
+    $ jscan analyze --text src/ | head -1
+    Analyzing 1 files...
+    ```
+
+    If that count looks wrong, override `exclude_patterns` with a list that leaves out the short entries:
+
+    ```json
+    {
+      "analysis": {
+        "exclude_patterns": [
+          "node_modules",
+          "bower_components",
+          "jspm_packages",
+          "vendor",
+          "third_party",
+          "coverage",
+          ".git",
+          ".next",
+          ".nuxt",
+          ".turbo",
+          ".cache",
+          "*.min.js",
+          "*.min.mjs",
+          "*.min.cjs",
+          "*.bundle.js",
+          "*.map"
+        ]
+      }
+    }
+    ```
+
+    This list drops `out`, `dist`, `build`, `assets`, `extern`, `external`, and `overrides`, which are the entries most likely to over-match. Dropping them has a cost: a directory named `dist` or `build` inside the analyzed path will now be analyzed, because the same list drives both the directory rule and the file rule. Point jscan at your source directory rather than the project root to avoid that:
+
+    ```bash
+    jscan analyze src/
+    ```
+
+Because your list replaces the default, start from one of the lists above and append to it rather than writing a short one from scratch. Omitting `node_modules` in particular will make jscan analyze your entire dependency tree.
+
+### `analysis.include_patterns`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; array of strings
+
+The analyzed extensions are fixed at `.js`, `.jsx`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.mts`, and `.cts`. This key is validated only to the extent that it must not be an empty array, which means you cannot delete it from a file that already has one.
+
+### `analysis.recursive`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; boolean &nbsp;&middot;&nbsp; default `true`
+
+Directory walks are always recursive.
+
+### `analysis.follow_symlinks`
+
+:material-minus-circle: **Not applied** &nbsp;&middot;&nbsp; boolean &nbsp;&middot;&nbsp; default `false`
+
+Symbolic links are never followed.
+
+---
+
+## `dead_code`
+
+Every key in this group is :material-minus-circle: **not applied**. Dead code detection currently runs with a fixed configuration: it reports at info severity and above, sorts by severity, and enables all six unreachable-code checks.
+
+The keys are still validated, so an invalid value fails the run.
+
+| Key | Type | Default | Validation |
+| --- | --- | --- | --- |
+| `dead_code.enabled` | boolean | `true` | |
+| `dead_code.min_severity` | string | `"warning"` | One of `critical`, `warning`, `info` |
+| `dead_code.show_context` | boolean | `false` | |
+| `dead_code.context_lines` | integer | `3` | From 0 to 20 |
+| `dead_code.sort_by` | string | `"severity"` | One of `severity`, `line`, `file`, `function` |
+| `dead_code.detect_after_return` | boolean | `true` | |
+| `dead_code.detect_after_break` | boolean | `true` | |
+| `dead_code.detect_after_continue` | boolean | `true` | |
+| `dead_code.detect_after_throw` | boolean | `true` | |
+| `dead_code.detect_unreachable_branches` | boolean | `true` | |
+| `dead_code.ignore_patterns` | array of strings | `[]` | |
+
+To exclude dead code from a gate, use `jscan check --allow-dead-code` rather than `dead_code.enabled`.
+
+---
+
+## `clones`
+
+:material-minus-circle: **Not applied.** Clone detection runs with the built-in defaults, which are:
+
+| Setting | Default |
+| --- | --- |
+| Minimum fragment size | 10 lines and 20 syntax tree nodes |
+| Enabled clone types | Type 1, Type 2, and Type 4 |
+| Type 1 similarity threshold | 0.85 |
+| Type 2 similarity threshold | 0.75 |
+| Type 3 similarity threshold | 0.70 |
+| Type 4 similarity threshold | 0.65 |
+| Grouping strategy | Connected components |
+| Locality-sensitive hashing | Enabled automatically above 500 fragments |
+
+Type 3 is excluded from the enabled set because near-miss matches produce too many false positives for everyday use.
+
+---
+
+## Reserved groups
+
+These four groups exist in the schema for planned features. All of them default to disabled and none of them is read by any command today.
+
+| Group | Intended purpose |
+| --- | --- |
+| `system_analysis` | Combining the individual analyses into one system-level view |
+| `dependencies` | Filtering and reporting options for dependency analysis |
+| `architecture` | Layer definitions and rules for validating architectural boundaries |
+| `module_analysis` | Import resolution options, including path alias handling |
+
+Values inside them are unmarshalled without validation. Writing them today is harmless and has no effect.
+
+---
+
+## Environment variables
+
+| Variable | Effect |
+| --- | --- |
+| `JSCAN_CONFIG` | Path to a configuration file, consulted late in the search order |
+| `PYSCN_CONFIG` | Same, kept for backward compatibility |
+| `XDG_CONFIG_HOME` | Changes where jscan looks for a user-level `jscan/` config directory |
+
+The two config variables are checked only after every directory in the search has been tried, so a `jscan.config.json` anywhere above your source will take priority over them. See [config discovery](index.md#how-jscan-finds-your-config-file) for the full order.

--- a/website/docs/contributing.md
+++ b/website/docs/contributing.md
@@ -1,0 +1,107 @@
+# Contributing
+
+jscan lives in the [polyscan monorepo](https://github.com/ludo-technologies/polyscan) under `jscan/`. The standalone `jscan` repository was retired and its history moved here.
+
+## Set up
+
+You need Go 1.24.6 or later, a C compiler, and `golangci-lint`. The C compiler is required because jscan parses with tree-sitter, which is a C library reached through cgo.
+
+```bash
+git clone https://github.com/ludo-technologies/polyscan.git
+cd polyscan/jscan
+go mod download
+make build
+```
+
+## Everyday commands
+
+Run these from the `jscan/` directory.
+
+| Command | What it does |
+| --- | --- |
+| `make build` | Build the `jscan` binary |
+| `make test` | Run the full test suite |
+| `make test-short` | Skip the long-running tests |
+| `make lint` | Run `golangci-lint` |
+| `make fmt` | Format the Go sources |
+| `make coverage` | Write an HTML coverage report |
+| `make bench` | Run benchmarks with allocation statistics |
+| `make run` | Build and run against the bundled fixtures |
+| `make tidy` | Tidy `go.mod` and `go.sum` |
+
+Run `make lint` and `make test` before opening a pull request. Continuous integration runs both.
+
+!!! note "`make build-all` does not work for every target"
+
+    The target sets `GOOS` and `GOARCH` for five platforms, but tree-sitter needs cgo, so cross-compiling only succeeds for the platform you are already on. The release pipeline builds each target on its own runner for this reason. Use it to check that a build works locally, not to produce release artifacts.
+
+## Where the code lives
+
+```text
+jscan/
+├── cmd/jscan/     CLI entry point, one file per command
+├── app/           Application use cases
+├── service/       Orchestration, formatting, output
+├── domain/        Models and service interfaces, depends on nothing
+├── internal/
+│   ├── parser/    tree-sitter integration
+│   ├── analyzer/  The analysis engines
+│   ├── config/    Configuration loading and validation
+│   ├── reporter/  Report formatting
+│   └── version/   Version information
+├── npm/           The npm package wrapper
+└── testdata/      Test fixtures
+```
+
+The layering follows Clean Architecture, with every layer depending on `domain` and `domain` depending on nothing. Command handlers may call either a use case in `app/` or a service directly, whichever keeps the concurrency simpler. [`jscan/docs/ARCHITECTURE.md`](https://github.com/ludo-technologies/polyscan/blob/main/jscan/docs/ARCHITECTURE.md) describes each layer and the reasoning behind the main design decisions.
+
+## The shared core
+
+Algorithms that are not specific to a language live in the `core/` module at the repository root, which both jscan and pyscn depend on as a published Go module. That covers APTED tree edit distance, control flow graph structures and their analyses, clone grouping, graph algorithms including Tarjan's, MinHash and locality-sensitive hashing, and the health score calculation.
+
+This matters when you plan a change. A fix to a shared algorithm belongs in `core/` and affects both analyzers, so it needs a `core/vX.Y.Z` tag before the consuming change can reference it. A fix to JavaScript-specific behavior, such as the control flow graph builder or the module resolver, belongs in `jscan/`.
+
+If you are unsure which side a change belongs on, say so in the issue before writing it.
+
+## Commits
+
+The project uses [Conventional Commits](https://www.conventionalcommits.org/):
+
+```text
+feat: add support for Vue single-file components
+fix: resolve false positive in dead code detection for re-exports
+docs: document the exclude pattern matching rules
+chore: upgrade tree-sitter to v0.25
+```
+
+The accepted types are `feat`, `fix`, `docs`, `chore`, `refactor`, and `test`.
+
+## Pull requests
+
+Branch from `main`, write tests for the behavior you are changing, and open the pull request against `main` with a description of what changed and why.
+
+Changes to the analyzers need test coverage in particular, since a regression there is silent. It produces a different number rather than an error, and nobody notices until the score moves.
+
+## Contributing to these docs
+
+This site is built with MkDocs Material from `website/` in the same repository.
+
+```bash
+cd website
+pip install -r requirements.txt
+mkdocs serve
+```
+
+That serves the site at `http://127.0.0.1:8000` with live reload. Continuous integration builds with `mkdocs build --strict`, which turns a broken internal link into a build failure, so check your links before pushing.
+
+Every page has an edit link in its top right corner that takes you to the source file on GitHub.
+
+One request specific to this site. Much of what is documented here was verified by running the binary rather than by reading the code, because the two disagreed in several places. If you document a behavior, run it first, and paste the output you actually got.
+
+## Reporting bugs
+
+Open an issue in the [polyscan repository](https://github.com/ludo-technologies/polyscan/issues). Include the output of `jscan version`, the exact command, and the smallest input that reproduces the problem.
+
+## Code of Conduct
+
+Participation is governed by the [Code of Conduct](https://github.com/ludo-technologies/polyscan/blob/main/CODE_OF_CONDUCT.md).

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -1,0 +1,152 @@
+# FAQ
+
+## Usage
+
+### Why did jscan analyze far fewer files than my project has?
+
+Almost certainly the exclude patterns. jscan matches a file against `analysis.exclude_patterns` by testing whether a pattern appears anywhere in the file's full path as a plain substring. The default list contains `out` and `dist`, which means:
+
+- `src/routes/api.ts` is skipped, because `routes` contains `out`.
+- `src/layout/Header.tsx` and `app/**/layout.tsx` are skipped.
+- `src/checkout/Cart.ts` is skipped.
+- `src/utils/distance.ts` is skipped, because `distance` contains `dist`.
+
+Nothing in the output names the missing files. Compare the `Analyzing N files...` line against a `find` count to confirm, then commit a configuration file with an explicit exclude list. The [configuration reference](configuration/reference.md#analysisexclude_patterns) has a safe list.
+
+A second possibility is your `.gitignore`. jscan reads the one at the root of the analyzed directory and skips whatever it ignores.
+
+### Why is every one of my exports reported as unused?
+
+The unused-export check compares imports against exports across the files in the current run only. It has no way to see importers outside that set.
+
+This happens in two situations. Analyzing a subdirectory, such as `src/components/`, means the importers in the rest of `src/` were never read. Pass the whole source root instead. Analyzing a library means the importers are in other repositories entirely, and there is nothing to do about it except run `jscan check --allow-dead-code`.
+
+### Why does `jscan check` fail on a codebase that looks fine?
+
+The default gate fails on any dead code finding, at any severity. The `unused_exported_function` warning described above is usually the cause. Start with:
+
+```bash
+jscan check --allow-dead-code --max-complexity 20 src/
+```
+
+### Does jscan need my project to compile?
+
+No. It parses the source with tree-sitter and never invokes `tsc`. It works on code that currently fails type checking, and it does not read `tsconfig.json`.
+
+### Does jscan read `tsconfig.json` path aliases?
+
+No. An import written `@/lib/util` becomes a module node of its own rather than resolving to `src/lib/util.ts`. This inflates module counts in `jscan deps`, drops real edges, and hides cycles that pass through an alias. Relative imports resolve correctly. See [the TypeScript guide](guides/typescript-projects.md#path-aliases-are-not-resolved).
+
+### Does jscan support Vue single-file components?
+
+Not yet. `.vue` files are not collected, so the `<script>` block inside them is never analyzed. The `.ts` and `.js` files in a Vue or Nuxt project are analyzed normally.
+
+### Can I run jscan on a single file?
+
+Yes. Every command accepts files as well as directories:
+
+```bash
+jscan check --select complexity src/server/router.ts
+```
+
+Bear in mind that cross-file analyses cannot say anything useful about one file. Dead code detection will report its exports as unused, and the dependency graph will have one node.
+
+### Why did my score go up when I changed nothing?
+
+Check whether the `--select` value changed. A category that did not run contributes no penalty, so a narrower selection produces a higher score for identical code. Always use the same selection when tracking the score over time. See [the health score page](output/health-score.md#selecting-fewer-analyses-raises-the-score).
+
+## Configuration
+
+### I set a value in my config file and nothing changed. Why?
+
+jscan validates the whole configuration schema but acts on only part of it. These keys change behavior today:
+
+- `complexity.low_threshold` and `complexity.medium_threshold`
+- `complexity.max_complexity`, used by `jscan check` only
+- `output.min_complexity`, used by `jscan analyze` only
+- `analysis.exclude_patterns`
+
+Everything else, including all of `dead_code`, is parsed and then ignored. The [configuration guide](configuration/index.md#which-keys-take-effect-today) has the full list of both kinds.
+
+### Why does adding `exclude_patterns` make jscan analyze *more* files?
+
+Your value replaces the default list rather than extending it. The default is 26 entries long and covers dependency directories, build outputs, framework caches, and minified files. A short custom list therefore removes most of that protection. Copy the [full default list](configuration/reference.md#analysisexclude_patterns) and add to it.
+
+### Can I use YAML or TOML instead of JSON?
+
+Yes. The format is chosen from the file extension. `jscan.yaml`, `jscan.yml`, and `.jscan.toml` all work, with the same keys.
+
+### Which config file does jscan use?
+
+It searches upward from the path you asked it to analyze, then falls back to the current directory, the XDG config directory, `~/.config/jscan/`, your home directory, and finally the `JSCAN_CONFIG` environment variable. The first file found wins. Pass `--config` to remove the guesswork, and note that `jscan analyze --config` prints the path it used.
+
+## Results
+
+### What counts toward cyclomatic complexity?
+
+Each branch adds one to a baseline of 1: `if`, `else if`, each loop, each `catch`, each ternary, and each `&&`, `||`, or `??`. Optional chaining with `?.` does not count.
+
+A function with no branching scores 1.
+
+`switch` is the exception, and it is worth knowing about. The whole statement adds 1 regardless of how many cases it has, so a four-case switch scores 2 while the equivalent chain of four `if` statements scores 5:
+
+```console
+$ jscan analyze --json --select complexity src/d.ts \
+  | jq -r '.complexity.functions[] | "\(.name): \(.metrics.complexity)"'
+ifChain: 5
+sw4: 2
+```
+
+The `switch_cases` field in the JSON output is always 0 for the same reason. Switch-heavy code such as reducers and state machines is therefore scored more leniently than equivalent branching written another way. Do not read a low complexity score on a large `switch` as evidence that it is simple.
+
+### The CBO section says "classes" but my code has none. Why?
+
+In jscan the coupling analysis produces one entry per file, named after the module. The label "classes" comes from the shared metric definition and applies literally in pyscn, which analyzes Python. Read every count in that section as a per-module count.
+
+### What is a good health score?
+
+Grade A starts at 90 and grade B at 75. In practice, treat the category scores as more actionable than the total, because each category saturates at a different point and the total hides which one is costing you.
+
+The complexity category saturates fastest. Its penalty maxes out once the weighted ratio of problematic functions reaches 5 percent, so a handful of high complexity functions in a small codebase can max it out alone.
+
+### Why is `architecture_score` always 0?
+
+Architecture validation is not implemented in jscan. The field exists because the scoring code is shared with pyscn. Ignore both `architecture_score` and `arch_enabled` in JSON output.
+
+### Why does jscan flag code my linter does not?
+
+They answer different questions. A linter checks style and known bug patterns statement by statement. jscan builds a control flow graph and an import graph, which lets it find unreachable code, duplication across files, and circular imports. Neither replaces the other, and running both is normal.
+
+## Performance
+
+### Which analysis is slowest?
+
+Clone detection, followed by dead code detection. The five analyses run in parallel, so total time is set by the slowest rather than by their sum. Dropping clone detection is the single most effective speedup:
+
+```bash
+jscan analyze --select complexity,deadcode,cbo,deps src/
+```
+
+`jscan check` is fast because it never runs clone or coupling analysis at all.
+
+### The progress bar sits near the end for a long time. Is it stuck?
+
+No. The bar is driven by an elapsed-time estimate rather than by real progress. When a run takes longer than estimated, the bar advances slowly toward 99 percent rather than stopping, so that it does not look frozen. Large repositories often reach that state.
+
+## Project
+
+### How does jscan relate to pyscn?
+
+They are the same analyses for different languages: pyscn for Python, jscan for JavaScript and TypeScript. The language-independent algorithms live in a shared `core` module in the polyscan repository, which both depend on. That is why grade thresholds and the health score formula are identical across the two.
+
+### Where does jscan's source live?
+
+In the [polyscan monorepo](https://github.com/ludo-technologies/polyscan), under `jscan/`. The standalone `jscan` repository was retired and moved into the monorepo.
+
+### Is the JSON output stable?
+
+Not yet. Fields are more likely to be added than removed, but treat the structure as subject to change between releases. Pin the jscan version in anything that parses it.
+
+### How do I report a bug?
+
+Open an issue in the [polyscan repository](https://github.com/ludo-technologies/polyscan/issues). Including the jscan version from `jscan version`, the command you ran, and a small reproduction makes it much faster to act on.

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -1,0 +1,92 @@
+# Installation
+
+jscan is distributed as a single self-contained binary. There is no runtime dependency to install alongside it, and it does not need your project's `node_modules` to be present.
+
+## Run without installing
+
+The fastest way to try jscan is to let npm fetch it for one run:
+
+```bash
+npx jscan analyze src/
+```
+
+This downloads the binary for your platform into the npm cache and runs it. Nothing is added to your project.
+
+## Install with npm
+
+Install jscan globally when you expect to run it regularly:
+
+```bash
+npm install -g jscan
+```
+
+Install it as a development dependency when you want every contributor and every continuous integration run to use the same version:
+
+```bash
+npm install --save-dev jscan
+```
+
+The npm package is a small launcher script. It selects the correct platform package from `optionalDependencies` and runs the binary inside it, so the download only ever includes the build for the machine doing the install.
+
+### Supported platforms
+
+| Operating system | Architecture | Platform package |
+| --- | --- | --- |
+| macOS | arm64 (Apple silicon) | `jscan-darwin-arm64` |
+| Linux | x64 | `jscan-linux-x64` |
+| Linux | arm64 | `jscan-linux-arm64` |
+| Windows | x64 | `jscan-windows-x64` |
+
+There is no prebuilt binary for Intel macOS or for 32-bit systems. On those machines the launcher exits with an error that names your platform, and you should build from source instead.
+
+## Install with Go
+
+If you already have a Go toolchain, you can install jscan directly:
+
+```bash
+go install github.com/ludo-technologies/polyscan/jscan/cmd/jscan@latest
+```
+
+This places the `jscan` binary in your `GOBIN` directory, which defaults to `$(go env GOPATH)/bin`. Make sure that directory is on your `PATH`.
+
+## Build from source
+
+Building from source requires Go 1.24.6 or later and a working C compiler. The C compiler is necessary because jscan parses with tree-sitter, which is a C library reached through cgo.
+
+```bash
+git clone https://github.com/ludo-technologies/polyscan.git
+cd polyscan/jscan
+go build -o jscan ./cmd/jscan
+```
+
+!!! note "Cross-compilation does not work"
+
+    Because tree-sitter needs cgo, you cannot build a Linux binary on macOS by setting `GOOS`. Each platform binary has to be compiled on that platform. This is why the release pipeline uses a separate runner for every target.
+
+## Verify the installation
+
+```bash
+jscan version
+```
+
+The command prints the release version:
+
+```console
+$ jscan version
+jscan version 0.4.1
+```
+
+A binary you build yourself reports `dev`, because the version string is injected during the release build through linker flags.
+
+Adding `--verbose` prints the same version together with three build metadata fields:
+
+```console
+$ jscan version --verbose
+0.4.1 (commit: unknown, built: unknown, by: source)
+```
+
+The release pipeline currently injects only the version number, so the commit, build date, and builder fields keep their placeholder values on official builds as well.
+
+## Next step
+
+Continue to the [quick start](quick-start.md) to run your first analysis and read the report.

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -1,0 +1,109 @@
+# Quick Start
+
+This page walks through a first run on a real project. It takes about five minutes and assumes you have jscan available, either through `npx` or through a global install. If you do not, see [installation](installation.md).
+
+## 1. Run the analysis
+
+Point jscan at the directory that holds your source:
+
+```bash
+jscan analyze src/
+```
+
+jscan collects every JavaScript and TypeScript file below that directory, runs all five analyses in parallel, writes an HTML report to `jscan-report.html`, and opens it in your browser. It also prints a summary to the terminal:
+
+```console
+$ jscan analyze src/
+Analyzing 2 files...
+📊 Unified HTML report generated and opened: /home/you/project/jscan-report.html
+
+📊 Analysis Summary:
+Health Score: 91/100 (Grade: A)
+Total time: 5ms
+
+📈 Detailed Scores:
+  Complexity:      100/100 ✅  (avg: 4.5, high-risk: 0 functions)
+  Dead Code:        65/100 ⚠️  (3 issues, 1 critical)
+  Duplication:     100/100 ✅  (0.0% fragments cloned, 0 groups)
+  Coupling (CBO):  100/100 ✅  (avg: 0.5, 0/2 high-coupling)
+  Dependencies:     85/100 ✅  (0 cycles, depth: 1)
+```
+
+The health score is a single number from 0 to 100 with a letter grade attached. It starts at 100 and subtracts a penalty for each category. The [health score page](../output/health-score.md) gives the exact formula.
+
+!!! tip "Working over SSH or in a container?"
+
+    jscan skips the browser step automatically when it detects an SSH session. To suppress it in any other situation, pass `--no-open`.
+
+## 2. Read the terminal output instead
+
+If you would rather stay in the terminal, ask for text output. This prints the full findings to standard output and writes no file:
+
+```bash
+jscan analyze --text src/
+```
+
+The text report lists every function with its complexity, every dead code finding with its file and line, every clone group, the coupling table, and the dependency summary. It ends with the same health score breakdown.
+
+## 3. Narrow the analysis
+
+Running all five analyses on a large repository takes longer than you may want during an edit and re-run loop. Use `--select` to run only the ones you care about:
+
+```bash
+# Only complexity
+jscan analyze --select complexity src/
+
+# Complexity and dead code together
+jscan analyze --select complexity,deadcode src/
+```
+
+The five values accepted by `--select` are `complexity`, `deadcode`, `clone`, `cbo`, and `deps`. Omitting the flag runs all five.
+
+## 4. Add a quality gate
+
+`jscan analyze` always succeeds, because its job is to report rather than to judge. When you want a command that fails, use `jscan check`:
+
+```console
+$ jscan check src/
+FAIL: Quality check failed
+  Violations: 2
+  [ERROR] deadcode: Found 1 critical dead code issues
+  [WARN] deadcode: Found 2 warning-level dead code issues
+$ echo $?
+1
+```
+
+The exit code is 0 when everything passes, 1 when a threshold is violated, and 2 when the analysis itself could not run. That makes it usable directly as a continuous integration step.
+
+!!! warning "The default gate is strict"
+
+    With no flags, `jscan check` fails on any dead code finding at all, including the warning that an exported function is never imported. That warning fires constantly in library packages, whose exports are consumed outside the analyzed directory. Most projects should start with `jscan check --allow-dead-code src/` and tighten from there. The [check reference](../cli/check.md) covers each threshold flag.
+
+## 5. Create a configuration file
+
+Rather than repeating flags, write them down once:
+
+```bash
+jscan init
+```
+
+This creates `jscan.config.json` in the current directory. Add `--interactive` for a short wizard that asks about your framework and how strict you want the thresholds to be, then writes a file tuned to those answers.
+
+Be aware that jscan reads only part of that file today. The [configuration guide](../configuration/index.md) states plainly which keys take effect and which are accepted but not yet applied.
+
+## 6. Look at the dependency graph
+
+The `deps` command exports your module graph in Graphviz DOT format:
+
+```bash
+jscan deps src/ --dot | dot -Tsvg -o deps.svg
+```
+
+This needs Graphviz installed, which provides the `dot` program. The [dependency graph guide](../guides/dependency-graph.md) explains how to read the colors and what the coupling numbers in each tooltip mean.
+
+## Where to go next
+
+- The [CLI reference](../cli/index.md) documents every command and flag.
+- The [configuration reference](../configuration/reference.md) lists every key in the config file.
+- The [CI/CD page](../integrations/ci-cd.md) has ready-made GitHub Actions and GitLab CI jobs.
+- The [TypeScript guide](../guides/typescript-projects.md) covers path aliases, type-only imports, and monorepos.

--- a/website/docs/guides/dependency-graph.md
+++ b/website/docs/guides/dependency-graph.md
@@ -1,0 +1,136 @@
+# Read the Dependency Graph
+
+`jscan deps` builds the module import graph and reports metrics derived from it. The numbers come from Robert Martin's package metrics, which are widely used but easy to misread. This guide explains what each one means and what to do about a bad value.
+
+```bash
+jscan deps src/
+jscan deps src/ --dot | dot -Tsvg -o deps.svg
+```
+
+## The vocabulary
+
+Every metric is built from two counts. For a given module:
+
+**Afferent coupling, written `Ca`.** The number of modules that import this one. High `Ca` means many things depend on you.
+
+**Efferent coupling, written `Ce`.** The number of modules this one imports. High `Ce` means you depend on many things.
+
+The two describe opposite kinds of exposure. A module with high `Ca` is dangerous to change, because the change ripples outward. A module with high `Ce` is fragile, because it breaks when anything it uses changes.
+
+## Instability
+
+```text
+instability = Ce ÷ (Ca + Ce)
+```
+
+The result runs from 0 to 1.
+
+An instability of **0** means nothing this module imports and many things import it. It is maximally stable: hard to change, safe to depend on. Type definitions and shared constants belong here.
+
+An instability of **1** means it imports things and nothing imports it. It is maximally unstable: easy to change, and nothing breaks when you do. Application entry points and route handlers belong here.
+
+Neither extreme is a problem in itself. The problem is a module in the wrong place. A stable module is only appropriate when its contents rarely need to change, so a stable module full of business rules is a liability, since every rule change forces a change to something many modules depend on.
+
+The rule of thumb is that dependencies should point toward stability. A module should import things more stable than itself. When an unstable module is imported by a stable one, the stable module inherits the instability of what it depends on.
+
+## Abstractness and the main sequence
+
+Abstractness measures how much of a module is interface rather than implementation. Instability measures how exposed it is to change. Plotting the two against each other gives a line from `(0, 1)` to `(1, 0)`, called the main sequence, which represents a healthy balance: concrete modules should be unstable, abstract modules should be stable.
+
+The **main sequence deviation** is the distance from that line, between 0 and 1. Zero is on the line and 1 is as far from it as possible.
+
+The two bad corners are:
+
+**Abstract and unstable**, at the top right. The module is full of interfaces that nothing uses. This is usually over-engineering, or the remains of an abstraction whose implementations were deleted.
+
+**Concrete and stable**, at the bottom left. Many modules import a module full of concrete implementation. This is the more common and more painful case, since every change to that implementation touches everything downstream. The fix is to extract an interface and let dependents import that instead.
+
+The deviation feeds the health score, contributing up to 3 penalty points. See [the health score page](../output/health-score.md#dependencies).
+
+## Circular dependencies
+
+A cycle is a group of modules that import each other, directly or through a chain. jscan finds them with Tarjan's strongly connected components algorithm, which finds every cycle in one pass.
+
+Cycles matter for practical reasons rather than aesthetic ones. Module initialization order becomes undefined, so one module in the cycle sees a partially initialized version of another, which shows up as `undefined` at runtime in a way that is hard to trace. Bundlers cannot tree-shake across a cycle, so dead code survives into your bundle. Neither module can be understood or tested alone.
+
+Dynamic imports written as `import("./module")` are excluded from cycle detection, because a dynamic import resolves at call time rather than at load time and therefore does not create a load-time cycle. This is often the cheapest way to break a cycle you cannot otherwise untangle.
+
+Find them with:
+
+```bash
+jscan deps src/ --format json \
+  | jq -r '.analysis.circular_dependencies.circular_dependencies[].description'
+```
+
+Or fail the build on them:
+
+```bash
+jscan check --select deps src/
+```
+
+The usual fix is to find the thing both modules need and move it into a third module that both import. A cycle between `user.ts` and `order.ts` usually means there is a shared type or helper wanting to live in its own file.
+
+## Depth
+
+Maximum depth is the length of the longest import chain. jscan compares it against what a healthy graph of your size would have:
+
+```text
+expected depth = max(3, ⌈log₂(module count + 1)⌉ + 1)
+```
+
+A graph of 100 modules is expected to be about 8 deep. Exceeding the expectation costs up to 3 points in the health score.
+
+Deep chains make change expensive, because a modification at the bottom must be understood at every level above it. They usually come from layering that has grown one wrapper at a time.
+
+## Reading the DOT output
+
+```bash
+jscan deps src/ --dot | dot -Tsvg -o deps.svg
+```
+
+Nodes are colored green for low risk, yellow for medium, and red for high. Each node's tooltip carries its role, its `Ca` and `Ce`, and its instability. Modules that form a cycle are drawn inside a shared cluster, which makes cycles visible at a glance.
+
+Large graphs are unreadable as a single image. Two flags help:
+
+```bash
+# Keep only the hubs
+jscan deps src/ --dot --min-coupling 5 | dot -Tsvg -o hubs.svg
+
+# Wide graphs read better horizontally
+jscan deps src/ --dot --rank-dir LR | dot -Tsvg -o deps.svg
+```
+
+Rendering needs Graphviz, which provides the `dot` program. Install it with `brew install graphviz`, `apt install graphviz`, or the equivalent for your system.
+
+## A caution about path aliases
+
+jscan does not resolve TypeScript path aliases. An import written `@/lib/util` becomes a module node of its own rather than resolving to `src/lib/util.ts`, which inflates the module count and drops the real edge.
+
+Every metric on this page is computed from the graph, so every one of them is affected. In a project that uses aliases throughout, treat the coupling numbers as a lower bound and the cycle list as incomplete. Projects using relative imports get accurate results. The [TypeScript guide](typescript-projects.md#path-aliases-are-not-resolved) covers this in detail.
+
+## A worked reading
+
+```console
+$ jscan deps src/
+Summary:
+  Total modules: 2
+  Total dependencies: 1
+  Root modules (entry points): 1
+  Leaf modules (no dependencies): 1
+  Max depth: 1
+
+Coupling Analysis:
+  Average coupling: 1.00
+  Average instability: 0.50
+  Highly coupled modules: 0
+  Stable modules: 1
+```
+
+Two modules and one edge between them. One module imports nothing, so it is a leaf and a stable module with instability 0. The other imports it and nothing imports the other, so it is an entry point with instability 1. The average of 0 and 1 is the reported 0.50.
+
+There are no cycles and the depth of 1 is well under the expected 3, so the only dependency penalty comes from the main sequence deviation.
+
+## See also
+
+- [`jscan deps` reference](../cli/deps.md) for every flag
+- [Health score](../output/health-score.md#dependencies) for how these metrics affect the score

--- a/website/docs/guides/reduce-duplicate-code.md
+++ b/website/docs/guides/reduce-duplicate-code.md
@@ -1,0 +1,147 @@
+# Reduce Duplicate Code
+
+jscan finds duplicated code by comparing syntax trees rather than text. That means it still recognizes a copy after the variables have been renamed, the statements reordered, or the formatting changed, which is what separates it from a plain text search.
+
+```bash
+jscan analyze --select clone src/
+```
+
+## How the detection works
+
+Two stages run in sequence, for reasons of cost.
+
+First, every candidate fragment is reduced to a **MinHash fingerprint**, a compact summary of its structure. Fingerprints are indexed with locality-sensitive hashing so that fragments with similar structure land in the same bucket. This step is fast and approximate, and its job is to discard the overwhelming majority of pairs that could not possibly match.
+
+Second, the surviving pairs are compared with **APTED**, an algorithm that computes the edit distance between two trees, meaning the cheapest sequence of insertions, deletions, and relabellings that turns one into the other. This is accurate but cubic in fragment size, which is exactly why the first stage exists.
+
+Locality-sensitive hashing switches on automatically once a run exceeds 500 fragments. Below that, every pair is compared directly.
+
+## Clone types
+
+Results are graded by how much the copies differ.
+
+| Type | Meaning | Similarity threshold | On by default |
+| --- | --- | --- | --- |
+| Type 1 | Identical apart from whitespace and comments | 0.85 | Yes |
+| Type 2 | Identical after renaming identifiers and literals | 0.75 | Yes |
+| Type 3 | A copy with statements added, removed, or changed | 0.70 | No |
+| Type 4 | Different code computing the same result | 0.65 | Yes |
+
+Type 3 is disabled by default. Near-miss matching produces a high false positive rate, and the findings it adds tend to be pairs that merely resemble each other rather than pairs worth merging.
+
+A fragment must be at least **10 lines** and **20 syntax tree nodes** to be considered at all. This keeps short boilerplate such as getters, simple constructors, and one-line handlers out of the results, since those repeat everywhere and merging them makes code worse rather than better.
+
+## A worked example
+
+Two functions written months apart in different files:
+
+```ts title="src/orders.ts"
+export function summarizeOrders(rows: any[]) {
+  const out: any[] = [];
+  for (const row of rows) {
+    if (!row) continue;
+    if (row.status === "cancelled") continue;
+    const total = row.price * row.qty;
+    if (total <= 0) continue;
+    out.push({ id: row.id, total, label: row.name.trim().toLowerCase() });
+  }
+  out.sort((a, b) => b.total - a.total);
+  return out;
+}
+```
+
+```ts title="src/invoices.ts"
+export function summarizeInvoices(items: any[]) {
+  const results: any[] = [];
+  for (const item of items) {
+    if (!item) continue;
+    if (item.status === "cancelled") continue;
+    const amount = item.price * item.qty;
+    if (amount <= 0) continue;
+    results.push({ id: item.id, total: amount, label: item.name.trim().toLowerCase() });
+  }
+  results.sort((a, b) => b.total - a.total);
+  return results;
+}
+```
+
+Every identifier differs. A text search finds nothing. jscan reports:
+
+```console
+$ jscan analyze --text --select clone src/
+=== Clone Detection ===
+
+Statistics:
+  Total clone pairs: 1
+  Total clone groups: 1
+  Files analyzed: 2
+  Average similarity: 0.85
+
+Clone Types:
+  Type-2: 1
+
+Top Clone Pairs:
+  Type-2: src/invoices.ts:1:7-12:1 <-> src/orders.ts:1:7-12:1 (85.0% similar)
+```
+
+Type 2 at 85 percent similarity is the signature of a copy and paste followed by renaming.
+
+## Pairs and groups
+
+A **pair** is two fragments that match. A **group** collects fragments that are all mutually similar.
+
+Groups are the more useful view once the same logic has been copied more than once. Five copies of one function produce ten pairs but a single group of five, and the group tells you the thing you actually want to know, which is that one function needs extracting rather than that ten pairs need reviewing.
+
+The duplication percentage in the health score is computed from fragments rather than pairs:
+
+```text
+duplication percentage = clone fragments ÷ total fragments × 100
+```
+
+It reaches the maximum penalty of 20 points at 30 percent. See [the health score page](../output/health-score.md#duplication).
+
+## What to do about a finding
+
+Not every clone should be merged. Work through these questions in order.
+
+**Do the copies change for the same reason?** This is the question that matters most. Two functions that look alike but serve different parts of the business will drift apart, and merging them creates a shared function full of conditional branches serving both callers badly. Duplication is cheaper than the wrong abstraction.
+
+**Is the copy a bug waiting to happen?** If fixing a bug in one copy requires remembering to fix the others, merge them. This is the strongest argument for extraction and usually the correct one for validation logic, parsing, and formatting.
+
+**Is the duplication accidental or structural?** Two functions that are similar because both iterate a list and filter it are structurally similar without being duplicated. jscan cannot tell the difference, and Type 4 findings in particular often fall into this category.
+
+**Is it test code?** Test files repeat setup deliberately, because a test that reads top to bottom without indirection is easier to debug. Exclude test directories from clone analysis if the findings are noise.
+
+When you do merge, extract the varying parts as parameters. In the example above, the two functions differ only in their variable names, so a single `summarize(rows)` replaces both directly.
+
+## Reviewing findings efficiently
+
+Start with the highest similarity rather than the largest fragment. A pair at 95 percent is almost certainly a copy. A pair at 66 percent, just over the Type 4 threshold, is often a coincidence.
+
+```bash
+# The most similar pairs first, which is the default order
+jscan analyze --select clone --text src/ | head -40
+```
+
+For a project you are reviewing over time, track the group count rather than the pair count. Pairs grow quadratically with each new copy and overstate the problem.
+
+```bash
+jscan analyze --json --select clone src/ 2>/dev/null \
+  | jq '{groups: .summary.clone_groups, pairs: .summary.clone_pairs,
+         percent: .summary.code_duplication_percentage}'
+```
+
+## Speed
+
+Clone detection is usually the slowest of the five analyses. When you are iterating on something else, leave it out:
+
+```bash
+jscan analyze --select complexity,deadcode src/
+```
+
+It is also unavailable in `jscan check`, which is deliberate. A gate should be fast, and clone detection is not.
+
+## See also
+
+- [`jscan analyze` reference](../cli/analyze.md#clone) for the detection settings
+- [Health score](../output/health-score.md#duplication) for how duplication affects the score

--- a/website/docs/guides/typescript-projects.md
+++ b/website/docs/guides/typescript-projects.md
@@ -1,0 +1,190 @@
+# Analyze a TypeScript Project
+
+jscan reads TypeScript directly. It does not run `tsc`, does not read `tsconfig.json`, and does not need your project to compile. Everything it reports comes from parsing the source with a TypeScript grammar, which is why it works on a project that is mid-refactor and currently full of type errors.
+
+That design has consequences worth understanding before you trust the output.
+
+## What jscan understands
+
+These TypeScript constructs are parsed and analyzed normally:
+
+| Construct | Handled |
+| --- | --- |
+| Type annotations and generics | Yes. Generic functions and classes are analyzed like any other |
+| `interface` and `type` declarations | Yes, and they count toward coupling |
+| `enum` | Yes |
+| Class methods, getters, setters | Yes, each measured as its own function |
+| `import type` and `export type` | Yes. Included as dependency graph edges by default |
+| `.ts`, `.tsx`, `.mts`, `.cts` | Yes, all four extensions are collected |
+| Decorators | Parsed. The decorated class and its methods are analyzed normally |
+| Nullish coalescing (`??`) | Yes, and it adds 1 to cyclomatic complexity |
+| Optional chaining (`?.`) | Parsed, but it does **not** add to cyclomatic complexity |
+
+Type-only imports are treated as real edges in the dependency graph because they express a design dependency, even though they vanish at compile time. Pass `--include-types=false` to `jscan deps` when you want the runtime graph instead.
+
+## What jscan does not do
+
+Because there is no type checker involved, jscan cannot reason about types across files. It will not tell you that a function returns the wrong type or that an interface member is unused. Use `tsc --noEmit` for that. jscan answers a different question, which is whether the code is structured in a way you can keep working with.
+
+### Path aliases are not resolved
+
+This is the limitation most likely to affect you. If your `tsconfig.json` maps `@/*` to `src/*`, jscan does not know that.
+
+```ts title="src/app/main.ts"
+import { label } from "@/lib/util";
+import type { Role } from "@/lib/types";
+```
+
+jscan records `@/lib/util` as a module in its own right rather than resolving it to `src/lib/util.ts`. In a three-file project with two aliased imports, the dependency graph reports five modules instead of three:
+
+```console
+$ jscan deps --format json src/ | jq -r '.graph.nodes | keys[]'
+src/app/main.ts
+src/lib/types.ts
+src/lib/util.ts
+@/lib/types
+@/lib/util
+```
+
+The two extra entries are phantoms. They have no file behind them, and the real edge from `main.ts` to `util.ts` is missing.
+
+The effects are:
+
+- **Module counts are inflated** in the `deps` output and in the health score's dependency category.
+- **Real edges are missing**, so cycles that pass through an aliased import are not detected.
+- **Maximum depth is understated**, because chains are broken at every alias.
+
+Relative imports such as `./util` and `../lib/util` resolve correctly, so a project that uses relative imports throughout gets an accurate graph.
+
+There is an `module_analysis.alias_patterns` key in the configuration schema, defaulting to `["@/", "~/"]`, but no command reads it yet. See the [configuration reference](../configuration/reference.md#reserved-groups).
+
+!!! tip "Getting an accurate graph today"
+
+    If the dependency graph matters to you more than your import style does, relative imports give correct results now. Otherwise, read the `deps` numbers as a lower bound on your real coupling, and rely on the complexity, dead code, and clone analyses, none of which depend on import resolution.
+
+### Vue single-file components are not parsed
+
+`.vue` files are not collected, so the `<script>` block inside them is never analyzed. The `.ts` and `.js` files in a Vue or Nuxt project are analyzed normally. Support is on the roadmap.
+
+Note that `jscan init --interactive` adds `**/*.vue` to `analysis.include_patterns` when you choose the Vue preset. That key is not read, so the entry has no effect either way.
+
+## Recommended setup
+
+### 1. Fix the exclude patterns first
+
+The default exclude list contains short entries that match as substrings of a file's full path. In a TypeScript application this silently removes real source directories:
+
+- `src/routes/` is skipped, because `routes` contains `out`.
+- `src/layout/` and `app/**/layout.tsx` are skipped, for the same reason.
+- `src/checkout/` is skipped.
+- `src/utils/distance.ts` is skipped, because `distance` contains `dist`.
+
+Nothing in the output mentions the missing files. The only clue is a low count on the `Analyzing N files...` line.
+
+Write an explicit list without the short entries:
+
+```json title="jscan.config.json"
+{
+  "complexity": {
+    "low_threshold": 12,
+    "medium_threshold": 24
+  },
+  "analysis": {
+    "exclude_patterns": [
+      "node_modules",
+      "coverage",
+      ".git",
+      ".next",
+      ".nuxt",
+      ".turbo",
+      "*.min.js",
+      "*.map"
+    ]
+  }
+}
+```
+
+Then confirm the file count matches reality:
+
+```console
+$ jscan analyze --text src/ | head -1
+Analyzing 214 files...
+
+$ find src -name '*.ts' -o -name '*.tsx' | wc -l
+214
+```
+
+Those two numbers should agree, apart from anything your `.gitignore` excludes. If they do not, a pattern is over-matching.
+
+### 2. Point jscan at the source root
+
+Analyze `src/` rather than the project root. This keeps build output, configuration files, and scripts out of the analysis without needing patterns for them, which is what lets you drop the risky short patterns in step one.
+
+```bash
+jscan analyze src/
+```
+
+Pass the whole source root rather than a subdirectory. The unused-export analysis compares imports against exports across the analyzed files only, so running it on `src/components/` alone reports every component as unused, because the importers in the rest of `src/` were never read.
+
+### 3. Raise the complexity thresholds
+
+Component code accumulates conditional rendering, and each `&&`, `||`, `??`, and `?:` counts toward cyclomatic complexity. A React component that is entirely readable can score 12 to 15 on that measure. Thresholds of 12 and 24 rather than the default 9 and 19 give a truer picture.
+
+```json
+{
+  "complexity": {
+    "low_threshold": 12,
+    "medium_threshold": 24
+  }
+}
+```
+
+### 4. Allow dead code in the gate at first
+
+An exported symbol that no analyzed file imports produces a warning, and `jscan check` fails on warnings by default. In a library, or in any project analyzed one directory at a time, that describes most of your public API.
+
+```bash
+jscan check --allow-dead-code --max-complexity 20 src/
+```
+
+Tighten both once the first round of fixes has landed.
+
+## Monorepos
+
+There is no workspace-aware mode. Run jscan once per package:
+
+```bash
+for pkg in packages/*/; do
+  jscan check --allow-dead-code "$pkg/src" || exit 1
+done
+```
+
+Because config discovery walks upward from the analyzed path, each package can carry its own `jscan.config.json` and fall back to a root file when it has none. The [monorepo example](../configuration/examples.md#monorepo) shows the layout.
+
+Cross-package imports usually go through a workspace alias such as `@myorg/core`, which jscan does not resolve, so a per-package run cannot see them. Run `jscan analyze packages/` for the combined view and per-package runs for the gates.
+
+## Frameworks
+
+### Next.js
+
+jscan knows the App Router conventions. Inside a file under a path containing `/app/` and named `page`, `layout`, `template`, `loading`, `error`, `not-found`, `default`, or `route`, the default export is exempt from the unused-export warning, as are the framework's reserved names such as `metadata`, `generateStaticParams`, and `revalidate`. In `route` files the HTTP verb exports are exempt too.
+
+That exemption only helps if the file reaches the analyzer. A file named `layout.tsx` is dropped by the default exclude list before the exemption is consulted, which is one more reason to fix the patterns first.
+
+Add `.next`, `.vercel`, and `.turbo` to your exclude list.
+
+### Nuxt and Vue
+
+Add `.nuxt` and `.output` to your exclude list. Only the `.ts` and `.js` files are analyzed, since `.vue` files are not parsed.
+
+Note that `.output` is safe to include as a pattern, since it is long enough not to over-match, unlike the bare `out` entry in the default list.
+
+### Node backends
+
+Express and Fastify projects usually have a `routes` directory, which the default exclude list removes. Fix the patterns and the rest works normally. Relative imports are common in backend code, so the dependency graph tends to be accurate here.
+
+## See also
+
+- [Configuration examples](../configuration/examples.md) for complete files
+- [Reading the dependency graph](dependency-graph.md) for what the coupling metrics mean
+- [CI/CD integration](../integrations/ci-cd.md) for pipeline setups

--- a/website/docs/index.md
+++ b/website/docs/index.md
@@ -1,0 +1,110 @@
+---
+title: jscan
+hide:
+  - navigation
+---
+
+<div class="jscan-hero" markdown>
+<div class="jscan-hero__copy" markdown>
+
+<p class="jscan-hero__eyebrow">JavaScript and TypeScript</p>
+
+# Find what to fix first
+
+<p class="jscan-hero__lede">jscan reads your JavaScript and TypeScript source, scores the codebase from 0 to 100, and produces an HTML report that ranks the problems worth your attention. It runs as a single command and needs no build step, no type checker, and no project configuration.</p>
+
+```bash
+npx jscan analyze src/
+```
+
+[Get started](getting-started/quick-start.md){ .md-button .md-button--primary }
+[Browse the CLI reference](cli/index.md){ .md-button }
+
+<p class="jscan-hero__meta">Written in Go. Parses with tree-sitter. Runs analyses in parallel.</p>
+
+</div>
+<div class="jscan-hero__art" markdown>
+
+<span class="jscan-score__grade">91/100 &nbsp;Grade A</span>
+
+<div class="jscan-score__row"><span class="jscan-score__label">Complexity</span><span class="jscan-score__bar"><span class="jscan-score__fill" style="width:100%"></span></span><span class="jscan-score__value">100</span></div>
+<div class="jscan-score__row"><span class="jscan-score__label">Dead Code</span><span class="jscan-score__bar"><span class="jscan-score__fill jscan-score__fill--warn" style="width:65%"></span></span><span class="jscan-score__value">65</span></div>
+<div class="jscan-score__row"><span class="jscan-score__label">Duplication</span><span class="jscan-score__bar"><span class="jscan-score__fill" style="width:100%"></span></span><span class="jscan-score__value">100</span></div>
+<div class="jscan-score__row"><span class="jscan-score__label">Coupling</span><span class="jscan-score__bar"><span class="jscan-score__fill" style="width:100%"></span></span><span class="jscan-score__value">100</span></div>
+<div class="jscan-score__row"><span class="jscan-score__label">Dependencies</span><span class="jscan-score__bar"><span class="jscan-score__fill" style="width:85%"></span></span><span class="jscan-score__value">85</span></div>
+
+</div>
+</div>
+
+## What jscan measures
+
+jscan looks at your code from five angles. Each one contributes a category score, and the five combine into a single health score. The [health score page](output/health-score.md) explains exactly how the arithmetic works.
+
+<div class="grid cards" markdown>
+
+-   :material-broom: **Dead code**
+
+    ---
+
+    Statements that can never execute, exported functions that nothing imports, and imports that nothing uses. jscan finds these by building a control flow graph for every function and walking it from the entry point.
+
+    [Read more](cli/analyze.md#dead-code)
+
+-   :material-content-duplicate: **Duplicate code**
+
+    ---
+
+    Copy-pasted and structurally similar code. jscan compares syntax trees rather than text, so it still matches fragments after variables have been renamed or statements reordered.
+
+    [Read more](guides/reduce-duplicate-code.md)
+
+-   :material-sine-wave: **Complexity**
+
+    ---
+
+    Cyclomatic complexity per function, which counts the number of independent paths through the code. High values mark the functions that are hardest to read and to test.
+
+    [Read more](cli/analyze.md#complexity)
+
+-   :material-graph-outline: **Dependencies**
+
+    ---
+
+    The module import graph, including circular imports and the Martin coupling metrics. jscan can export the graph as Graphviz DOT for rendering.
+
+    [Read more](guides/dependency-graph.md)
+
+-   :material-vector-link: **Class design**
+
+    ---
+
+    Coupling between objects, which counts how many other types each class or module depends on. Classes near the top of this list are the ones that break when anything else changes.
+
+    [Read more](cli/analyze.md#cbo)
+
+-   :material-check-decagram: **Quality gates**
+
+    ---
+
+    A separate command built for continuous integration. It runs a subset of the analyses, prints a short verdict, and sets a process exit code your pipeline can act on.
+
+    [Read more](cli/check.md)
+
+</div>
+
+## Three commands worth knowing
+
+```bash
+# Full analysis with an HTML report that opens in your browser
+jscan analyze src/
+
+# Fast pass or fail gate for CI, which exits non-zero on a violation
+jscan check src/
+
+# Dependency graph rendered with Graphviz
+jscan deps src/ --dot | dot -Tsvg -o deps.svg
+```
+
+## Working with Python instead?
+
+The same analyses are available for Python in [pyscn](https://docs.codescan.dev/), which shares its core algorithms with jscan through the `polyscan` repository.

--- a/website/docs/integrations/agent-skills.md
+++ b/website/docs/integrations/agent-skills.md
@@ -1,0 +1,70 @@
+# Agent Skills
+
+jscan ships four Agent Skills. A skill is a short instruction file that tells an AI coding agent when a tool is relevant, which command to run, and how to interpret the output. Installing them means you can ask for the analysis in plain language instead of remembering the flags.
+
+## Install
+
+```bash
+npx skills add ludo-technologies/polyscan
+```
+
+This installs the skills into the current project for whichever agents it detects. Two flags are worth knowing:
+
+```bash
+npx skills add ludo-technologies/polyscan --agent cursor   # One agent only
+npx skills add ludo-technologies/polyscan --global         # All your projects
+```
+
+The skills work with Claude Code, Cursor, Codex, Gemini CLI, and [many other agents](https://github.com/vercel-labs/skills).
+
+## Install as a Claude Code plugin
+
+Claude Code can install the same skills through its plugin system:
+
+```bash
+claude plugin marketplace add ludo-technologies/polyscan
+claude plugin install jscan@polyscan-marketplace
+```
+
+The contents are identical. Choose whichever fits how you already manage tooling. There is no benefit to installing both.
+
+## The four skills
+
+| Skill | Triggers on | Runs |
+| --- | --- | --- |
+| `health-check` | Questions about overall quality, a grade, or a before and after comparison | `jscan analyze` and reads the health score |
+| `refactoring` | Questions about duplication, complexity hotspots, or dead code | `jscan analyze` with the relevant `--select` |
+| `architecture-review` | Questions about module structure, coupling, or circular imports | `jscan deps` and the coupling analysis |
+| `cli-analysis` | Requests for a report file, a CI gate, or project configuration | `jscan check`, `jscan init`, and report generation |
+
+Each skill runs jscan through `npx jscan@latest`, so no separate install is needed. The agent will download it on first use.
+
+## What to ask
+
+Once installed, ordinary requests reach the right analysis:
+
+- "How healthy is the code in `src/`?"
+- "Find duplicate code and help me refactor it."
+- "Which functions are too complex?"
+- "Are there any circular imports?"
+- "Set up a CI quality gate for this project."
+- "Generate an HTML quality report."
+
+## Reading the results critically
+
+An agent will report what jscan says, and jscan has limitations that are easy to miss when the output is summarized for you. Two are worth telling your agent about.
+
+**Unused exports depend on what was analyzed.** If the agent runs jscan on one directory, every export in it is reported as unused, because the importers elsewhere were never read. Ask the agent to analyze the whole source root before acting on those findings.
+
+**The default exclude patterns drop real directories.** Short entries such as `out` and `dist` match as substrings of the full path, so `src/routes/`, `src/layout/`, and `src/checkout/` are silently skipped. If an agent reports a clean codebase, ask it to confirm the file count on the `Analyzing N files...` line against the number of source files you actually have. The [configuration reference](../configuration/reference.md#analysisexclude_patterns) explains the fix.
+
+Committing a `jscan.config.json` with a corrected exclude list solves this for every future agent run, since the agent picks the file up automatically.
+
+## Working with Python too?
+
+pyscn provides the equivalent skills for Python, but they live in the [pyscn repository](https://github.com/ludo-technologies/pyscn) rather than this one. Installing from `ludo-technologies/polyscan` gives you the four jscan skills only. Add the pyscn skills separately for a mixed codebase.
+
+## See also
+
+- [CLI reference](../cli/index.md) for what the agent is actually running
+- [Configuration](../configuration/index.md) for making agent runs accurate by default

--- a/website/docs/integrations/ci-cd.md
+++ b/website/docs/integrations/ci-cd.md
@@ -1,0 +1,234 @@
+# CI/CD Integration
+
+`jscan check` exists for this. It runs a fast subset of the analyses, prints a short verdict, and sets an exit code your pipeline can act on.
+
+| Exit code | Meaning | What the pipeline should do |
+| --- | --- | --- |
+| 0 | Every check passed | Continue |
+| 1 | A threshold was violated | Fail the build |
+| 2 | jscan could not run | Fail the build and investigate the job, not the code |
+
+Distinguishing 1 from 2 is worth doing. Exit code 2 usually means a wrong path or a missing checkout rather than a genuine quality problem.
+
+## Before you write the job
+
+Two things will otherwise waste your time.
+
+**The default gate fails on any dead code finding**, including the warning that an exported function is not imported by another analyzed file. In a library, that describes your entire public API. Start with `--allow-dead-code` and tighten later.
+
+**The default exclude patterns silently drop source directories.** Short entries such as `out` and `dist` are matched as substrings of the full file path, so `src/routes/`, `src/layout/`, and `src/checkout/` are skipped. A gate that analyzes a fraction of your code passes easily and tells you nothing. Commit a configuration file with an explicit exclude list, and check the `Analyzing N files...` count against reality once. The [configuration reference](../configuration/reference.md#analysisexclude_patterns) has a safe list to start from.
+
+## GitHub Actions
+
+### A quality gate
+
+```yaml title=".github/workflows/quality.yml"
+name: Code Quality
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  jscan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Quality gate
+        run: npx jscan@0.4.1 check --allow-dead-code --max-complexity 20 src/
+```
+
+Pinning the version keeps a new release from turning a green pipeline red without a change to your code.
+
+### Publishing the HTML report
+
+The report is a single self-contained file, which makes it a good artifact. Note that `analyze` never fails, so this job reports without gating.
+
+```yaml title=".github/workflows/quality.yml"
+      - name: Full analysis
+        run: npx jscan@0.4.1 analyze --no-open --output jscan-report.html src/
+
+      - uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: jscan-report
+          path: jscan-report.html
+          retention-days: 30
+```
+
+`--no-open` matters here. Without it jscan tries to launch a browser, which does nothing useful on a runner.
+
+### Posting the score on a pull request
+
+```yaml
+      - name: Analyze
+        id: jscan
+        run: |
+          npx jscan@0.4.1 analyze --json src/ 2>/dev/null > report.json
+          {
+            echo "score=$(jq '.summary.health_score' report.json)"
+            echo "grade=$(jq -r '.summary.grade' report.json)"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `**jscan**: ${{ steps.jscan.outputs.score }}/100 (grade ${{ steps.jscan.outputs.grade }})`
+            })
+```
+
+The `2>/dev/null` keeps the score summary out of the JSON file.
+
+### Failing below a grade
+
+`jscan check` gates on individual thresholds rather than on the score. To gate on the score itself, read it from the JSON:
+
+```yaml
+      - name: Require grade B or better
+        run: |
+          score=$(npx jscan@0.4.1 analyze --json src/ 2>/dev/null | jq '.summary.health_score')
+          echo "Health score: $score"
+          if [ "$score" -lt 75 ]; then
+            echo "::error::Health score $score is below the grade B threshold of 75"
+            exit 1
+          fi
+```
+
+Always run the same `--select` when you gate on the score. A category that did not run contributes no penalty, so a narrower selection scores higher for the same code. See [the health score page](../output/health-score.md#selecting-fewer-analyses-raises-the-score).
+
+### Analyzing a monorepo
+
+```yaml
+jobs:
+  jscan:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        package: [core, web, api]
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npx jscan@0.4.1 check --allow-dead-code packages/${{ matrix.package }}/src
+```
+
+`fail-fast: false` means one failing package does not cancel the others, so a single run tells you about all of them.
+
+## GitLab CI
+
+```yaml title=".gitlab-ci.yml"
+quality:
+  stage: test
+  image: node:20
+  script:
+    - npx jscan@0.4.1 check --allow-dead-code --max-complexity 20 src/
+    - npx jscan@0.4.1 analyze --no-open --output jscan-report.html src/
+  artifacts:
+    when: always
+    paths:
+      - jscan-report.html
+    expire_in: 30 days
+```
+
+`when: always` publishes the report even when the gate fails, which is exactly when you want to read it.
+
+Note the ordering. `check` runs first and stops the job on failure, so put `analyze` after it and rely on `when: always` to still collect the artifact.
+
+## Pre-commit hook
+
+A gate on the whole project is too slow for a commit hook. Check only the staged files:
+
+```bash title=".git/hooks/pre-commit"
+#!/usr/bin/env bash
+set -euo pipefail
+
+files=$(git diff --cached --name-only --diff-filter=ACM \
+        | grep -E '\.(js|jsx|mjs|cjs|ts|tsx|mts|cts)$' || true)
+
+[ -z "$files" ] && exit 0
+
+# shellcheck disable=SC2086
+npx jscan check --select complexity --max-complexity 20 $files
+```
+
+Make it executable with `chmod +x .git/hooks/pre-commit`.
+
+Restricting `--select` to `complexity` is deliberate. Dead code detection on a handful of staged files reports almost every export as unused, because the importers are not in the file list.
+
+### With the pre-commit framework
+
+```yaml title=".pre-commit-config.yaml"
+repos:
+  - repo: local
+    hooks:
+      - id: jscan
+        name: jscan complexity check
+        entry: npx jscan check --select complexity --max-complexity 20
+        language: system
+        files: \.(js|jsx|mjs|cjs|ts|tsx|mts|cts)$
+        pass_filenames: true
+```
+
+## Docker
+
+There is no official image. Install jscan into whichever image you already use:
+
+```dockerfile
+FROM node:20-alpine
+RUN npm install -g jscan@0.4.1
+WORKDIR /src
+ENTRYPOINT ["jscan"]
+```
+
+```bash
+docker build -t jscan-ci .
+docker run --rm -v "$PWD:/src" jscan-ci check --allow-dead-code src/
+```
+
+## Tracking the score over time
+
+Appending one line per commit gives you a trend without any extra infrastructure:
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+json=$(jscan analyze --json src/ 2>/dev/null)
+printf '%s\t%s\t%s\t%s\n' \
+  "$(git rev-parse --short HEAD)" \
+  "$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+  "$(jq '.summary.health_score' <<<"$json")" \
+  "$(jq -r '.summary.grade' <<<"$json")" \
+  >> quality-history.tsv
+```
+
+Two rules keep the series meaningful. Pin the jscan version, since scoring changes between releases would show up as a change in your code quality. Keep the same `--select` and the same configuration file, for the same reason.
+
+## Recommended progression
+
+Adopting the strictest settings on day one means a permanently red pipeline that people learn to ignore. A workable sequence is:
+
+1. **Report only.** Run `jscan analyze` and publish the artifact. Nothing fails. Let the team look at it for a couple of weeks.
+2. **Gate on complexity alone**, at a threshold your codebase already passes. `jscan check --select complexity --max-complexity 30 src/`.
+3. **Lower the threshold** by five whenever the pipeline has been comfortably green for a while.
+4. **Add the dependency check** once the cycles are fixed. `--select complexity,deps`.
+5. **Remove `--allow-dead-code`** last, and only if your project is an application rather than a library. In a library the unused-export warnings never go away.
+
+## See also
+
+- [`jscan check` reference](../cli/check.md) for every threshold flag
+- [Configuration examples](../configuration/examples.md) for files to commit alongside these jobs

--- a/website/docs/integrations/index.md
+++ b/website/docs/integrations/index.md
@@ -1,0 +1,78 @@
+# Integrations
+
+jscan is a single binary that reads files and writes results, so it fits anywhere you can run a command.
+
+<div class="grid cards" markdown>
+
+-   :material-source-branch: **CI/CD**
+
+    ---
+
+    Quality gates for GitHub Actions, GitLab CI, and pre-commit hooks, including how to publish the HTML report as a build artifact.
+
+    [Read more](ci-cd.md)
+
+-   :material-robot: **Agent Skills**
+
+    ---
+
+    Teach an AI coding agent when to run each analysis and how to read the output, for Claude Code, Cursor, Codex, and others.
+
+    [Read more](agent-skills.md)
+
+</div>
+
+## Editor integration
+
+There is no editor extension yet. The closest thing available today is a task or watch script that runs jscan on save. It is not fast enough to run on every keystroke, since a full analysis of a large project takes seconds rather than milliseconds, but a fast subset works well on save:
+
+```json title=".vscode/tasks.json"
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "jscan: complexity",
+      "type": "shell",
+      "command": "jscan analyze --select complexity --text src/",
+      "problemMatcher": []
+    }
+  ]
+}
+```
+
+## Using jscan from a script
+
+Every command works in a pipeline. `--json` gives machine-readable output, and `jscan check` gives an exit code.
+
+```bash
+#!/usr/bin/env bash
+set -euo pipefail
+
+score=$(jscan analyze --json src/ 2>/dev/null | jq '.summary.health_score')
+echo "Health score: $score"
+
+if [ "$score" -lt 75 ]; then
+  echo "Score is below the grade B threshold" >&2
+  exit 1
+fi
+```
+
+Note the `2>/dev/null`. `jscan analyze --json` writes its score summary to standard error, so discarding standard error keeps the parsed output clean. See [output formats](../output/index.md#standard-output-and-standard-error).
+
+## Pinning the version
+
+The JSON output shape is not covered by a stability guarantee yet. Anything that parses it should pin a version rather than track the latest release:
+
+```json title="package.json"
+{
+  "devDependencies": {
+    "jscan": "0.4.1"
+  }
+}
+```
+
+In a pipeline that uses `npx`, name the version explicitly:
+
+```bash
+npx jscan@0.4.1 check src/
+```

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -1,0 +1,176 @@
+# Health Score
+
+The health score is a single number from 0 to 100 summarizing everything jscan measured, with a letter grade attached. It appears at the end of the terminal summary, at the top of the HTML report, and in the `summary` object of the JSON output.
+
+```text
+Health Score: 91/100 (Grade: A)
+```
+
+This page documents exactly how that number is produced, so that you can predict how a change to your code will move it.
+
+## The formula
+
+The score starts at 100 and subtracts one penalty per category:
+
+```text
+score = 100 - (complexity + dead code + duplication + coupling + dependencies + architecture)
+```
+
+The result is clamped to the range 0 to 100. Every penalty is an integer.
+
+| Category | Maximum penalty |
+| --- | --- |
+| Complexity | 20 |
+| Dead code | 20 |
+| Duplication | 20 |
+| Coupling | 20 |
+| Dependencies | 16 |
+| Architecture | 12 |
+
+Architecture validation is not implemented in jscan, so its penalty is always 0. In practice the largest penalty a JavaScript or TypeScript project can accumulate is 96, and the lowest reachable score is 4.
+
+## Grades
+
+| Grade | Score |
+| --- | --- |
+| A | 90 to 100 |
+| B | 75 to 89 |
+| C | 60 to 74 |
+| D | 45 to 59 |
+| F | 0 to 44 |
+
+These thresholds are shared with pyscn so that a grade means the same thing regardless of the language being analyzed.
+
+## How each penalty is computed
+
+Four of the categories use the same shape. A ratio is computed, and the penalty grows linearly from 0 until the ratio reaches a saturation point, beyond which the penalty stays at its maximum.
+
+### Complexity
+
+```text
+ratio   = (high risk functions + 0.5 × medium risk functions) ÷ total functions
+penalty = 20 × ratio ÷ 0.05, capped at 20
+```
+
+The penalty reaches its maximum once the weighted ratio hits 5 percent. That is a demanding target: a codebase where one function in twenty is high risk already receives the full 20 point penalty. Medium risk functions count half as much as high risk ones.
+
+Which functions count as high or medium risk depends on your configured thresholds, so raising `complexity.medium_threshold` raises the score without changing any code.
+
+### Dead code
+
+```text
+weighted = 1.0 × critical + 0.5 × warning + 0.2 × info
+rate     = weighted ÷ total files
+penalty  = 20 × rate ÷ 3.0, capped at 20
+```
+
+This is a per-file rate rather than a raw count, so a large codebase is not penalized simply for being large. The penalty maxes out at three weighted findings per file.
+
+Note that the divisor is the file count reported by the dead code analysis. When dead code detection is not selected, the file count is 0 and the penalty is 0.
+
+### Duplication
+
+```text
+penalty = 20 × duplication percentage ÷ 30, capped at 20
+```
+
+The duplication percentage is the proportion of code fragments that participate in at least one clone pair or group. It reaches the maximum penalty at 30 percent.
+
+### Coupling
+
+```text
+ratio   = (high coupling modules + 0.3 × medium coupling modules) ÷ total modules
+penalty = 20 × ratio ÷ 0.40, capped at 20
+```
+
+Medium risk modules are weighted at 0.3 rather than 0.5, which is more forgiving than the complexity weighting. The penalty saturates when the weighted ratio reaches 40 percent.
+
+### Dependencies
+
+This penalty is the sum of three independent parts.
+
+**Cycles, up to 10 points.** Two candidate values are computed and the larger wins:
+
+```text
+proportional = 10 × modules in cycles ÷ total modules
+floor        = log₂(modules in cycles + 1)
+cycle points = min(10, max(proportional, floor))
+```
+
+The logarithmic floor exists so that circular imports always cost something. Without it, three modules in a cycle inside a thousand-module repository would round away to nothing.
+
+**Depth, up to 3 points.** jscan compares your longest import chain against the depth a healthy graph of that size would have:
+
+```text
+expected     = max(3, ⌈log₂(total modules + 1)⌉ + 1)
+depth points = min(3, max(0, max depth - expected))
+```
+
+**Main sequence deviation, up to 3 points.** The Martin distance from the main sequence, a value between 0 and 1, multiplied by 3 and rounded. The [dependency graph guide](../guides/dependency-graph.md) explains what that metric means.
+
+### Architecture
+
+Always 0 in jscan. The category exists because the scoring code is shared with pyscn, where architectural layer validation is implemented.
+
+## Category scores
+
+Alongside the overall number, jscan reports a 0 to 100 score per category. These are presentation values and do not feed back into the total.
+
+For complexity, dead code, duplication, and coupling the conversion is direct:
+
+```text
+category score = 100 - (penalty × 5)
+```
+
+A penalty of 4 out of 20 therefore displays as 80 out of 100.
+
+The dependency score is normalized first, because its maximum penalty is 16 rather than 20:
+
+```text
+normalized     = round(penalty ÷ 16 × 20)
+category score = 100 - (normalized × 5)
+```
+
+The architecture score is the compliance ratio times 100, which in jscan is always 0. Ignore the `architecture_score` field in JSON output.
+
+## Selecting fewer analyses raises the score
+
+A category that did not run contributes no penalty. That makes scores from different `--select` values incomparable:
+
+```console
+$ jscan analyze --json --select complexity src/ | jq .summary.health_score
+100
+
+$ jscan analyze --json --select complexity,deadcode src/ | jq .summary.health_score
+93
+
+$ jscan analyze --json src/ | jq .summary.health_score
+91
+```
+
+The code is identical in all three runs. Only the number of categories being scored changed.
+
+If you track the score over time, always run the same selection. The default, which runs all five analyses, is the right choice for a tracked metric.
+
+## Worked example
+
+Take the run summarized as 91 out of 100 with grade A:
+
+| Category | Measurement | Penalty | Category score |
+| --- | --- | --- | --- |
+| Complexity | 0 high risk and 0 medium risk of 4 functions | 0 | 100 |
+| Dead code | 1 critical and 2 warnings across 2 files, a rate of 1.0 | 7 | 65 |
+| Duplication | 0 percent | 0 | 100 |
+| Coupling | 0 of 2 modules at risk | 0 | 100 |
+| Dependencies | 0 cycles, depth 1, deviation 0.6 | 2 | 85 |
+| Architecture | not implemented | 0 | 0 |
+
+The total penalty is 9, giving a score of 91 and a grade of A.
+
+The dead code figure is the one worth following through. The weighted finding count is `1.0 × 1 + 0.5 × 2 = 2.0`, spread over 2 files, giving a rate of 1.0. That is one third of the way to the saturation point of 3.0, so the penalty is one third of 20, which rounds to 7. The category score is `100 - 7 × 5 = 65`.
+
+## What moves the score most
+
+Because every category saturates, the fastest gains come from whichever category is furthest from zero rather than from whichever has the most raw findings. A project with a dead code score of 65 and a complexity score of 100 should fix dead code first, even if it has far more functions than findings.
+
+The categories also differ in how quickly they saturate. Complexity saturates at a weighted ratio of 5 percent, which is by far the tightest of the four. A handful of high complexity functions in a small codebase can max out that penalty on its own.

--- a/website/docs/output/html-report.md
+++ b/website/docs/output/html-report.md
@@ -1,0 +1,81 @@
+# HTML Report
+
+The HTML report is what `jscan analyze` produces by default. It is a single self-contained file with no external assets, so you can email it, attach it to a pull request, or publish it as a continuous integration artifact and it will render anywhere.
+
+```bash
+jscan analyze src/
+```
+
+The file is written to `jscan-report.html` in the current directory and opened in your browser. Change the path with `--output`, and suppress the browser with `--no-open`.
+
+```bash
+jscan analyze --output reports/quality.html --no-open src/
+```
+
+## Layout
+
+The report opens on a summary and has one tab per analysis. Tabs appear only for the analyses that ran, so a report produced with `--select complexity` has two tabs rather than six.
+
+| Tab | Contents |
+| --- | --- |
+| Summary | The overall score and grade, the six category scores, and file statistics |
+| Complexity | Function count, average and maximum complexity, and a table of functions |
+| Dead Code | Finding counts by severity and a table of every issue |
+| Clones | Clone pair and group counts and a table of the most similar pairs |
+| Coupling | Module count, average CBO, and a table ranked by coupling |
+| Dependencies | Module count, entry points, maximum depth, and any circular imports |
+
+Each tab header carries that category's score out of 100, colored by quality band, so you can see where the problem is without opening every tab.
+
+## Row limits
+
+Tables are truncated so that the file stays a reasonable size on a large codebase.
+
+| Table | Limit | Notes |
+| --- | --- | --- |
+| Functions | 20 | A line below the table reports the true total |
+| Clone pairs | 20 | A line below the table reports the true total |
+| Modules by coupling | 20 | A line below the table reports the true total |
+| Circular dependencies | 10 | A line below the table reports the true total |
+| Dead code, per function | 20 | **No line is printed**, so the truncation is silent |
+| Dead code, file level | no limit | Every file level finding is shown |
+
+The dead code limit applies per function rather than to the table as a whole. A function with more than 20 findings shows the first 20 and nothing indicates that others exist. Use `--json` or `--text` when you need the complete list.
+
+## Reading the summary tab
+
+The headline is the health score and its grade. Below it sit the six category scores, and below those the file statistics.
+
+Two details in this tab are easy to misread.
+
+The **Total Functions** card changes meaning when `output.min_complexity` filtered anything out. In that case it shows two numbers and relabels itself **Reported / Parsed**, for example `12 / 340`. The first is what the report contains and the second is what jscan actually parsed. When the label says **Total Functions** with a single number, nothing was filtered.
+
+The **architecture score** is not shown, because architecture validation is not implemented in jscan. Only five category scores carry meaning. See [the health score page](health-score.md) for what each one measures.
+
+## Sorting
+
+Every table is sorted by the metric it is about, worst first. Functions are ordered by descending complexity, modules by descending coupling, and clone pairs by descending similarity. Since the tables are truncated at 20 rows, this means you always see the worst offenders rather than an arbitrary sample.
+
+Sorting is fixed. `output.sort_by` is not read.
+
+## Sharing and archiving
+
+The report embeds its own styles and scripts and loads nothing over the network, so it works offline and inside a restricted environment. That also makes it a good continuous integration artifact:
+
+```yaml
+- name: Analyze
+  run: jscan analyze --no-open --output jscan-report.html src/
+
+- uses: actions/upload-artifact@v4
+  with:
+    name: jscan-report
+    path: jscan-report.html
+```
+
+The [CI/CD page](../integrations/ci-cd.md) has complete pipeline configurations.
+
+## When the browser does not open
+
+jscan skips opening a browser when it detects an SSH session, since there is usually no display to open it on. It also prints a warning rather than failing when the browser cannot be launched for any other reason, such as inside a container with no desktop environment.
+
+The report file is written either way. The absolute path is printed on the line beginning `📊 Unified HTML report generated`, so you can open it yourself.

--- a/website/docs/output/index.md
+++ b/website/docs/output/index.md
@@ -1,0 +1,63 @@
+# Output Formats
+
+Which formats are available depends on the command.
+
+| Command | Formats | Default | Destination |
+| --- | --- | --- | --- |
+| `analyze` | `html`, `json`, `text` | `html` | HTML to a file, the others to standard output |
+| `check` | text, `--json` | text | Standard output |
+| `deps` | `text`, `json`, `dot` | `text` | Standard output, or `--output` |
+
+## Choosing a format
+
+**HTML** is the format to use when a person is going to read the results. It ranks findings, groups them by category, and is the only format that shows the full clone comparison side by side. See [the HTML report](html-report.md).
+
+**Text** is for a quick look in the terminal and for pasting into an issue. It contains everything the HTML report does, in reading order rather than ranked order.
+
+**JSON** is for anything programmatic: a dashboard, a script that tracks the score over time, or a bot that comments on pull requests. See [the JSON schema](json-schema.md).
+
+**DOT** applies to `jscan deps` only, and produces a Graphviz document for rendering the dependency graph as an image.
+
+## Standard output and standard error
+
+This matters when you redirect output in a script.
+
+For `jscan analyze --json`, the JSON document goes to standard output and the human-readable score summary goes to standard error. That separation is deliberate, and it means the following works:
+
+```bash
+jscan analyze --json src/ > report.json     # report.json holds valid JSON
+jscan analyze --json src/ 2> /dev/null      # summary suppressed, JSON kept
+```
+
+For `jscan analyze --text`, everything goes to standard output, because the text report already ends with its own score section and printing it twice would be noise.
+
+For `jscan analyze` in HTML mode, the report goes to the file and the summary goes to standard output.
+
+Progress bars are written only when the output is an interactive terminal, so redirecting to a file never captures escape sequences.
+
+## Exit codes
+
+Only `jscan check` varies its exit code by result. Every other command exits 0 on success and 1 on an internal error.
+
+| Command | 0 | 1 | 2 |
+| --- | --- | --- | --- |
+| `analyze` | Analysis completed | Could not run | not used |
+| `check` | All checks passed | A threshold was violated | Could not run |
+| `deps` | Analysis completed | Could not run | not used |
+| `init` | File written | Could not write | not used |
+
+An individual analysis failing inside `analyze` does not fail the command. jscan prints the error to standard error and reports the categories that did succeed, so a parse failure in one file never costs you the whole run.
+
+## The health score
+
+Every format that carries a summary includes a health score from 0 to 100 and a letter grade. It is computed identically in all of them. See [the health score page](health-score.md) for the formula.
+
+## Report file location
+
+The HTML report is written to `jscan-report.html` in the current working directory. Change it with `--output`:
+
+```bash
+jscan analyze --output reports/quality.html src/
+```
+
+The directory must already exist. jscan does not create intermediate directories, and the command fails if the path cannot be opened for writing.

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -1,0 +1,331 @@
+# JSON Schema
+
+`jscan analyze --json` writes a single document to standard output. This page describes its structure. The score summary is written to standard error, so redirecting standard output gives you valid JSON with nothing else mixed in.
+
+```bash
+jscan analyze --json src/ > report.json
+```
+
+## Top level
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "duration_ms": 5,
+  "complexity": { },
+  "dead_code": { },
+  "clone": { },
+  "cbo": { },
+  "deps": { },
+  "summary": { }
+}
+```
+
+| Field | Type | Notes |
+| --- | --- | --- |
+| `version` | string | The jscan version. `dev` for a locally built binary |
+| `generated_at` | string | RFC 3339 timestamp |
+| `duration_ms` | integer | Wall clock time of the whole run |
+| `complexity` | object | Present only when complexity analysis ran |
+| `dead_code` | object | Present only when dead code detection ran |
+| `clone` | object | Present only when clone detection ran |
+| `cbo` | object | Present only when coupling analysis ran |
+| `deps` | object | Present only when dependency analysis ran |
+| `summary` | object | Always present |
+
+The five analysis keys are omitted entirely when `--select` excludes them, so consumers should check for their presence rather than assume it.
+
+## `summary`
+
+This is the object most scripts want. It carries the health score, the per-category scores, and the headline counts.
+
+```json
+{
+  "total_files": 2,
+  "analyzed_files": 2,
+  "skipped_files": 0,
+  "complexity_enabled": true,
+  "dead_code_enabled": true,
+  "clone_enabled": true,
+  "cbo_enabled": true,
+  "deps_enabled": true,
+  "arch_enabled": false,
+  "deps_total_modules": 2,
+  "deps_modules_in_cycles": 0,
+  "deps_max_depth": 1,
+  "deps_main_sequence_deviation": 0.6,
+  "arch_compliance": 0,
+  "total_functions": 4,
+  "functions_parsed": 4,
+  "average_complexity": 4.5,
+  "high_complexity_count": 0,
+  "medium_complexity_count": 0,
+  "dead_code_count": 3,
+  "critical_dead_code": 1,
+  "warning_dead_code": 2,
+  "info_dead_code": 0,
+  "total_clones": 0,
+  "clone_pairs": 0,
+  "clone_groups": 0,
+  "code_duplication_percentage": 0,
+  "cbo_classes": 2,
+  "high_coupling_classes": 0,
+  "medium_coupling_classes": 0,
+  "average_coupling": 0.5,
+  "health_score": 91,
+  "grade": "A",
+  "complexity_score": 100,
+  "dead_code_score": 65,
+  "duplication_score": 100,
+  "coupling_score": 100,
+  "dependency_score": 85,
+  "architecture_score": 0
+}
+```
+
+A few fields need explanation.
+
+`total_functions` is the count **after** the `output.min_complexity` filter. `functions_parsed` is the count before it. When the two differ, the report you are looking at is a filtered view.
+
+`cbo_classes`, `high_coupling_classes`, and `medium_coupling_classes` count modules rather than classes in jscan, despite the names. See [the analyze reference](../cli/analyze.md#cbo).
+
+`arch_enabled` is always `false` and `architecture_score` is always `0`, because architecture validation is not implemented in jscan. Ignore both.
+
+`grade` is one of `A`, `B`, `C`, `D`, `F`, or `N/A`. The last appears only when the summary failed validation, in which case `health_score` is 0 as well.
+
+## `complexity`
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "functions": [ ],
+  "summary": { },
+  "warnings": [ ],
+  "errors": [ ],
+  "config": { }
+}
+```
+
+Each entry in `functions` looks like this:
+
+```json
+{
+  "name": "shippingCost",
+  "file_path": "/home/you/project/src/cart.ts",
+  "start_line": 25,
+  "start_column": 7,
+  "end_line": 35,
+  "metrics": {
+    "complexity": 9,
+    "nodes": 16,
+    "edges": 22,
+    "nesting_depth": 0,
+    "if_statements": 6,
+    "loop_statements": 1,
+    "exception_handlers": 1,
+    "switch_cases": 0
+  },
+  "risk_level": "low"
+}
+```
+
+`nodes` and `edges` describe the control flow graph the complexity was derived from. `risk_level` is `low`, `medium`, or `high`, determined by your configured thresholds.
+
+File paths are reported exactly as jscan resolved them, which means they are absolute when you passed an absolute path and relative when you passed a relative one.
+
+## `dead_code`
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "files": [ ],
+  "summary": { },
+  "warnings": [ ],
+  "errors": [ ],
+  "config": { }
+}
+```
+
+Each entry in `files` separates findings inside functions from findings about the file as a whole:
+
+```json
+{
+  "file_path": "/home/you/project/src/cart.ts",
+  "functions": [
+    {
+      "name": "totalPrice",
+      "file_path": "/home/you/project/src/cart.ts",
+      "findings": [
+        {
+          "location": {
+            "file_path": "/home/you/project/src/cart.ts",
+            "start_line": 20,
+            "end_line": 20,
+            "start_column": 0,
+            "end_column": 0
+          },
+          "function_name": "totalPrice",
+          "code": "",
+          "reason": "unreachable_after_return",
+          "severity": "critical",
+          "description": "Code after return statement is unreachable"
+        }
+      ],
+      "total_blocks": 18,
+      "dead_blocks": 1,
+      "reachable_ratio": 0.7777777777777778,
+      "critical_count": 1,
+      "warning_count": 0,
+      "info_count": 0
+    }
+  ],
+  "file_level_findings": [ ],
+  "total_findings": 2,
+  "total_functions": 2,
+  "affected_functions": 1,
+  "dead_code_ratio": 0.5
+}
+```
+
+Findings inside a function appear under `functions[].findings`. Findings about the file itself, such as an unused export or an orphan file, appear under `file_level_findings`. A consumer that reads only one of the two will miss findings.
+
+Both arrays may be `null` rather than empty when a file has no findings of that kind, so guard for it.
+
+The `code` field is present in the schema but is not populated, because context extraction is controlled by `dead_code.show_context`, which jscan does not read yet.
+
+The `reason` values are listed in [the analyze reference](../cli/analyze.md#dead-code). `severity` is `critical`, `warning`, or `info`.
+
+The `summary` object carries a `findings_by_reason` map, which is the most convenient thing to chart over time:
+
+```json
+{
+  "total_files": 2,
+  "total_functions": 4,
+  "total_findings": 3,
+  "files_with_dead_code": 2,
+  "functions_with_dead_code": 1,
+  "critical_findings": 1,
+  "warning_findings": 2,
+  "info_findings": 0,
+  "findings_by_reason": {
+    "unreachable_after_return": 1,
+    "unused_exported_function": 2
+  },
+  "total_blocks": 42,
+  "dead_blocks": 1,
+  "overall_dead_ratio": 0.023809523809523808
+}
+```
+
+## `clone`
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "duration_ms": 3,
+  "clone_pairs": [ ],
+  "clone_groups": [ ],
+  "statistics": { },
+  "success": true
+}
+```
+
+`clone_pairs` lists every pair of similar fragments with its similarity value and clone type. `clone_groups` collects fragments that are mutually similar, which is the more useful view when the same code has been copied several times. An `error` field appears alongside `success` when detection failed.
+
+`statistics.total_fragments` and `statistics.total_clones` are the two numbers behind the duplication percentage in the summary, which is `total_clones ÷ total_fragments × 100`.
+
+## `cbo`
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "classes": [ ],
+  "summary": { },
+  "warnings": [ ],
+  "errors": [ ],
+  "config": { }
+}
+```
+
+!!! warning "This section uses different field naming"
+
+    Entries in `classes` use PascalCase keys, while every other part of the document uses snake_case. This is an inconsistency in the output rather than in this documentation, and a parser written against the rest of the schema will not read this section correctly.
+
+```json
+{
+  "Name": "report",
+  "FilePath": "/home/you/project/src/report.js",
+  "StartLine": 1,
+  "EndLine": 11,
+  "Metrics": {
+    "CouplingCount": 1,
+    "InheritanceDependencies": 0,
+    "TypeHintDependencies": 0,
+    "InstantiationDependencies": 0,
+    "AttributeAccessDependencies": 0,
+    "ImportDependencies": 1,
+    "DependentClasses": ["cart"]
+  },
+  "RiskLevel": "low",
+  "IsAbstract": false,
+  "BaseClasses": null
+}
+```
+
+`CouplingCount` is the CBO value. `DependentClasses` names what this module depends on, and the four `*Dependencies` counters break the total down by how the dependency was formed.
+
+## `deps`
+
+```json
+{
+  "version": "0.4.1",
+  "generated_at": "2026-08-04T16:20:46+09:00",
+  "graph": { },
+  "analysis": { }
+}
+```
+
+`graph` holds the nodes and edges. `analysis` holds the derived results, including `circular_dependencies`, `max_depth`, and `coupling_analysis`.
+
+The same structure is produced by `jscan deps --format json`, which is the better command to use when you want only this section.
+
+## `jscan check --json`
+
+The check command emits a different and much smaller document. It is documented on [the check page](../cli/check.md#json-output).
+
+## Recipes
+
+```bash
+# Just the score, for a dashboard
+jscan analyze --json src/ 2>/dev/null | jq '.summary.health_score'
+
+# Fail a script below grade B
+score=$(jscan analyze --json src/ 2>/dev/null | jq '.summary.health_score')
+[ "$score" -ge 75 ] || { echo "Score $score is below 75"; exit 1; }
+
+# The ten most complex functions as a table
+jscan analyze --json --select complexity src/ 2>/dev/null \
+  | jq -r '.complexity.functions[:10][]
+           | [.metrics.complexity, .name, "\(.file_path):\(.start_line)"]
+           | @tsv'
+
+# Every critical dead code finding, from both places they can appear
+jscan analyze --json --select deadcode src/ 2>/dev/null \
+  | jq -r '.dead_code.files[]
+           | (.functions // [] | .[].findings // []), (.file_level_findings // [])
+           | .[] | select(.severity == "critical")
+           | "\(.location.file_path):\(.location.start_line) \(.reason)"'
+
+# Count findings by reason
+jscan analyze --json --select deadcode src/ 2>/dev/null \
+  | jq '.dead_code.summary.findings_by_reason'
+```
+
+## Stability
+
+The JSON shape is not covered by a stability guarantee yet. Fields are more likely to be added than removed, but treat the structure as subject to change between releases, and pin the jscan version in any pipeline that parses it.

--- a/website/docs/stylesheets/extra.css
+++ b/website/docs/stylesheets/extra.css
@@ -1,0 +1,263 @@
+/* jscan docs theme — brand tokens, typography, and the homepage hero. */
+
+@import url("https://fonts.googleapis.com/css2?family=Space+Grotesk:wght@500;600;700&display=swap");
+
+:root {
+  --jscan-blue: #3178c6;
+  --jscan-blue-dark: #245a96;
+  --jscan-blue-light: #6aa5e0;
+  --jscan-header: #1b3a5c;
+  --jscan-violet: #7c3aed;
+  --jscan-yellow: #f7df1e;
+  --jscan-amber: #f59e0b;
+  --jscan-ink: #0b1120;
+  --jscan-ink-line: rgba(148, 163, 184, 0.16);
+  --jscan-ink-text: #cbd5e1;
+
+  /* Wire the custom Material palette to the jscan brand colors. */
+  --md-primary-fg-color: var(--jscan-blue);
+  --md-primary-fg-color--light: var(--jscan-blue-light);
+  --md-primary-fg-color--dark: var(--jscan-blue-dark);
+  --md-primary-bg-color: #ffffff;
+  --md-primary-bg-color--light: rgba(255, 255, 255, 0.7);
+
+  --md-accent-fg-color: var(--jscan-violet);
+  --md-accent-fg-color--transparent: rgba(124, 58, 237, 0.1);
+  --md-accent-bg-color: #ffffff;
+  --md-accent-bg-color--light: rgba(255, 255, 255, 0.7);
+}
+
+/* ---------- Header & tabs ---------- */
+/* A shade darker than the logo's own blue (#3178c6) so the mark doesn't
+   blend into the bar it sits on. */
+
+.md-header,
+.md-tabs {
+  background-color: var(--jscan-header);
+}
+
+.md-tabs__item {
+  position: relative;
+}
+
+.md-tabs__item::after {
+  content: "";
+  position: absolute;
+  left: 0.6rem;
+  right: 0.6rem;
+  bottom: 0;
+  height: 2px;
+  border-radius: 2px 2px 0 0;
+  background: var(--jscan-yellow);
+  transform: scaleX(0);
+  transition: transform 0.2s ease;
+}
+
+.md-tabs__item--active::after,
+.md-tabs__item:hover::after {
+  transform: scaleX(1);
+}
+
+.md-tabs__link {
+  font-size: 0.78rem;
+  font-weight: 500;
+}
+
+/* ---------- Typography ---------- */
+/* Space Grotesk is reserved for large content headings — at small UI sizes
+   (tabs, nav titles) it reads worse than the body font, so chrome stays on Inter. */
+
+.md-typeset h1,
+.md-typeset h2,
+.md-typeset h3,
+.md-typeset h4,
+.md-header__title,
+.jscan-hero__eyebrow {
+  font-family: "Space Grotesk", "Inter", var(--md-text-font-family), sans-serif;
+  letter-spacing: -0.01em;
+}
+
+.md-typeset h1 {
+  font-weight: 700;
+}
+
+.md-typeset h2 {
+  font-weight: 600;
+}
+
+.md-typeset {
+  line-height: 1.65;
+}
+
+.md-typeset code {
+  border-radius: 0.25rem;
+}
+
+.md-typeset pre > code {
+  border-radius: 0.5rem;
+}
+
+.md-typeset .admonition,
+.md-typeset details {
+  border-radius: 0.5rem;
+}
+
+/* ---------- Buttons ---------- */
+
+.md-typeset .md-button {
+  border-radius: 0.4rem;
+  font-weight: 600;
+  padding: 0.5em 1.2em;
+}
+
+.md-typeset .md-button--primary {
+  background-color: var(--jscan-blue);
+  border-color: var(--jscan-blue);
+}
+
+.md-typeset .md-button--primary:hover {
+  background-color: var(--jscan-blue-dark);
+  border-color: var(--jscan-blue-dark);
+}
+
+/* ---------- Grid cards (feature grid on the homepage) ---------- */
+
+.md-typeset .grid.cards > ul > li,
+.md-typeset .grid.cards > ol > li {
+  border-radius: 0.6rem;
+  transition: border-color 0.15s, transform 0.15s;
+}
+
+.md-typeset .grid.cards > ul > li:hover,
+.md-typeset .grid.cards > ol > li:hover {
+  border-color: var(--jscan-blue);
+  transform: translateY(-2px);
+}
+
+.md-typeset .grid.cards > ul > li > p:first-child .twemoji {
+  color: var(--jscan-blue);
+}
+
+/* ---------- Hero (homepage) ---------- */
+
+.jscan-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 2rem;
+  align-items: center;
+  margin: 1.5rem 0 3rem;
+}
+
+@media screen and (max-width: 76.1875em) {
+  .jscan-hero {
+    grid-template-columns: 1fr;
+  }
+}
+
+.jscan-hero__copy .md-typeset h1 {
+  margin: 0.4rem 0 1rem;
+  font-size: 2.4rem;
+}
+
+.jscan-hero__eyebrow {
+  display: inline-block;
+  margin: 0;
+  font-size: 0.72rem;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--jscan-blue);
+}
+
+[data-md-color-scheme="slate"] .jscan-hero__eyebrow {
+  color: var(--jscan-blue-light);
+}
+
+.jscan-hero__lede {
+  font-size: 1.05rem;
+  line-height: 1.7;
+  color: var(--md-default-fg-color--light);
+  max-width: 42rem;
+}
+
+.jscan-hero__copy .highlight {
+  margin: 1.25rem 0;
+}
+
+.jscan-hero__copy .md-button {
+  margin: 1rem 0.75rem 0.5rem 0;
+}
+
+.jscan-hero__meta {
+  font-size: 0.75rem;
+  color: var(--md-default-fg-color--light);
+  font-family: var(--md-code-font-family);
+}
+
+/* ---------- Score card (homepage art panel) ---------- */
+
+.jscan-hero__art {
+  background: var(--jscan-ink);
+  border-radius: 0.75rem;
+  padding: 1.5rem;
+  background-image:
+    linear-gradient(var(--jscan-ink-line) 1px, transparent 1px),
+    linear-gradient(90deg, var(--jscan-ink-line) 1px, transparent 1px);
+  background-size: 22px 22px;
+  font-family: var(--md-code-font-family);
+  color: var(--jscan-ink-text);
+  font-size: 0.72rem;
+  line-height: 1.9;
+}
+
+.jscan-score__grade {
+  font-family: "Space Grotesk", var(--md-text-font-family), sans-serif;
+  font-size: 1.6rem;
+  font-weight: 700;
+  color: #ffffff;
+  letter-spacing: -0.02em;
+}
+
+.jscan-score__row {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  white-space: nowrap;
+}
+
+.jscan-score__label {
+  flex: 0 0 7.5rem;
+}
+
+.jscan-score__bar {
+  flex: 1 1 auto;
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(148, 163, 184, 0.22);
+  overflow: hidden;
+  min-width: 3rem;
+}
+
+.jscan-score__fill {
+  display: block;
+  height: 100%;
+  border-radius: 3px;
+  background: var(--jscan-blue-light);
+}
+
+.jscan-score__fill--warn {
+  background: var(--jscan-amber);
+}
+
+.jscan-score__value {
+  flex: 0 0 2.5rem;
+  text-align: right;
+  color: #ffffff;
+}
+
+/* ---------- Tables ---------- */
+/* Reference tables run wide; let them scroll rather than the page body. */
+
+.md-typeset__table {
+  min-width: 0;
+}

--- a/website/mkdocs.yml
+++ b/website/mkdocs.yml
@@ -1,0 +1,137 @@
+site_name: jscan
+site_description: A code quality analyzer for JavaScript and TypeScript
+site_url: https://jscan.codescan.dev/
+site_author: ludo-technologies
+repo_url: https://github.com/ludo-technologies/polyscan
+repo_name: ludo-technologies/polyscan
+edit_uri: edit/main/website/docs/
+copyright: Copyright &copy; 2024–2026 ludo-technologies
+
+docs_dir: docs
+site_dir: site
+
+theme:
+  name: material
+  language: en
+  logo: assets/icon.svg
+  favicon: assets/icon.svg
+  icon:
+    repo: fontawesome/brands/github
+  font:
+    text: Inter
+    code: JetBrains Mono
+  palette:
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: custom
+      accent: custom
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+  features:
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.sections
+    - navigation.expand
+    - navigation.path
+    - navigation.top
+    - navigation.indexes
+    - navigation.tracking
+    - toc.follow
+    - search.suggest
+    - search.highlight
+    - search.share
+    - content.code.copy
+    - content.code.annotate
+    - content.tabs.link
+    - content.action.edit
+    - content.tooltips
+
+extra_css:
+  - stylesheets/extra.css
+
+plugins:
+  - search:
+      separator: '[\s\-,:!=\[\]()"`/]+|\.(?!\d)|&[lg]t;|(?!\b)(?=[A-Z][a-z])'
+
+markdown_extensions:
+  - abbr
+  - admonition
+  - attr_list
+  - def_list
+  - footnotes
+  - md_in_html
+  - tables
+  - toc:
+      permalink: true
+      toc_depth: 3
+  - pymdownx.betterem
+  - pymdownx.caret
+  - pymdownx.details
+  - pymdownx.emoji:
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+  - pymdownx.inlinehilite
+  - pymdownx.keys
+  - pymdownx.mark
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      custom_checkbox: true
+  - pymdownx.tilde
+
+extra:
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/ludo-technologies/polyscan
+    - icon: fontawesome/brands/npm
+      link: https://www.npmjs.com/package/jscan
+
+nav:
+  - Home: index.md
+  - Getting Started:
+      - Installation: getting-started/installation.md
+      - Quick Start: getting-started/quick-start.md
+  - Guides:
+      - Analyze a TypeScript Project: guides/typescript-projects.md
+      - Reduce Duplicate Code: guides/reduce-duplicate-code.md
+      - Read the Dependency Graph: guides/dependency-graph.md
+  - CLI Reference:
+      - cli/index.md
+      - analyze: cli/analyze.md
+      - check: cli/check.md
+      - deps: cli/deps.md
+      - init: cli/init.md
+      - version: cli/version.md
+  - Configuration:
+      - configuration/index.md
+      - Reference: configuration/reference.md
+      - Examples: configuration/examples.md
+  - Output Formats:
+      - output/index.md
+      - HTML Report: output/html-report.md
+      - JSON Schema: output/json-schema.md
+      - Health Score: output/health-score.md
+  - Integrations:
+      - integrations/index.md
+      - CI/CD: integrations/ci-cd.md
+      - Agent Skills: integrations/agent-skills.md
+  - Contributing: contributing.md
+  - FAQ: faq.md

--- a/website/requirements.txt
+++ b/website/requirements.txt
@@ -1,0 +1,2 @@
+mkdocs-material>=9.5.0
+pymdown-extensions>=10.7


### PR DESCRIPTION
Closes #24.

Adds a MkDocs Material documentation site under `website/`, deployed to GitHub Pages at `jscan.codescan.dev`.

## What is here

21 pages covering the issue #24 checklist:

- **Getting started**: installation, quick start
- **CLI reference**: every flag, default, and exit code for `analyze`, `check`, `deps`, `init`, `version`
- **Configuration**: discovery order, a per-key reference, and complete example files for six project shapes
- **Output formats**: text, JSON, HTML, and DOT, plus the JSON schema and the health score formula
- **Guides**: TypeScript projects, reading the dependency graph, reducing duplicate code
- **Integrations**: CI/CD pipelines for GitHub Actions, GitLab, pre-commit, and Docker; Agent Skills
- **Contributing** and **FAQ**

English only. The i18n plugin can be added later without moving pages, since it falls back to the default language for anything untranslated.

## On accuracy

Every documented behavior was verified by running the binary rather than by reading the source. That turned out to matter, because the two disagreed in several places, and each disagreement is now filed separately:

| Issue | What the docs say |
| --- | --- |
| #39 | `exclude_patterns` matches files by substring, so `src/routes/` and `src/layout/` are silently skipped |
| #40 | `switch` counts as one branch, so a four-case switch scores 2 against an if-chain's 5 |
| #41 | Only five configuration keys are applied; the rest are validated and ignored |
| #42 | `--format csv` produces HTML rather than an error |
| #43 | Released binaries report `unknown` for commit and build date |

The pages describe current behavior with workarounds where one exists. They do not link the issues, so they need editing rather than unlinking as each is fixed. The affected sections are the `exclude_patterns` entry in the configuration reference, the complexity section of the analyze page, the "which keys take effect today" table, and the FAQ.

## Also in this PR

Package doc comments for the ten `jscan` packages that had none. `internal/testutil` already had one.

Three corrections to existing contributor docs, all of which were wrong rather than merely incomplete:

- `jscan/CONTRIBUTING.md` told contributors to clone the retired standalone `jscan` repository.
- Neither file listed the C compiler prerequisite, which cgo and tree-sitter require.
- `jscan/docs/DEVELOPMENT.md` described `make build-all` as cross-compiling for five platforms. cgo prevents that, which is why the release workflow uses one runner per target.

## Verification

- `mkdocs build --strict` passes with no warnings.
- All 90 internal links and anchors were checked against the `id` attributes in the built HTML.
- `go build`, `go vet`, `gofmt`, and `golangci-lint` are clean, and the full test suite passes.

## Before this publishes

Merging deploys to `gh-pages` but does not make the domain live. Two manual steps remain:

1. Add a Cloudflare CNAME record for `jscan` pointing at `ludo-technologies.github.io`, **DNS only** with the proxy disabled. Proxying breaks certificate issuance.
2. Enable Pages on this repository with `gh-pages` as the source. `docs/CNAME` is committed, so the custom domain should populate on its own.

`docs.codescan.dev` is untouched, so pyscn's site stays up throughout. If the two sites are merged later, moving pyscn's pages into this `website/` directory is the remaining step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
