### PR TITLE
fix(jscan): make CBO orderings deterministic under tied sort keys

### DIFF
--- a/jscan/service/cbo_service.go
+++ b/jscan/service/cbo_service.go
@@ -11,6 +11,9 @@ import (
 	"github.com/ludo-technologies/polyscan/jscan/internal/version"
 )
 
+// mostCoupledClassesLimit caps the summary's most-coupled-classes ranking.
+const mostCoupledClassesLimit = 10
+
 // CBOServiceImpl implements the CBOService interface
 type CBOServiceImpl struct {
 	config *analyzer.CBOAnalyzerConfig
@@ -194,28 +197,54 @@ func (s *CBOServiceImpl) sortClasses(classes []domain.ClassCoupling, sortBy doma
 	sorted := make([]domain.ClassCoupling, len(classes))
 	copy(sorted, classes)
 
+	// Every comparator falls back to source location so that classes the
+	// primary criterion cannot separate still come out in the same order on
+	// every run.
 	switch sortBy {
-	case domain.SortByCoupling:
-		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
-		})
 	case domain.SortByName:
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Name < sorted[j].Name
+			if sorted[i].Name != sorted[j].Name {
+				return sorted[i].Name < sorted[j].Name
+			}
+			return classPrecedes(sorted[i], sorted[j])
 		})
 	case domain.SortByRisk:
 		riskOrder := map[domain.RiskLevel]int{domain.RiskLevelHigh: 0, domain.RiskLevelMedium: 1, domain.RiskLevelLow: 2}
 		sort.Slice(sorted, func(i, j int) bool {
-			return riskOrder[sorted[i].RiskLevel] < riskOrder[sorted[j].RiskLevel]
+			if riskOrder[sorted[i].RiskLevel] != riskOrder[sorted[j].RiskLevel] {
+				return riskOrder[sorted[i].RiskLevel] < riskOrder[sorted[j].RiskLevel]
+			}
+			return classPrecedes(sorted[i], sorted[j])
 		})
 	default:
-		// Default: sort by coupling descending
+		// Default and domain.SortByCoupling: coupling descending.
 		sort.Slice(sorted, func(i, j int) bool {
-			return sorted[i].Metrics.CouplingCount > sorted[j].Metrics.CouplingCount
+			return couplingPrecedes(sorted[i], sorted[j])
 		})
 	}
 
 	return sorted
+}
+
+// couplingPrecedes orders classes by coupling count descending, falling back
+// to source location for classes with equal coupling.
+func couplingPrecedes(a, b domain.ClassCoupling) bool {
+	if a.Metrics.CouplingCount != b.Metrics.CouplingCount {
+		return a.Metrics.CouplingCount > b.Metrics.CouplingCount
+	}
+	return classPrecedes(a, b)
+}
+
+// classPrecedes is the deterministic tie-break ordering: by source location,
+// then name.
+func classPrecedes(a, b domain.ClassCoupling) bool {
+	if a.FilePath != b.FilePath {
+		return a.FilePath < b.FilePath
+	}
+	if a.StartLine != b.StartLine {
+		return a.StartLine < b.StartLine
+	}
+	return a.Name < b.Name
 }
 
 // generateSummary generates a summary of the CBO analysis
