### PR TITLE
fix(jscan): match exclude_patterns on path segments, not substrings

### DIFF
--- a/jscan/CHANGELOG.md
+++ b/jscan/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Adopt `core/clone` for grouping strategies, group dedup, Type-1/2 similarity gates, pair classification, and AST feature extraction; keep JS/TS adapters (fragment extraction, comment stripping, cost model, LSH orchestration)
 
+### Fixed
+
+- Match `analysis.exclude_patterns` against whole path segments instead of any substring of a file's path, so the default entries `out` and `dist` no longer drop `src/routes/`, `src/layout/`, `src/checkout/`, or `src/utils/distance.ts`. Patterns containing a slash are matched against the path, with `**` spanning any number of directories, and patterns are now evaluated relative to the analyzed path so a parent directory named `build` no longer excludes an entire project. Affected projects will see more files analyzed and therefore different scores
+
 ## [0.9.0] - 2026-07-11
 
 ### Added

--- a/jscan/app/app_test.go
+++ b/jscan/app/app_test.go
@@ -129,6 +129,35 @@ func TestFileHelperIsExcluded(t *testing.T) {
 		{"test.test.js", []string{"*.test.js"}, true},
 		{"node_modules/test.js", []string{"node_modules"}, true},
 		{"src/test.js", []string{"node_modules"}, false},
+
+		// A pattern names a whole path segment, not a substring of one.
+		{"src/routes/api.ts", []string{"out"}, false},
+		{"src/layout/Header.tsx", []string{"out"}, false},
+		{"src/checkout/Cart.ts", []string{"out"}, false},
+		{"src/utils/distance.ts", []string{"dist"}, false},
+		{"src/build-tools/rollup.ts", []string{"build"}, false},
+		{"app/dashboard/layout.tsx", []string{"out", "dist", "build"}, false},
+
+		// Intended exclusions still apply.
+		{"out/bundle.js", []string{"out"}, true},
+		{"dist/bundle.js", []string{"dist"}, true},
+		{"packages/ui/dist/index.js", []string{"dist"}, true},
+		{"src/vendor/jquery.js", []string{"vendor"}, true},
+		{"src/app.min.js", []string{"*.min.js"}, true},
+
+		// Directory globs match segments.
+		{"src/__tests__/app.test.ts", []string{"__*__"}, true},
+		{"src/tests/app.ts", []string{"__*__"}, false},
+
+		// Patterns containing a slash are matched against the path.
+		{"src/generated/api.ts", []string{"src/generated"}, true},
+		{"src/generated/nested/api.ts", []string{"src/generated/**"}, true},
+		{"src/generated.ts", []string{"src/generated"}, false},
+		{"packages/a/dist/index.js", []string{"**/dist/**"}, true},
+		{"packages/a/src/index.js", []string{"**/dist/**"}, false},
+
+		// Empty patterns exclude nothing.
+		{"src/index.ts", []string{""}, false},
 	}
 
 	for _, tt := range tests {
@@ -136,6 +165,93 @@ func TestFileHelperIsExcluded(t *testing.T) {
 		if result != tt.expected {
 			t.Errorf("isExcluded(%s, %v) = %v, expected %v", tt.path, tt.excludePatterns, result, tt.expected)
 		}
+	}
+}
+
+// TestFileHelperCollectKeepsSubstringDirectories covers the collection path for
+// issue #39: directories whose names contain an exclude pattern as a substring
+// were dropped from the analysis without any diagnostic.
+func TestFileHelperCollectKeepsSubstringDirectories(t *testing.T) {
+	tempDir := t.TempDir()
+
+	kept := []string{
+		"src/layout/Header.ts",
+		"src/checkout/Cart.ts",
+		"src/routes/api.ts",
+		"src/utils/distance.ts",
+		"src/normal/Plain.ts",
+	}
+	dropped := []string{
+		"dist/bundle.js",
+		"out/server.js",
+		"node_modules/pkg/index.js",
+	}
+
+	for _, rel := range append(append([]string{}, kept...), dropped...) {
+		path := filepath.Join(tempDir, filepath.FromSlash(rel))
+		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+			t.Fatalf("Failed to create dir for %s: %v", rel, err)
+		}
+		if err := os.WriteFile(path, []byte("export const a = 1;"), 0644); err != nil {
+			t.Fatalf("Failed to create %s: %v", rel, err)
+		}
+	}
+
+	helper := NewFileHelper()
+	excludePatterns := []string{"node_modules", "dist", "build", "out"}
+
+	files, err := helper.CollectJSFiles([]string{tempDir}, true, nil, excludePatterns)
+	if err != nil {
+		t.Fatalf("CollectJSFiles failed: %v", err)
+	}
+
+	found := make(map[string]bool, len(files))
+	for _, f := range files {
+		rel, err := filepath.Rel(tempDir, f)
+		if err != nil {
+			t.Fatalf("Failed to relativize %s: %v", f, err)
+		}
+		found[filepath.ToSlash(rel)] = true
+	}
+
+	for _, rel := range kept {
+		if !found[rel] {
+			t.Errorf("Expected %s to be analyzed, but it was excluded", rel)
+		}
+	}
+	for _, rel := range dropped {
+		if found[rel] {
+			t.Errorf("Expected %s to be excluded, but it was analyzed", rel)
+		}
+	}
+	if len(files) != len(kept) {
+		t.Errorf("Expected %d files, got %d: %v", len(kept), len(files), files)
+	}
+}
+
+// TestFileHelperCollectIgnoresParentDirectoryNames verifies that exclude
+// patterns are matched relative to the analysis root, so a project checked out
+// under a directory such as "build" is still analyzed.
+func TestFileHelperCollectIgnoresParentDirectoryNames(t *testing.T) {
+	tempDir := t.TempDir()
+
+	root := filepath.Join(tempDir, "build", "myapp")
+	if err := os.MkdirAll(filepath.Join(root, "src"), 0755); err != nil {
+		t.Fatalf("Failed to create project dir: %v", err)
+	}
+	srcFile := filepath.Join(root, "src", "index.ts")
+	if err := os.WriteFile(srcFile, []byte("export const a = 1;"), 0644); err != nil {
+		t.Fatalf("Failed to create source file: %v", err)
+	}
+
+	helper := NewFileHelper()
+
+	files, err := helper.CollectJSFiles([]string{root}, true, nil, []string{"build", "dist"})
+	if err != nil {
+		t.Fatalf("CollectJSFiles failed: %v", err)
+	}
+	if len(files) != 1 {
+		t.Errorf("Expected 1 file below a parent directory named build, got %d: %v", len(files), files)
 	}
 }
 

