### PR TITLE
fix(complexity): count each switch case as a decision point

### DIFF
--- a/core/cfg/complexity.go
+++ b/core/cfg/complexity.go
@@ -29,13 +29,15 @@ type ComplexityResult struct {
 }
 
 // ComputeComplexity computes McCabe cyclomatic complexity for a CFG.
-// A decision point is a block that has at least one outgoing edge of type
-// EdgeCondTrue, EdgeCondFalse, or EdgeException. Each such block counts as
-// exactly one decision point regardless of how many decision edges it has
-// (e.g. an if-else has both EdgeCondTrue and EdgeCondFalse but is one
-// decision point). EdgeLoop is a back-edge and does not count as a decision
-// point; loop headers should use EdgeCondTrue/EdgeCondFalse for the
-// loop-body vs exit branch. McCabe = DecisionPoints + ExtraContributions + 1.
+// A block whose outgoing EdgeCondTrue/EdgeCondFalse edges lead to k distinct
+// branch targets is a k-way branch and contributes k-1 decision points: an
+// if-else (true + false) or a loop header (body + exit) contributes one, while
+// a switch/match that emits one edge per case plus a no-match edge contributes
+// one per case. A block with any EdgeException successor contributes one more,
+// for the implicit raise-or-not branch. EdgeLoop is a back-edge and does not
+// count as a decision point; loop headers should use EdgeCondTrue/EdgeCondFalse
+// for the loop-body vs exit branch.
+// McCabe = DecisionPoints + ExtraContributions + 1.
 func ComputeComplexity(c *CFG, config ComplexityConfig) (*ComplexityResult, error) {
 	result := &ComplexityResult{
 		EdgeBreakdown: make(map[EdgeType]int),
@@ -47,15 +49,23 @@ func ComputeComplexity(c *CFG, config ComplexityConfig) (*ComplexityResult, erro
 	}
 
 	for _, block := range c.Blocks {
-		isDecision := false
-		for _, edge := range block.Successors {
+		branchTargets := 0
+		hasException := false
+		for i, edge := range block.Successors {
 			result.EdgeBreakdown[edge.Type]++
 			switch edge.Type {
-			case EdgeCondTrue, EdgeCondFalse, EdgeException:
-				isDecision = true
+			case EdgeCondTrue, EdgeCondFalse:
+				if !isBranchTarget(block.Successors[:i], edge.To) {
+					branchTargets++
+				}
+			case EdgeException:
+				hasException = true
 			}
 		}
-		if isDecision {
+		if branchTargets > 1 {
+			result.DecisionPoints += branchTargets - 1
+		}
+		if hasException {
 			result.DecisionPoints++
 		}
 
@@ -73,4 +83,19 @@ func ComputeComplexity(c *CFG, config ComplexityConfig) (*ComplexityResult, erro
 
 	result.McCabe = result.DecisionPoints + result.ExtraContributions + 1
 	return result, nil
+}
+
+// isBranchTarget reports whether target is already reached by a conditional
+// edge among the successors listed, so that repeated edges to the same block
+// count as a single branch target.
+func isBranchTarget(successors []*Edge, target *BasicBlock) bool {
+	for _, edge := range successors {
+		if edge.To != target {
+			continue
+		}
+		if edge.Type == EdgeCondTrue || edge.Type == EdgeCondFalse {
+			return true
+		}
+	}
+	return false
 }

--- a/core/cfg/complexity_test.go
+++ b/core/cfg/complexity_test.go
@@ -134,6 +134,86 @@ func TestComplexityLoop(t *testing.T) {
 	}
 }
 
+func TestComplexityMultiWayBranch(t *testing.T) {
+	// A switch/match dispatch: one conditional edge per case plus a no-match
+	// edge. Four cases branch four ways beyond the fall-out path, so the
+	// dispatch is worth four decision points, like a chain of four ifs.
+	c := NewCFG("multi_way")
+	dispatch := c.CreateBlock("dispatch")
+	join := c.CreateBlock("join")
+
+	c.ConnectBlocks(c.Entry, dispatch, EdgeNormal)
+	for i := 0; i < 4; i++ {
+		caseBlock := c.CreateBlock("case")
+		c.ConnectBlocks(dispatch, caseBlock, EdgeCondTrue)
+		c.ConnectBlocks(caseBlock, join, EdgeNormal)
+	}
+	c.ConnectBlocks(dispatch, join, EdgeCondFalse)
+	c.ConnectBlocks(join, c.Exit, EdgeNormal)
+
+	result, err := ComputeComplexity(c, ComplexityConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.DecisionPoints != 4 {
+		t.Fatalf("expected 4 decision points, got %d", result.DecisionPoints)
+	}
+	if result.McCabe != 5 {
+		t.Fatalf("expected McCabe=5, got %d", result.McCabe)
+	}
+}
+
+func TestComplexitySingleBranchTarget(t *testing.T) {
+	// A dispatch with no cases branches only one way, so it decides nothing.
+	c := NewCFG("empty_dispatch")
+	dispatch := c.CreateBlock("dispatch")
+	join := c.CreateBlock("join")
+
+	c.ConnectBlocks(c.Entry, dispatch, EdgeNormal)
+	c.ConnectBlocks(dispatch, join, EdgeCondFalse)
+	c.ConnectBlocks(join, c.Exit, EdgeNormal)
+
+	result, err := ComputeComplexity(c, ComplexityConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.DecisionPoints != 0 {
+		t.Fatalf("expected 0 decision points, got %d", result.DecisionPoints)
+	}
+	if result.McCabe != 1 {
+		t.Fatalf("expected McCabe=1, got %d", result.McCabe)
+	}
+}
+
+func TestComplexityRepeatedBranchTarget(t *testing.T) {
+	// Several conditional edges to the same block are one branch target.
+	c := NewCFG("repeated_target")
+	cond := c.CreateBlock("cond")
+	bTrue := c.CreateBlock("true")
+	join := c.CreateBlock("join")
+
+	c.ConnectBlocks(c.Entry, cond, EdgeNormal)
+	c.ConnectBlocks(cond, bTrue, EdgeCondTrue)
+	c.ConnectBlocks(cond, bTrue, EdgeCondTrue)
+	c.ConnectBlocks(cond, join, EdgeCondFalse)
+	c.ConnectBlocks(bTrue, join, EdgeNormal)
+	c.ConnectBlocks(join, c.Exit, EdgeNormal)
+
+	result, err := ComputeComplexity(c, ComplexityConfig{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.DecisionPoints != 1 {
+		t.Fatalf("expected 1 decision point, got %d", result.DecisionPoints)
+	}
+	if result.McCabe != 2 {
+		t.Fatalf("expected McCabe=2, got %d", result.McCabe)
+	}
+}
+
 func TestComplexityException(t *testing.T) {
 	c := NewCFG("exception")
 	tryBlock := c.CreateBlock("try")

--- a/jscan/CHANGELOG.md
+++ b/jscan/CHANGELOG.md
@@ -13,6 +13,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Count one decision point per `case` label so a `switch` scores like the equivalent `if` chain instead of adding 1 no matter how many cases it has, and report the case count in the previously always-zero `switch_cases` metric. A `default` clause adds nothing, matching `else`. Switch-heavy code (reducers, dispatchers, state machines) now scores higher, so some functions cross the medium/high risk thresholds and complexity scores drop; the code did not get worse, it was under-measured. The same fix corrects a decision point that was lost when a branch sat inside a `try` block, so an `if` inside `try` now adds 1 as it does anywhere else
+- Keep the braces of a `switch` body out of its parsed case list, which also stops them from appearing as empty case branches in the control flow graph
 - Match `analysis.exclude_patterns` against whole path segments instead of any substring of a file's path, so the default entries `out` and `dist` no longer drop `src/routes/`, `src/layout/`, `src/checkout/`, or `src/utils/distance.ts`. Patterns containing a slash are matched against the path, with `**` spanning any number of directories, and patterns are now evaluated relative to the analyzed path so a parent directory named `build` no longer excludes an entire project. Affected projects will see more files analyzed and therefore different scores
 
 ## [0.9.0] - 2026-07-11

--- a/jscan/internal/analyzer/complexity.go
+++ b/jscan/internal/analyzer/complexity.go
@@ -145,9 +145,27 @@ func CalculateComplexityWithConfig(cfg *CFG, complexityConfig *config.Complexity
 		result.StartLine = functionNode.Location.StartLine
 		result.StartCol = functionNode.Location.StartCol
 		result.EndLine = functionNode.Location.EndLine
+		result.SwitchCases = countSwitchCases(functionNode)
 	}
 
 	return result
+}
+
+// countSwitchCases counts the case clauses of every switch statement owned by
+// this function. Default clauses are excluded, matching the treatment of else,
+// and nested functions are skipped because they get their own CFG and result.
+func countSwitchCases(functionNode *parser.Node) int {
+	switchCases := 0
+	functionNode.Walk(func(current *parser.Node) bool {
+		if current != functionNode && isFunctionNode(current) {
+			return false
+		}
+		if current.Type == parser.NodeCaseClause {
+			switchCases++
+		}
+		return true
+	})
+	return switchCases
 }
 
 // determineRiskLevel determines the risk level based on complexity thresholds

--- a/jscan/internal/analyzer/complexity_test.go
+++ b/jscan/internal/analyzer/complexity_test.go
@@ -651,9 +651,150 @@ func TestCalculateComplexity_SwitchStatement(t *testing.T) {
 
 	result := CalculateComplexity(cfg)
 
-	// Switch with 4 cases should have higher complexity
-	if result.Complexity < 2 {
-		t.Errorf("Switch statement should increase complexity, got %d", result.Complexity)
+	// One decision point per case label; default adds nothing, like else.
+	if result.Complexity != 4 {
+		t.Errorf("Switch with 3 cases should have complexity 4, got %d", result.Complexity)
+	}
+	if result.SwitchCases != 3 {
+		t.Errorf("Switch with 3 cases should report 3 switch cases, got %d", result.SwitchCases)
+	}
+}
+
+// A switch and the equivalent if chain describe the same branching, so they
+// must score the same (issue #40).
+func TestCalculateComplexity_SwitchMatchesEquivalentIfChain(t *testing.T) {
+	code := `
+		function sw4(a) {
+			switch (a) {
+				case 1: return 1;
+				case 2: return 2;
+				case 3: return 3;
+				case 4: return 4;
+				default: return 0;
+			}
+		}
+
+		function ifChain(a) {
+			if (a === 1) return 1;
+			if (a === 2) return 2;
+			if (a === 3) return 3;
+			if (a === 4) return 4;
+			return 0;
+		}
+	`
+	ast := parseJS(t, code)
+
+	complexityOf := func(name string) *ComplexityResult {
+		builder := NewCFGBuilder()
+		cfg, err := builder.Build(findFunction(ast, name))
+		if err != nil {
+			t.Fatalf("Build failed for %s: %v", name, err)
+		}
+		return CalculateComplexity(cfg)
+	}
+
+	switchResult := complexityOf("sw4")
+	ifResult := complexityOf("ifChain")
+
+	if switchResult.Complexity != ifResult.Complexity {
+		t.Errorf("switch complexity %d should match if chain complexity %d",
+			switchResult.Complexity, ifResult.Complexity)
+	}
+	if switchResult.Complexity != 5 {
+		t.Errorf("switch with 4 cases should have complexity 5, got %d", switchResult.Complexity)
+	}
+	if switchResult.SwitchCases != 4 {
+		t.Errorf("switch with 4 cases should report 4 switch cases, got %d", switchResult.SwitchCases)
+	}
+	if ifResult.SwitchCases != 0 {
+		t.Errorf("if chain should report 0 switch cases, got %d", ifResult.SwitchCases)
+	}
+}
+
+func TestCalculateComplexity_SwitchWithoutDefault(t *testing.T) {
+	code := `
+		function test(x) {
+			switch (x) {
+				case 1: return "one";
+				case 2: return "two";
+			}
+			return "other";
+		}
+	`
+	ast := parseJS(t, code)
+
+	builder := NewCFGBuilder()
+	cfg, err := builder.Build(findFunction(ast, "test"))
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	result := CalculateComplexity(cfg)
+
+	if result.Complexity != 3 {
+		t.Errorf("Switch with 2 cases should have complexity 3, got %d", result.Complexity)
+	}
+	if result.SwitchCases != 2 {
+		t.Errorf("Switch with 2 cases should report 2 switch cases, got %d", result.SwitchCases)
+	}
+}
+
+func TestCalculateComplexity_EmptySwitch(t *testing.T) {
+	code := `
+		function test(x) {
+			switch (x) {
+			}
+			return x;
+		}
+	`
+	ast := parseJS(t, code)
+
+	builder := NewCFGBuilder()
+	cfg, err := builder.Build(findFunction(ast, "test"))
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	result := CalculateComplexity(cfg)
+
+	// No case labels means nothing is decided.
+	if result.Complexity != 1 {
+		t.Errorf("Empty switch should have complexity 1, got %d", result.Complexity)
+	}
+	if result.SwitchCases != 0 {
+		t.Errorf("Empty switch should report 0 switch cases, got %d", result.SwitchCases)
+	}
+}
+
+// A switch inside a nested function belongs to that function's own result.
+func TestCalculateComplexity_SwitchInNestedFunction(t *testing.T) {
+	code := `
+		function outer(a) {
+			const inner = (b) => {
+				switch (b) {
+					case 1: return 1;
+					case 2: return 2;
+				}
+				return 0;
+			};
+			return inner(a);
+		}
+	`
+	ast := parseJS(t, code)
+
+	builder := NewCFGBuilder()
+	cfg, err := builder.Build(findFunction(ast, "outer"))
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	result := CalculateComplexity(cfg)
+
+	if result.Complexity != 1 {
+		t.Errorf("outer should have complexity 1, got %d", result.Complexity)
+	}
+	if result.SwitchCases != 0 {
+		t.Errorf("outer should report 0 switch cases, got %d", result.SwitchCases)
 	}
 }
 

--- a/jscan/internal/parser/ast_builder.go
+++ b/jscan/internal/parser/ast_builder.go
@@ -354,16 +354,22 @@ func (b *ASTBuilder) buildSwitchStatement(tsNode *sitter.Node) *Node {
 		node.Test = b.buildNode(valueNode)
 	}
 
-	// Extract cases
+	// Extract cases. The switch body also contains its braces, so keep only
+	// the nodes that are actual case or default clauses.
 	if bodyNode := b.getChildByFieldName(tsNode, "body"); bodyNode != nil {
 		for i := 0; i < int(bodyNode.ChildCount()); i++ {
 			child := bodyNode.Child(i)
-			if child != nil && !b.isTrivia(child) {
-				caseNode := b.buildNode(child)
-				if caseNode != nil {
-					node.Cases = append(node.Cases, caseNode)
-				}
+			if child == nil || b.isTrivia(child) {
+				continue
 			}
+			caseNode := b.buildNode(child)
+			if caseNode == nil {
+				continue
+			}
+			if caseNode.Type != NodeCaseClause && caseNode.Type != NodeDefaultClause {
+				continue
+			}
+			node.Cases = append(node.Cases, caseNode)
 		}
 	}
 

--- a/jscan/internal/parser/parser_test.go
+++ b/jscan/internal/parser/parser_test.go
@@ -496,6 +496,23 @@ func TestParseSwitchStatement(t *testing.T) {
 			if n.Test == nil {
 				t.Error("Expected switch to have test expression")
 			}
+			// Cases must hold the clauses only, not the surrounding braces.
+			if len(n.Cases) != 3 {
+				t.Errorf("Expected 3 clauses, got %d", len(n.Cases))
+			}
+			caseClauses := 0
+			for _, clause := range n.Cases {
+				switch clause.Type {
+				case NodeCaseClause:
+					caseClauses++
+				case NodeDefaultClause:
+				default:
+					t.Errorf("Unexpected clause type in switch cases: %s", clause.Type)
+				}
+			}
+			if caseClauses != 2 {
+				t.Errorf("Expected 2 case clauses, got %d", caseClauses)
+			}
 			return false
 		}
 		return true

--- a/jscan/service/complexity_service.go
+++ b/jscan/service/complexity_service.go
@@ -151,6 +151,7 @@ func (s *ComplexityServiceImpl) analyzeFile(ctx context.Context, filePath string
 				IfStatements:      result.IfStatements,
 				LoopStatements:    result.LoopStatements,
 				ExceptionHandlers: result.ExceptionHandlers,
+				SwitchCases:       result.SwitchCases,
 			},
 			RiskLevel: domain.RiskLevel(result.RiskLevel),
 		}

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -62,13 +62,9 @@ The format determines where results go and what else is printed.
 
 Measures the cyclomatic complexity of every function, which counts the number of linearly independent paths through it. jscan builds a control flow graph for each function and derives the count from the graph, so the number reflects real branching rather than a text heuristic.
 
-Starting from a baseline of 1, each of the following adds 1: an `if` or `else if`, a loop, a `catch`, a ternary, and each `&&`, `||`, or `??` operator. Optional chaining with `?.` adds nothing.
+Starting from a baseline of 1, each of the following adds 1: an `if` or `else if`, a loop, a `catch`, a `case` label, a ternary, and each `&&`, `||`, or `??` operator. A `default` clause adds nothing, the same as `else`, and neither does optional chaining with `?.`.
 
-!!! warning "`switch` is counted as a single branch"
-
-    A `switch` statement adds 1 no matter how many cases it contains. A four-case switch scores 2, while the same logic written as four `if` statements scores 5. The `switch_cases` field in the JSON output is always 0.
-
-    Code built around large switch statements, such as reducers and state machines, is therefore scored more leniently than equivalent code written with `if`. A low score on a large switch is not evidence that it is simple.
+Counting each `case` label means a `switch` scores the same as the equivalent chain of `if` statements: a four-case switch and four `if` statements both score 5. The number of case labels seen in a function is reported as `switch_cases` in the JSON output.
 
 Functions are assigned a risk level from two thresholds, both configurable:
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -79,20 +79,22 @@ It searches upward from the path you asked it to analyze, then falls back to the
 
 ### What counts toward cyclomatic complexity?
 
-Each branch adds one to a baseline of 1: `if`, `else if`, each loop, each `catch`, each ternary, and each `&&`, `||`, or `??`. Optional chaining with `?.` does not count.
+Each branch adds one to a baseline of 1: `if`, `else if`, each loop, each `catch`, each `case` label, each ternary, and each `&&`, `||`, or `??`. A `default` clause adds nothing, the same as `else`, and neither does optional chaining with `?.`.
 
 A function with no branching scores 1.
 
-`switch` is the exception, and it is worth knowing about. The whole statement adds 1 regardless of how many cases it has, so a four-case switch scores 2 while the equivalent chain of four `if` statements scores 5:
+Because every `case` label counts, a `switch` scores the same as the equivalent chain of `if` statements:
 
 ```console
 $ jscan analyze --json --select complexity src/d.ts \
   | jq -r '.complexity.functions[] | "\(.name): \(.metrics.complexity)"'
 ifChain: 5
-sw4: 2
+sw4: 5
 ```
 
-The `switch_cases` field in the JSON output is always 0 for the same reason. Switch-heavy code such as reducers and state machines is therefore scored more leniently than equivalent branching written another way. Do not read a low complexity score on a large `switch` as evidence that it is simple.
+The `switch_cases` field in the JSON output reports how many case labels the function contains, `default` excluded.
+
+Versions before this behavior landed scored the whole `switch` as a single branch, so switch-heavy code such as reducers and state machines will score higher after upgrading. The code did not get worse; it was under-measured.
 
 ### The CBO section says "classes" but my code has none. Why?
 


### PR DESCRIPTION
Fixes #40.

## The problem

A `switch` contributed 1 to cyclomatic complexity no matter how many cases it had, so a four-case switch scored 2 while the equivalent `if` chain scored 5. Reducers, dispatchers, and state machines were scored far more leniently than the same logic written any other way, and a 30-case reducer could never fail `jscan check --max-complexity`.

## Two causes

1. `core/cfg.ComputeComplexity` collapsed every branching block to exactly one decision point regardless of how many conditional successors it had. The CFG builder already emitted one `EdgeCondTrue` per case — the counter threw that information away.
2. `ast_builder.buildSwitchStatement` collected *every* child of the switch body into `node.Cases`, braces included, so each switch gained two phantom case branches in the CFG. Invisible while switches counted as 1; it would have inflated the score by 2 as soon as cases were counted.

## The fix

- `core/cfg/complexity.go` — a block whose conditional edges lead to k distinct targets is a k-way branch worth k-1 decision points. An if-else and a loop header still count 1; a switch counts 1 per case and 0 for `default`, matching the treatment of `else`. Repeated edges to the same target count once. Exception edges are counted separately from conditional ones.
- `jscan/internal/parser/ast_builder.go` — keep only case and default clauses in `Cases`.
- `jscan/internal/analyzer/complexity.go` — populate `SwitchCases` from the function's case labels, skipping nested functions since those get their own result.
- `jscan/service/complexity_service.go` — pass `SwitchCases` through to the output; the field existed in the schema but was never assigned.
- Tests in `core/cfg`, `internal/analyzer`, and `internal/parser`; CHANGELOG; and `website/docs/cli/analyze.md`, whose warning documented the old behavior.

## Verification

The issue's repro:

```console
$ jscan analyze --json --select complexity src/d.ts | jq ...
sw4: complexity=5 switch_cases=4
ifChain: complexity=5 switch_cases=0
```

Checked a range of shapes against what ESLint's `complexity` rule counts — try/catch, try/finally, throw, loops, fall-through cases, a reducer — all match exactly. Full `core` and `jscan` suites pass, `go vet` clean.

## Score impact

Separating exception counting from conditional counting reaches beyond switches: an `if` inside a `try` used to add 0 and now adds 1, which is the same undercounting bug in a different construct. Measured on three real TS repos, 7-28 functions each shifted; omnibook's complexity category went 70 -> 65 (health 72 -> 71), with dead code, duplication, and coupling unchanged. Analyzed code did not get worse — it was under-measured. Called out in the CHANGELOG for release notes.

## Notes

- `if_statements` in the JSON is `DecisionPoints`, so it already conflated ifs, loops, and exceptions, and now includes switch cases too. Left alone here (an accurate derivation can go negative on odd graphs); worth a separate issue.
- pyscn's `processMatchStatement` emits the same one-`EdgeCondTrue`-per-case shape, so Python `match` statements pick this up when pyscn bumps its pinned `core`. Nothing to port by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)