### PR TITLE
feat(jscan): report project scale in analyze output

### DIFF
--- a/jscan/CHANGELOG.md
+++ b/jscan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Report a project scale line (Micro, Small, Medium, Large, Enterprise, classified by analyzed file count) directly below the health score in the terminal summary, the text output, and the HTML report header. The `summary` object of the JSON and YAML output gains `project_scale` and `total_loc`. The scale is contextual only and does not affect the health score
+
 ### Changed
 
 - Adopt `core/clone` for grouping strategies, group dedup, Type-1/2 similarity gates, pair classification, and AST feature extraction; keep JS/TS adapters (fragment extraction, comment stripping, cost model, LSH orchestration)

--- a/jscan/domain/analyze.go
+++ b/jscan/domain/analyze.go
@@ -67,6 +67,25 @@ const (
 	FallbackPenalty             = coredomain.FallbackPenalty
 )
 
+// Project scale thresholds, expressed as the minimum number of analyzed files
+// a project needs to reach each scale label. Below ScaleSmallThreshold a
+// project is reported as "Micro".
+const (
+	ScaleSmallThreshold      = 10
+	ScaleMediumThreshold     = 50
+	ScaleLargeThreshold      = 200
+	ScaleEnterpriseThreshold = 1000
+)
+
+// Project scale labels reported in the analyze summary.
+const (
+	ScaleMicro      = "Micro"
+	ScaleSmall      = "Small"
+	ScaleMedium     = "Medium"
+	ScaleLarge      = "Large"
+	ScaleEnterprise = "Enterprise"
+)
+
 // AnalyzeResponse represents the combined results of all analyses
 type AnalyzeResponse struct {
 	// Analysis results
@@ -131,6 +150,12 @@ type AnalyzeSummary struct {
 	HighCouplingClasses   int     `json:"high_coupling_classes" yaml:"high_coupling_classes"`     // CBO > 7 (High Risk)
 	MediumCouplingClasses int     `json:"medium_coupling_classes" yaml:"medium_coupling_classes"` // 3 < CBO ≤ 7 (Medium Risk)
 	AverageCoupling       float64 `json:"average_coupling" yaml:"average_coupling"`
+
+	// Project scale
+	// TotalLOC is the number of lines the clone analysis read; it is 0 when
+	// clone analysis is disabled.
+	TotalLOC     int    `json:"total_loc" yaml:"total_loc"`
+	ProjectScale string `json:"project_scale" yaml:"project_scale"` // Micro, Small, Medium, Large, Enterprise
 
 	// Overall health score (0-100)
 	HealthScore int    `json:"health_score" yaml:"health_score"`
@@ -283,6 +308,10 @@ func penaltyToScore(penalty int, maxPenalty int) int {
 
 // CalculateHealthScore calculates an overall health score based on analysis results
 func (s *AnalyzeSummary) CalculateHealthScore() error {
+	// Scale only depends on the file count, so it is set even when the rest of
+	// the summary fails validation below.
+	s.ProjectScale = s.classifyScale()
+
 	// Validate input values first
 	if err := s.Validate(); err != nil {
 		// Set default values on error
@@ -359,6 +388,22 @@ func (s *AnalyzeSummary) CalculateFallbackScore() int {
 	}
 
 	return score
+}
+
+// classifyScale returns a project scale label based on the number of analyzed files
+func (s *AnalyzeSummary) classifyScale() string {
+	switch {
+	case s.AnalyzedFiles >= ScaleEnterpriseThreshold:
+		return ScaleEnterprise
+	case s.AnalyzedFiles >= ScaleLargeThreshold:
+		return ScaleLarge
+	case s.AnalyzedFiles >= ScaleMediumThreshold:
+		return ScaleMedium
+	case s.AnalyzedFiles >= ScaleSmallThreshold:
+		return ScaleSmall
+	default:
+		return ScaleMicro
+	}
 }
 
 // GetGradeFromScore maps a health score to a letter grade

--- a/jscan/domain/analyze_test.go
+++ b/jscan/domain/analyze_test.go
@@ -18,6 +18,54 @@ func TestScoringConstantsAndPublicGradeWrapperUseCoreDomain(t *testing.T) {
 	}
 }
 
+func TestClassifyScale(t *testing.T) {
+	tests := []struct {
+		name          string
+		analyzedFiles int
+		wantScale     string
+	}{
+		{"zero files", 0, ScaleMicro},
+		{"9 files (upper Micro)", 9, ScaleMicro},
+		{"10 files (lower Small)", 10, ScaleSmall},
+		{"49 files (upper Small)", 49, ScaleSmall},
+		{"50 files (lower Medium)", 50, ScaleMedium},
+		{"199 files (upper Medium)", 199, ScaleMedium},
+		{"200 files (lower Large)", 200, ScaleLarge},
+		{"999 files (upper Large)", 999, ScaleLarge},
+		{"1000 files (Enterprise)", 1000, ScaleEnterprise},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &AnalyzeSummary{
+				AnalyzedFiles: tt.analyzedFiles,
+			}
+			if err := s.CalculateHealthScore(); err != nil {
+				t.Fatalf("CalculateHealthScore() error: %v", err)
+			}
+			if s.ProjectScale != tt.wantScale {
+				t.Errorf("ProjectScale = %q, want %q for %d files",
+					s.ProjectScale, tt.wantScale, tt.analyzedFiles)
+			}
+		})
+	}
+}
+
+func TestClassifyScale_SetEvenWhenValidationFails(t *testing.T) {
+	// AverageComplexity is invalid, so CalculateHealthScore bails out early.
+	// The scale only depends on the file count and must still be reported.
+	s := &AnalyzeSummary{
+		AnalyzedFiles:     120,
+		AverageComplexity: -1,
+	}
+	if err := s.CalculateHealthScore(); err == nil {
+		t.Fatal("CalculateHealthScore() = nil error, want validation failure")
+	}
+	if s.ProjectScale != ScaleMedium {
+		t.Errorf("ProjectScale = %q, want %q", s.ProjectScale, ScaleMedium)
+	}
+}
+
 func TestCalculateHealthScore_CyclePenaltyLogFloor(t *testing.T) {
 	tests := []struct {
 		name              string

--- a/jscan/service/html_formatter.go
+++ b/jscan/service/html_formatter.go
@@ -105,6 +105,12 @@ func (f *OutputFormatterImpl) WriteHTML(
 				return "poor"
 			}
 		},
+		"projectScale": func(summary *domain.AnalyzeSummary) string {
+			if summary == nil {
+				return ""
+			}
+			return FormatProjectScale(summary)
+		},
 		"gradeClass": func(grade string) string {
 			switch grade {
 			case "A":
@@ -320,6 +326,7 @@ const htmlTemplate = `<!DOCTYPE html>
             <div class="score-badge {{gradeClass .Summary.Grade}}">
                 Health Score: {{.Summary.HealthScore}}/100 (Grade: {{.Summary.Grade}})
             </div>
+            <p class="subtitle">Project Scale: {{projectScale .Summary}}</p>
         </div>
 
         <div class="tabs">

--- a/jscan/service/output_formatter.go
+++ b/jscan/service/output_formatter.go
@@ -227,6 +227,7 @@ func BuildAnalyzeSummary(
 			summary.ClonePairs = cloneResponse.Statistics.TotalClonePairs
 			summary.CloneGroups = cloneResponse.Statistics.TotalCloneGroups
 			summary.CodeDuplication = calculateDuplicationPercentage(cloneResponse)
+			summary.TotalLOC = cloneResponse.Statistics.LinesAnalyzed
 		}
 	}
 
@@ -258,12 +259,25 @@ func BuildAnalyzeSummary(
 	return summary
 }
 
+// FormatProjectScale renders the project scale label together with the counts it
+// was derived from, e.g. "Medium (123 files, 456 functions, 7890 LOC)". The LOC
+// part is dropped when clone analysis did not run and no line count is available.
+func FormatProjectScale(summary *domain.AnalyzeSummary) string {
+	if summary.TotalLOC > 0 {
+		return fmt.Sprintf("%s (%d files, %d functions, %d LOC)",
+			summary.ProjectScale, summary.AnalyzedFiles, summary.TotalFunctions, summary.TotalLOC)
+	}
+	return fmt.Sprintf("%s (%d files, %d functions)",
+		summary.ProjectScale, summary.AnalyzedFiles, summary.TotalFunctions)
+}
+
 // FormatCLISummary formats an AnalyzeSummary as a compact CLI string (pyscn-style)
 func FormatCLISummary(summary *domain.AnalyzeSummary, duration time.Duration) string {
 	w := &strings.Builder{}
 
 	fmt.Fprintf(w, "\n\U0001F4CA Analysis Summary:\n")
 	fmt.Fprintf(w, "Health Score: %d/100 (Grade: %s)\n", summary.HealthScore, summary.Grade)
+	fmt.Fprintf(w, "Project Scale: %s\n", FormatProjectScale(summary))
 	fmt.Fprintf(w, "Total time: %dms\n", duration.Milliseconds())
 
 	fmt.Fprintf(w, "\n\U0001F4C8 Detailed Scores:\n")
@@ -610,7 +624,8 @@ func (f *OutputFormatterImpl) writeAnalyzeText(
 
 	// Write Health Score section
 	fmt.Fprintf(writer, "\n=== Health Score ===\n\n")
-	fmt.Fprintf(writer, "Overall: %d/100 (Grade: %s)\n\n", summary.HealthScore, summary.Grade)
+	fmt.Fprintf(writer, "Overall: %d/100 (Grade: %s)\n", summary.HealthScore, summary.Grade)
+	fmt.Fprintf(writer, "Project Scale: %s\n\n", FormatProjectScale(summary))
 	fmt.Fprintf(writer, "Category Scores:\n")
 	fmt.Fprintf(writer, "  Complexity:       %3d/100\n", summary.ComplexityScore)
 	fmt.Fprintf(writer, "  Dead Code:        %3d/100\n", summary.DeadCodeScore)

--- a/jscan/service/output_formatter_test.go
+++ b/jscan/service/output_formatter_test.go
@@ -54,6 +54,51 @@ func TestCalculateDuplicationPercentageReportsUncappedRatio(t *testing.T) {
 	}
 }
 
+func TestBuildAnalyzeSummary_WiresProjectScale(t *testing.T) {
+	complexityResponse := &domain.ComplexityResponse{
+		Summary: domain.ComplexitySummary{
+			TotalFunctions: 240,
+			FilesAnalyzed:  123,
+		},
+	}
+	cloneResponse := &domain.CloneResponse{Statistics: &domain.CloneStatistics{
+		LinesAnalyzed: 7890,
+	}}
+
+	summary := BuildAnalyzeSummary(complexityResponse, nil, cloneResponse, nil, nil)
+
+	if summary.ProjectScale != domain.ScaleMedium {
+		t.Errorf("ProjectScale = %q, want %q", summary.ProjectScale, domain.ScaleMedium)
+	}
+	if summary.TotalLOC != 7890 {
+		t.Errorf("TotalLOC = %d, want 7890", summary.TotalLOC)
+	}
+
+	want := "Medium (123 files, 240 functions, 7890 LOC)"
+	if got := FormatProjectScale(summary); got != want {
+		t.Errorf("FormatProjectScale() = %q, want %q", got, want)
+	}
+	if cli := FormatCLISummary(summary, time.Second); !strings.Contains(cli, "Project Scale: "+want) {
+		t.Errorf("CLI summary missing project scale line:\n%s", cli)
+	}
+}
+
+func TestFormatProjectScale_OmitsLOCWhenUnavailable(t *testing.T) {
+	// Clone analysis is what supplies the line count, so a run without it
+	// reports files and functions only.
+	summary := BuildAnalyzeSummary(&domain.ComplexityResponse{
+		Summary: domain.ComplexitySummary{
+			TotalFunctions: 6,
+			FilesAnalyzed:  4,
+		},
+	}, nil, nil, nil, nil)
+
+	want := "Micro (4 files, 6 functions)"
+	if got := FormatProjectScale(summary); got != want {
+		t.Errorf("FormatProjectScale() = %q, want %q", got, want)
+	}
+}
+
 func TestOutputFormatterWriteComplexityJSON(t *testing.T) {
 	formatter := NewOutputFormatter()
 

--- a/website/docs/getting-started/quick-start.md
+++ b/website/docs/getting-started/quick-start.md
@@ -19,6 +19,7 @@ Analyzing 2 files...
 
 📊 Analysis Summary:
 Health Score: 91/100 (Grade: A)
+Project Scale: Micro (2 files, 4 functions, 49 LOC)
 Total time: 5ms
 
 📈 Detailed Scores:
@@ -29,7 +30,7 @@ Total time: 5ms
   Dependencies:     85/100 ✅  (0 cycles, depth: 1)
 ```
 
-The health score is a single number from 0 to 100 with a letter grade attached. It starts at 100 and subtracts a penalty for each category. The [health score page](../output/health-score.md) gives the exact formula.
+The health score is a single number from 0 to 100 with a letter grade attached. It starts at 100 and subtracts a penalty for each category. The [health score page](../output/health-score.md) gives the exact formula. The project scale line below it reports the size of the repository and does not affect the score.
 
 !!! tip "Working over SSH or in a container?"
 

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -41,6 +41,28 @@ Architecture validation is not implemented in jscan, so its penalty is always 0.
 
 These thresholds are shared with pyscn so that a grade means the same thing regardless of the language being analyzed.
 
+## Project scale
+
+Directly below the health score, jscan prints the size of the repository it just analyzed:
+
+```text
+Project Scale: Medium (123 files, 456 functions, 7890 LOC)
+```
+
+The label comes from the number of analyzed files alone:
+
+| Label | Analyzed files |
+| --- | --- |
+| Micro | 0 to 9 |
+| Small | 10 to 49 |
+| Medium | 50 to 199 |
+| Large | 200 to 999 |
+| Enterprise | 1000 or more |
+
+The scale is reported for context only. It does not change the health score or the grade in any way, so two repositories of different sizes with identical metrics receive identical scores.
+
+The line count comes from the clone analysis, which is the stage that reads whole files. When clone analysis is turned off, the line count is omitted and the line reads `Project Scale: Medium (123 files, 456 functions)`.
+
 ## How each penalty is computed
 
 Four of the categories use the same shape. A ratio is computed, and the penalty grows linearly from 0 until the ratio reaches a saturation point, beyond which the penalty stays at its maximum.

--- a/website/docs/output/html-report.md
+++ b/website/docs/output/html-report.md
@@ -14,6 +14,8 @@ jscan analyze --output reports/quality.html --no-open src/
 
 ## Layout
 
+Above the tabs, the report header carries the health score badge, and directly below it the project scale line reports how large the analyzed repository is. See [Project scale](health-score.md#project-scale) for the size labels.
+
 The report opens on a summary and has one tab per analysis. Tabs appear only for the analyses that ran, so a report produced with `--select complexity` has two tabs rather than six.
 
 | Tab | Contents |

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -73,6 +73,8 @@ This is the object most scripts want. It carries the health score, the per-categ
   "high_coupling_classes": 0,
   "medium_coupling_classes": 0,
   "average_coupling": 0.5,
+  "total_loc": 49,
+  "project_scale": "Micro",
   "health_score": 91,
   "grade": "A",
   "complexity_score": 100,
@@ -93,6 +95,8 @@ A few fields need explanation.
 `arch_enabled` is always `false` and `architecture_score` is always `0`, because architecture validation is not implemented in jscan. Ignore both.
 
 `grade` is one of `A`, `B`, `C`, `D`, `F`, or `N/A`. The last appears only when the summary failed validation, in which case `health_score` is 0 as well.
+
+`project_scale` is a size label derived from `analyzed_files`. See [Project scale](health-score.md#project-scale) for the thresholds. `total_loc` is the number of lines the clone analysis read, so it is `0` when clone analysis is turned off.
 
 ## `complexity`
 


### PR DESCRIPTION
Closes #26.

## Summary

`jscan analyze` now prints a **Project Scale** line directly below the health score, classifying the repository as Micro, Small, Medium, Large, or Enterprise from the number of analyzed files. The line also carries the function count, and the line count when clone analysis supplied one.

```text
📊 Analysis Summary:
Health Score: 90/100 (Grade: A)
Project Scale: Micro (2 files, 7 functions, 49 LOC)
Total time: 2ms
```

| Label | Analyzed files |
| --- | --- |
| Micro | 0 to 9 |
| Small | 10 to 49 |
| Medium | 50 to 199 |
| Large | 200 to 999 |
| Enterprise | 1000 or more |

The scale is contextual only. It does not enter the health score or the grade.

## Changes

- `domain/analyze.go`: `AnalyzeSummary` gains `TotalLOC` and `ProjectScale`, and `classifyScale()` maps the analyzed file count to a label using named threshold constants. It runs before validation, so the scale is still reported when the rest of the summary fails validation and the grade falls back to `N/A`.
- `service/output_formatter.go`: `TotalLOC` is wired from `cloneResponse.Statistics.LinesAnalyzed`. A shared `FormatProjectScale()` renders the line and drops the LOC part when clone analysis did not run. The line is printed in the terminal summary and in the `--format text` output.
- `service/html_formatter.go`: a `projectScale` template function renders the line under the score badge in the report header.
- JSON and YAML pick the fields up through the existing struct tags. `jscan analyze` accepts only `html`, `json`, and `text` for `--format`, so YAML coverage here is the struct tag alone.
- Docs: the quick-start sample output, a new "Project scale" section on the health score page, the JSON schema fields, and the HTML report layout section.

## Scope notes

Two things go slightly beyond the literal issue text. The `--format text` output was included, because it is the same analyze summary and would otherwise be the one format missing the line. The documentation site was updated, because its sample outputs would otherwise no longer match what the tool prints.

## Test plan

- `TestClassifyScale` covers every boundary listed in the issue: 0, 9, 10, 49, 50, 199, 200, 999, 1000.
- `TestClassifyScale_SetEvenWhenValidationFails` asserts the scale survives a summary that fails validation.
- `TestBuildAnalyzeSummary_WiresProjectScale` and `TestFormatProjectScale_OmitsLOCWhenUnavailable` cover the LOC wiring and the no-LOC fallback.
- `go build ./...`, `go vet ./...`, and `go test ./...` are clean in `jscan/`.
- Verified on real runs: `Project Scale: Micro (2 files, 7 functions, 49 LOC)` on `testdata/javascript`, and `Project Scale: Medium (111 files, 27914 functions, 413898 LOC)` on a larger package. Checked in the HTML report, the JSON summary, and the text output.
- Not verified: the docs site build, because `mkdocs` is not installed in this environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)