--- a/jscan/app/file_helper.go
+++ b/jscan/app/file_helper.go
@@ -27,7 +27,9 @@ func (h *FileHelper) CollectJSFiles(paths []string, recursive bool, includePatte
 		}
 
 		if !info.IsDir() {
-			if h.isJSFile(path) && !h.isExcluded(path, excludePatterns) {
+			// A file named directly is only matched on its own name: the
+			// directories it happens to live under are not part of the request.
+			if h.isJSFile(path) && !h.isExcluded(filepath.Base(path), excludePatterns) {
 				files = append(files, path)
 			}
 			continue
@@ -43,36 +45,33 @@ func (h *FileHelper) CollectJSFiles(paths []string, recursive bool, includePatte
 					return err
 				}
 
-				// gitignore check (relative path required)
-				if gi != nil {
-					relPath, relErr := filepath.Rel(path, filePath)
-					if relErr == nil && gi.MatchesPath(relPath) {
-						if info.IsDir() {
-							return filepath.SkipDir
-						}
-						return nil
-					}
+				// Exclusions apply to the path relative to the analysis root, so
+				// directories above the root never exclude the whole tree.
+				relPath, relErr := filepath.Rel(path, filePath)
+				if relErr != nil {
+					relPath = filePath
 				}
 
-				// Skip excluded directories early
-				if info.IsDir() {
-					dirName := filepath.Base(filePath)
-					for _, pattern := range excludePatterns {
-						// Check for exact directory name match
-						if pattern == dirName {
-							return filepath.SkipDir
-						}
-						// Check for directory name with glob pattern
-						// Note: filepath.Match errors are ignored (invalid patterns simply don't match)
-						// This is intentional to allow the program to continue with valid patterns
-						if matched, err := filepath.Match(pattern, dirName); err == nil && matched {
-							return filepath.SkipDir
-						}
+				if gi != nil && relErr == nil && gi.MatchesPath(relPath) {
+					if info.IsDir() {
+						return filepath.SkipDir
 					}
 					return nil
 				}
 
-				if h.isJSFile(filePath) && !h.isExcluded(filePath, excludePatterns) {
+				// Skip excluded directories early
+				if info.IsDir() {
+					// The walk root itself is never excluded: the user asked for it.
+					if relPath == "." {
+						return nil
+					}
+					if h.isExcluded(relPath, excludePatterns) {
+						return filepath.SkipDir
+					}
+					return nil
+				}
+
+				if h.isJSFile(filePath) && !h.isExcluded(relPath, excludePatterns) {
 					files = append(files, filePath)
 				}
 
@@ -87,7 +86,7 @@ func (h *FileHelper) CollectJSFiles(paths []string, recursive bool, includePatte
 			for _, entry := range entries {
 				if !entry.IsDir() {
 					filePath := filepath.Join(path, entry.Name())
-					if h.isJSFile(filePath) && !h.isExcluded(filePath, excludePatterns) {
+					if h.isJSFile(filePath) && !h.isExcluded(entry.Name(), excludePatterns) {
 						files = append(files, filePath)
 					}
 				}
@@ -141,21 +140,84 @@ func (h *FileHelper) isJSFile(path string) bool {
 		ext == ".mjs" || ext == ".cjs" || ext == ".mts" || ext == ".cts"
 }
 
-// isExcluded checks if a path matches any exclude pattern
+// isExcluded checks if a path matches any exclude pattern.
+//
+// Patterns without a slash are matched against the file name and against each
+// directory segment of the path, so "dist" excludes "dist/bundle.js" but not
+// "src/utils/distance.ts". Patterns with a slash are matched against the path
+// as a whole, with "**" matching any number of segments.
+//
+// Note: filepath.Match errors are ignored throughout (invalid patterns simply
+// don't match) so that the remaining valid patterns still apply.
 func (h *FileHelper) isExcluded(path string, excludePatterns []string) bool {
-	baseName := filepath.Base(path)
+	segments := strings.Split(filepath.ToSlash(path), "/")
+	baseName := segments[len(segments)-1]
+	dirSegments := segments[:len(segments)-1]
+
 	for _, pattern := range excludePatterns {
-		// Check glob pattern against base name
-		// Note: filepath.Match errors are ignored (invalid patterns simply don't match)
+		pattern = strings.Trim(filepath.ToSlash(pattern), "/")
+		if pattern == "" {
+			continue
+		}
+
+		if strings.Contains(pattern, "/") {
+			if matchesPathPattern(pattern, segments) {
+				return true
+			}
+			continue
+		}
+
 		if matched, err := filepath.Match(pattern, baseName); err == nil && matched {
 			return true
 		}
-		// Also check if pattern appears in the full path (for directory matching)
-		if strings.Contains(path, pattern) {
+		for _, segment := range dirSegments {
+			if segment == pattern {
+				return true
+			}
+			if matched, err := filepath.Match(pattern, segment); err == nil && matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchesPathPattern reports whether a multi-segment pattern such as
+// "src/generated/**" matches the given path segments. The pattern may start at
+// any segment boundary, so it behaves like a relative path fragment.
+func matchesPathPattern(pattern string, segments []string) bool {
+	patternSegments := strings.Split(pattern, "/")
+	for i := range segments {
+		if matchSegments(patternSegments, segments[i:]) {
 			return true
 		}
 	}
 	return false
+}
+
+// matchSegments matches pattern segments against a leading run of path
+// segments, where "**" matches zero or more segments and every other segment is
+// a glob. Matching a prefix is enough, so a pattern naming a directory such as
+// "src/generated" also matches everything below it.
+func matchSegments(pattern, segments []string) bool {
+	if len(pattern) == 0 {
+		return true
+	}
+	if pattern[0] == "**" {
+		for i := 0; i <= len(segments); i++ {
+			if matchSegments(pattern[1:], segments[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(segments) == 0 {
+		return false
+	}
+	if matched, err := filepath.Match(pattern[0], segments[0]); err != nil || !matched {
+		return false
+	}
+	return matchSegments(pattern[1:], segments[1:])
 }
 
 // loadGitIgnore loads a .gitignore file from the root directory.

--- a/website/docs/configuration/examples.md
+++ b/website/docs/configuration/examples.md
@@ -5,7 +5,7 @@ Complete configuration files for common project shapes. Each one is valid as wri
 Remember two rules while reading these:
 
 - `analysis.exclude_patterns` **replaces** the default list rather than adding to it.
-- Short entries in that list also match as substrings of a file's full path, so `out` removes `src/routes/` and `src/layout/`. Every example below therefore avoids the short entries. The [reference](reference.md#analysisexclude_patterns) explains this in full.
+- Each entry matches a whole file or directory name, so `dist` skips a directory named `dist` and leaves `src/utils/distance.ts` alone. The [reference](reference.md#analysisexclude_patterns) explains the matching rules in full.
 
 ## Starting point for any project
 
@@ -69,9 +69,9 @@ The thresholds are raised because component code accumulates conditional renderi
 
 Next.js reserves several export names that nothing in your code imports. jscan recognizes them and does not report them as unused, but only inside App Router convention files, meaning a file under a path containing `/app/` and named `page`, `layout`, `template`, `loading`, `error`, `not-found`, `default`, or `route`. In those files the default export is exempt, along with `metadata`, `generateMetadata`, `viewport`, `generateViewport`, `generateStaticParams`, `dynamic`, `dynamicParams`, `revalidate`, `fetchCache`, `runtime`, `preferredRegion`, and `maxDuration`. In `route` files the HTTP verb exports such as `GET` and `POST` are exempt as well.
 
-!!! note "This exemption is easy to lose"
+!!! note "This exemption needs the file to reach the analyzer"
 
-    A file named `layout.tsx` contains the letters `out`, so the default `exclude_patterns` drops it before the exemption is ever consulted. The custom list above avoids that, which is another reason not to keep the default list in a Next.js project.
+    Up to version 0.9.0 a file named `layout.tsx` was dropped by the default `exclude_patterns`, because the pattern `out` matched any part of a path. The exemption was never consulted for those files. Later versions match whole names only, so `layout.tsx` is analyzed.
 
 ## Node.js backend service
 
@@ -188,7 +188,7 @@ When the current state is far from where you want it, set thresholds you can act
 
 The high `min_complexity` keeps the report focused on the worst functions rather than producing thousands of lines nobody reads. Lower `max_complexity` by five every time the build passes comfortably, and the gate will ratchet the codebase in the right direction without ever blocking work.
 
-Note that `legacy/generated` is long enough not to over-match, which is what makes it safe to include. Prefer specific multi-segment paths over short names for this reason.
+Note that `legacy/generated` contains a slash, so it is matched against the path rather than against a single name. It skips that directory and everything under it, and it matches nothing else.
 
 ## YAML instead of JSON
 

--- a/website/docs/configuration/reference.md
+++ b/website/docs/configuration/reference.md
@@ -151,62 +151,19 @@ The default is:
 }
 ```
 
-Matching happens in two places, with different rules.
+A pattern is matched against whole names, never against part of one.
 
-A **directory** is skipped when its own name equals a pattern exactly, or matches it as a glob. This behaves the way you would expect: `dist` skips any directory named `dist` at any depth, and nothing else.
+A pattern **without a slash** is compared to the file's own name and to each directory name above it. `dist` skips every directory named `dist` at any depth along with everything inside it, and it leaves `src/utils/distance.ts` alone, because no name in that path is exactly `dist`. Glob characters apply to a single name, so `*.min.js` matches file names and `__*__` matches a directory named `__tests__`.
 
-A **file** is skipped when its filename matches a pattern as a glob, **or when the pattern appears anywhere in the file's full path as a plain substring**. That second rule is far broader than it looks, and it is the cause of the problem described next.
+A pattern **containing a slash** is compared to the path itself, where `**` stands for any number of directory levels. `src/generated` skips that directory and everything under it. `**/dist/**` skips every file below any directory named `dist`.
 
-!!! danger "Short patterns silently exclude files you meant to analyze"
+Patterns are matched relative to the path you pass to jscan, so the directories above it are never considered. A project stored at `/home/me/build/myapp` is analyzed normally even though `build` is on the default list. A file you name directly on the command line is matched on its own name alone, so `jscan analyze src/dist/bundle.js` analyzes that file.
 
-    Because file matching falls back to a substring test on the whole path, a short pattern in the list removes every file whose path merely contains those characters. Two entries in the default list cause this in ordinary projects:
+!!! note "Behavior changed in the release after 0.9.0"
 
-    - `out` matches `src/layout/Header.tsx`, `src/checkout/Cart.ts`, and `src/routes/api.ts`, because `layout`, `checkout`, and `routes` all contain the letters `out`.
-    - `dist` matches `src/utils/distance.ts` and anything else containing `dist`.
+    Earlier versions also skipped a file when a pattern appeared anywhere in its path as a plain substring. The default entries `out` and `dist` therefore removed `src/routes/api.ts`, `src/layout/Header.tsx`, `src/checkout/Cart.ts`, and `src/utils/distance.ts` without reporting anything. If you worked around that by trimming the short entries out of your `exclude_patterns`, you can now go back to the default list.
 
-    The files are dropped during collection, so nothing in the output mentions them. The only visible symptom is that the `Analyzing N files...` count is lower than you expect.
-
-    Verify what jscan actually read before trusting a clean report:
-
-    ```console
-    $ jscan analyze --text src/ | head -1
-    Analyzing 1 files...
-    ```
-
-    If that count looks wrong, override `exclude_patterns` with a list that leaves out the short entries:
-
-    ```json
-    {
-      "analysis": {
-        "exclude_patterns": [
-          "node_modules",
-          "bower_components",
-          "jspm_packages",
-          "vendor",
-          "third_party",
-          "coverage",
-          ".git",
-          ".next",
-          ".nuxt",
-          ".turbo",
-          ".cache",
-          "*.min.js",
-          "*.min.mjs",
-          "*.min.cjs",
-          "*.bundle.js",
-          "*.map"
-        ]
-      }
-    }
-    ```
-
-    This list drops `out`, `dist`, `build`, `assets`, `extern`, `external`, and `overrides`, which are the entries most likely to over-match. Dropping them has a cost: a directory named `dist` or `build` inside the analyzed path will now be analyzed, because the same list drives both the directory rule and the file rule. Point jscan at your source directory rather than the project root to avoid that:
-
-    ```bash
-    jscan analyze src/
-    ```
-
-Because your list replaces the default, start from one of the lists above and append to it rather than writing a short one from scratch. Omitting `node_modules` in particular will make jscan analyze your entire dependency tree.
+Because your list replaces the default, start from the list above and append to it rather than writing a short one from scratch. Omitting `node_modules` in particular will make jscan analyze your entire dependency tree.
 
 ### `analysis.include_patterns`
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -4,14 +4,9 @@
 
 ### Why did jscan analyze far fewer files than my project has?
 
-Almost certainly the exclude patterns. jscan matches a file against `analysis.exclude_patterns` by testing whether a pattern appears anywhere in the file's full path as a plain substring. The default list contains `out` and `dist`, which means:
+Check your exclude patterns first. A pattern in `analysis.exclude_patterns` matches a whole file or directory name, so `dist` skips a directory named `dist` and leaves `src/utils/distance.ts` alone. A pattern that names a directory you did not mean to exclude removes every file under it, and nothing in the output names the missing files. Compare the `Analyzing N files...` line against a `find` count to confirm. The [configuration reference](configuration/reference.md#analysisexclude_patterns) describes the matching rules.
 
-- `src/routes/api.ts` is skipped, because `routes` contains `out`.
-- `src/layout/Header.tsx` and `app/**/layout.tsx` are skipped.
-- `src/checkout/Cart.ts` is skipped.
-- `src/utils/distance.ts` is skipped, because `distance` contains `dist`.
-
-Nothing in the output names the missing files. Compare the `Analyzing N files...` line against a `find` count to confirm, then commit a configuration file with an explicit exclude list. The [configuration reference](configuration/reference.md#analysisexclude_patterns) has a safe list.
+Versions up to 0.9.0 also matched a pattern against any part of a file's path, so the default entries `out` and `dist` silently dropped `src/routes/`, `src/layout/`, `src/checkout/`, and `src/utils/distance.ts`. Upgrade if you see that.
 
 A second possibility is your `.gitignore`. jscan reads the one at the root of the analyzed directory and skips whatever it ignores.
 

--- a/website/docs/guides/typescript-projects.md
+++ b/website/docs/guides/typescript-projects.md
@@ -70,18 +70,13 @@ Note that `jscan init --interactive` adds `**/*.vue` to `analysis.include_patter
 
 ## Recommended setup
 
-### 1. Fix the exclude patterns first
+### 1. Check the exclude patterns first
 
-The default exclude list contains short entries that match as substrings of a file's full path. In a TypeScript application this silently removes real source directories:
+An exclude pattern matches a whole file or directory name, so `dist` skips a directory named `dist` and leaves `src/utils/distance.ts` alone. Any pattern that names a directory you did not mean to exclude removes every file under it, and nothing in the output mentions the missing files. The only clue is a low count on the `Analyzing N files...` line.
 
-- `src/routes/` is skipped, because `routes` contains `out`.
-- `src/layout/` and `app/**/layout.tsx` are skipped, for the same reason.
-- `src/checkout/` is skipped.
-- `src/utils/distance.ts` is skipped, because `distance` contains `dist`.
+Versions up to 0.9.0 matched a pattern against any part of a path, so the default entries `out` and `dist` silently dropped `src/routes/`, `src/layout/`, `app/**/layout.tsx`, `src/checkout/`, and `src/utils/distance.ts`. Upgrade before trusting a report from one of those versions.
 
-Nothing in the output mentions the missing files. The only clue is a low count on the `Analyzing N files...` line.
-
-Write an explicit list without the short entries:
+A short explicit list is still worth writing, because your own list replaces the default rather than extending it:
 
 ```json title="jscan.config.json"
 {
@@ -118,7 +113,7 @@ Those two numbers should agree, apart from anything your `.gitignore` excludes. 
 
 ### 2. Point jscan at the source root
 
-Analyze `src/` rather than the project root. This keeps build output, configuration files, and scripts out of the analysis without needing patterns for them, which is what lets you drop the risky short patterns in step one.
+Analyze `src/` rather than the project root. This keeps build output, configuration files, and scripts out of the analysis without needing patterns for them, which is what lets you keep the list in step one short.
 
 ```bash
 jscan analyze src/
@@ -169,7 +164,7 @@ Cross-package imports usually go through a workspace alias such as `@myorg/core`
 
 jscan knows the App Router conventions. Inside a file under a path containing `/app/` and named `page`, `layout`, `template`, `loading`, `error`, `not-found`, `default`, or `route`, the default export is exempt from the unused-export warning, as are the framework's reserved names such as `metadata`, `generateStaticParams`, and `revalidate`. In `route` files the HTTP verb exports are exempt too.
 
-That exemption only helps if the file reaches the analyzer. A file named `layout.tsx` is dropped by the default exclude list before the exemption is consulted, which is one more reason to fix the patterns first.
+That exemption only helps if the file reaches the analyzer. Versions up to 0.9.0 dropped every file named `layout.tsx` before the exemption was consulted, because the default pattern `out` matched part of the name.
 
 Add `.next`, `.vercel`, and `.turbo` to your exclude list.
 
@@ -177,11 +172,9 @@ Add `.next`, `.vercel`, and `.turbo` to your exclude list.
 
 Add `.nuxt` and `.output` to your exclude list. Only the `.ts` and `.js` files are analyzed, since `.vue` files are not parsed.
 
-Note that `.output` is safe to include as a pattern, since it is long enough not to over-match, unlike the bare `out` entry in the default list.
-
 ### Node backends
 
-Express and Fastify projects usually have a `routes` directory, which the default exclude list removes. Fix the patterns and the rest works normally. Relative imports are common in backend code, so the dependency graph tends to be accurate here.
+Express and Fastify projects usually have a `routes` directory, which versions up to 0.9.0 removed from the analysis. Later versions read it normally. Relative imports are common in backend code, so the dependency graph tends to be accurate here.
 
 ## See also
 

--- a/website/docs/integrations/agent-skills.md
+++ b/website/docs/integrations/agent-skills.md
@@ -56,9 +56,9 @@ An agent will report what jscan says, and jscan has limitations that are easy to
 
 **Unused exports depend on what was analyzed.** If the agent runs jscan on one directory, every export in it is reported as unused, because the importers elsewhere were never read. Ask the agent to analyze the whole source root before acting on those findings.
 
-**The default exclude patterns drop real directories.** Short entries such as `out` and `dist` match as substrings of the full path, so `src/routes/`, `src/layout/`, and `src/checkout/` are silently skipped. If an agent reports a clean codebase, ask it to confirm the file count on the `Analyzing N files...` line against the number of source files you actually have. The [configuration reference](../configuration/reference.md#analysisexclude_patterns) explains the fix.
+**A clean report only covers the files that were read.** If an agent reports a clean codebase, ask it to confirm the file count on the `Analyzing N files...` line against the number of source files you actually have. Versions up to 0.9.0 matched the exclude patterns `out` and `dist` against any part of a path, which silently skipped `src/routes/`, `src/layout/`, and `src/checkout/`. The [configuration reference](../configuration/reference.md#analysisexclude_patterns) describes how patterns match now.
 
-Committing a `jscan.config.json` with a corrected exclude list solves this for every future agent run, since the agent picks the file up automatically.
+Committing a `jscan.config.json` records your exclude list for every future agent run, since the agent picks the file up automatically.
 
 ## Working with Python too?
 

--- a/website/docs/integrations/ci-cd.md
+++ b/website/docs/integrations/ci-cd.md
@@ -16,7 +16,7 @@ Two things will otherwise waste your time.
 
 **The default gate fails on any dead code finding**, including the warning that an exported function is not imported by another analyzed file. In a library, that describes your entire public API. Start with `--allow-dead-code` and tighten later.
 
-**The default exclude patterns silently drop source directories.** Short entries such as `out` and `dist` are matched as substrings of the full file path, so `src/routes/`, `src/layout/`, and `src/checkout/` are skipped. A gate that analyzes a fraction of your code passes easily and tells you nothing. Commit a configuration file with an explicit exclude list, and check the `Analyzing N files...` count against reality once. The [configuration reference](../configuration/reference.md#analysisexclude_patterns) has a safe list to start from.
+**A gate is only as good as the file set it runs on.** Check the `Analyzing N files...` count against reality once, so that you know the gate covers your source tree. Versions up to 0.9.0 matched the exclude patterns `out` and `dist` against any part of a path and skipped `src/routes/`, `src/layout/`, and `src/checkout/`, which made a passing gate meaningless. Pin a version later than 0.9.0 in CI, and see the [configuration reference](../configuration/reference.md#analysisexclude_patterns) for the current matching rules.
 
 ## GitHub Actions
 


### PR DESCRIPTION
Fixes #39.

## Problem

`analysis.exclude_patterns` was applied to files with a plain substring test over the whole path (`app/file_helper.go:154`). The default entries `out` and `dist` are short enough to appear inside ordinary path segments, so `src/routes/`, `src/layout/`, `src/checkout/`, and `src/utils/distance.ts` were dropped during collection. Nothing in the output named the missing files, so a clean `jscan check` was not trustworthy on most Next.js, Nuxt, Express, Fastify, SvelteKit, Remix, or commerce projects.

## Change

`isExcluded` now matches whole names:

- A pattern without a slash is matched against the file name and against each directory segment, by equality or glob. `dist` still excludes `dist/bundle.js` and `packages/ui/dist/index.js`, and no longer touches `src/utils/distance.ts`.
- A pattern containing a slash is matched against the path, with `**` spanning any number of segments, and naming a directory covers everything below it. This keeps patterns such as `src/generated` and `**/dist/**` working, which previously only worked through the substring test.
- Patterns are evaluated relative to the analyzed path, so a project stored at `/home/me/build/myapp` is no longer excluded in full when an absolute path is passed. The walk root itself is never excluded.
- The directory-skip step in the walk reuses the same matcher instead of its own base-name-only loop, so slash patterns now prune directories early.
- A file named directly on the command line is matched on its own name alone.

This also restores the Next.js App Router exemption in `internal/analyzer/unused_code.go`, which could never fire for `layout.tsx` because those files were dropped before the analyzer saw them.

## Compatibility

This is a behavior change. Affected projects will analyze more files and see different scores, since the current scores are computed over an incomplete file set.

## Tests

- `TestFileHelperIsExcluded` covers the reproduction cases, the exclusions that must still apply, directory globs, slash patterns, and empty patterns.
- `TestFileHelperCollectKeepsSubstringDirectories` asserts at the collection level that `layout`, `checkout`, `routes`, and `distance.ts` are analyzed while `dist`, `out`, and `node_modules` are not.
- `TestFileHelperCollectIgnoresParentDirectoryNames` covers the parent-directory case.

Verified against the issue's reproduction: 5 source files are now analyzed where 1 was before. `go test ./...` passes across the jscan module.

## Docs

The documentation described the substring behavior and offered a workaround list in six places. The configuration reference now documents the real matching rules, and the bug write-ups in the FAQ, examples, CI/CD, agent skills, and TypeScript guide became notes about versions up to 0.9.0. CHANGELOG has an Unreleased entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)