@@ -266,14 +295,15 @@ func (s *CBOServiceImpl) generateSummary(classes []domain.ClassCoupling, filesPr
 	summary.MaxCBO = maxCBO
 	summary.MinCBO = minCBO
 
-	// Get most coupled classes (top 10)
+	// Get most coupled classes. The tie-break in couplingPrecedes keeps the
+	// ranking's membership stable when classes tie at the cutoff.
 	sortedByCoupling := make([]domain.ClassCoupling, len(classes))
 	copy(sortedByCoupling, classes)
 	sort.Slice(sortedByCoupling, func(i, j int) bool {
-		return sortedByCoupling[i].Metrics.CouplingCount > sortedByCoupling[j].Metrics.CouplingCount
+		return couplingPrecedes(sortedByCoupling[i], sortedByCoupling[j])
 	})
 
-	maxMostCoupled := min(10, len(sortedByCoupling))
+	maxMostCoupled := min(mostCoupledClassesLimit, len(sortedByCoupling))
 	summary.MostCoupledClasses = sortedByCoupling[:maxMostCoupled]
 
 	return summary

--- a/jscan/service/cbo_service_test.go
+++ b/jscan/service/cbo_service_test.go
@@ -1,0 +1,110 @@
+package service
+
+import (
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/jscan/domain"
+)
+
+func couplingClass(name, filePath string, coupling int) domain.ClassCoupling {
+	return domain.ClassCoupling{
+		Name:     name,
+		FilePath: filePath,
+		Metrics:  domain.CBOMetrics{CouplingCount: coupling},
+	}
+}
+
+func reversed(classes []domain.ClassCoupling) []domain.ClassCoupling {
+	out := make([]domain.ClassCoupling, len(classes))
+	for i, c := range classes {
+		out[len(classes)-1-i] = c
+	}
+	return out
+}
+
+func classKeys(classes []domain.ClassCoupling) []string {
+	keys := make([]string, len(classes))
+	for i, c := range classes {
+		keys[i] = c.FilePath + ":" + c.Name
+	}
+	return keys
+}
+
+func assertSameOrder(t *testing.T, want, got []domain.ClassCoupling) {
+	t.Helper()
+	wantKeys, gotKeys := classKeys(want), classKeys(got)
+	if len(wantKeys) != len(gotKeys) {
+		t.Fatalf("length mismatch: want %d, got %d", len(wantKeys), len(gotKeys))
+	}
+	for i := range wantKeys {
+		if wantKeys[i] != gotKeys[i] {
+			t.Fatalf("order differs at %d: want %v, got %v", i, wantKeys, gotKeys)
+		}
+	}
+}
+
+// Classes that tie on the primary sort key must come out in the same order
+// regardless of input order, which varies under concurrent analysis.
+func TestCBOService_sortClasses_TieBreakIsInputOrderIndependent(t *testing.T) {
+	service := NewCBOServiceWithDefaults()
+
+	tied := []domain.ClassCoupling{
+		couplingClass("Gamma", "src/c.js", 7),
+		couplingClass("Alpha", "src/a.js", 7),
+		couplingClass("Beta", "src/b.js", 7),
+		couplingClass("Delta", "src/d.js", 9),
+	}
+
+	for _, sortBy := range []domain.SortCriteria{domain.SortByCoupling, domain.SortByName, domain.SortByRisk} {
+		forward := service.sortClasses(tied, sortBy)
+		backward := service.sortClasses(reversed(tied), sortBy)
+		assertSameOrder(t, forward, backward)
+	}
+}
+
+func TestCBOService_sortClasses_TiesOrderedBySourceLocation(t *testing.T) {
+	service := NewCBOServiceWithDefaults()
+
+	sorted := service.sortClasses([]domain.ClassCoupling{
+		couplingClass("Gamma", "src/c.js", 7),
+		couplingClass("Alpha", "src/a.js", 7),
+		couplingClass("Beta", "src/b.js", 7),
+	}, domain.SortByCoupling)
+
+	assertSameOrder(t, []domain.ClassCoupling{
+		couplingClass("Alpha", "src/a.js", 7),
+		couplingClass("Beta", "src/b.js", 7),
+		couplingClass("Gamma", "src/c.js", 7),
+	}, sorted)
+}
+
+// A tie at the top-10 cutoff must not let ranking membership depend on input
+// order: previously, whichever tied class the concurrent schedule happened to
+// place earlier won the last slot.
+func TestCBOService_generateSummary_MostCoupledClassesStableAtTiedCutoff(t *testing.T) {
+	service := NewCBOServiceWithDefaults()
+
+	classes := make([]domain.ClassCoupling, 0, mostCoupledClassesLimit+2)
+	for i := 0; i < mostCoupledClassesLimit-1; i++ {
+		classes = append(classes, couplingClass("Popular", "src/popular.js", 100+i))
+	}
+	// Three classes tie below the leaders; only one fits the last slot.
+	classes = append(classes,
+		couplingClass("TieC", "src/tie_c.js", 13),
+		couplingClass("TieA", "src/tie_a.js", 13),
+		couplingClass("TieB", "src/tie_b.js", 13),
+	)
+
+	forward := service.generateSummary(classes, 1, domain.CBORequest{})
+	backward := service.generateSummary(reversed(classes), 1, domain.CBORequest{})
+
+	if len(forward.MostCoupledClasses) != mostCoupledClassesLimit {
+		t.Fatalf("expected %d most coupled classes, got %d", mostCoupledClassesLimit, len(forward.MostCoupledClasses))
+	}
+	assertSameOrder(t, forward.MostCoupledClasses, backward.MostCoupledClasses)
+
+	last := forward.MostCoupledClasses[mostCoupledClassesLimit-1]
+	if last.Name != "TieA" {
+		t.Errorf("last slot should go to the tied class that precedes by source location, got %s", last.Name)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the nondeterministic CBO rankings reported in #51 (jscan counterpart of ludo-technologies/pyscn#708).

`sortClasses` compared a single key with unstable `sort.Slice`, so tied classes kept their input order — which varies run to run under concurrent per-file analysis. `generateSummary` then truncated that unstable order to the top 10, so a tie at the cutoff changed which class appeared in `MostCoupledClasses` between runs on identical input.

## Changes

- Every `sortClasses` comparator now falls back to source location (file path → start line → name), mirroring the `functionPrecedes` idiom already used by the complexity service. The duplicated `SortByCoupling`/default branches are merged the same way the complexity service handles it.
- The top-10 ranking sort uses the same coupling-descending comparator with tie-break (`couplingPrecedes`), so cutoff membership is stable.
- The magic `10` becomes `mostCoupledClassesLimit`.

## Tests

New `cbo_service_test.go`:

- ties come out in the same order for forward vs reversed input, across all three sort criteria (fails on the old code, where insertion sort preserves the differing input orders)
- tied classes are ordered by source location
- with three classes tied at the top-10 cutoff, `MostCoupledClasses` membership and order are input-order independent, and the last slot goes to the tie that precedes by source location

`go build ./...` and the full jscan test suite pass.

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)