### PR TITLE
fix(jscan): validate --format flag and expose yaml/csv formats (#42)

### DIFF
--- a/jscan/CHANGELOG.md
+++ b/jscan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Support `yaml` and `csv` output formats in `jscan analyze --format`, directing clean structured output to stdout and the score summary to stderr
 - Report a project scale line (Micro, Small, Medium, Large, Enterprise, classified by analyzed file count) directly below the health score in the terminal summary, the text output, and the HTML report header. The `summary` object of the JSON and YAML output gains `project_scale` and `total_loc`. The scale is contextual only and does not affect the health score
 - Apply `analysis.include_patterns`, `analysis.recursive`, `complexity.report_unchanged`, `dead_code.min_severity`, `dead_code.sort_by`, and `output.sort_by`, which until now were validated and then ignored. Include patterns select from the file types jscan can parse, using the same matching rules as `exclude_patterns`; a file named directly on the command line is analyzed whether or not it matches
 - Warn on stderr, naming each key, when a configuration file sets keys that no command reads. Misspelled keys are reported the same way
@@ -25,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Reject unrecognized `--format` values in `jscan analyze` with an error naming supported formats instead of silently falling back to HTML
 - Parse TypeScript with the TypeScript grammar in dependency analysis, which parsed every file with the JavaScript grammar and silently lost whatever a JS parse of a TS file drops — most visibly exports declared with TypeScript-only syntax, which made modules look unreferenced or export-free in the dependency graph. TypeScript projects will see more complete module nodes, and coupling metrics that follow from them (such as `deps_main_sequence_deviation`) can shift. The same rewiring gives dependency analysis real file names for every project, JavaScript included: dependency edges' `location.file_path` reported the placeholder `<input>` and now reports the analyzed file's path, both in `jscan analyze` and in `AnalyzeSingleFile`
 - Measure the `nesting_depth` metric, which was reported as 0 for every function because the calculation was never called and, when called, counted a function's control structures instead of measuring how deeply they nest. An `else if` continues the chain its `if` opened, a `catch` clause stays at the level of its `try`, and a nested function is measured on its own
 - Count one decision point per `case` label so a `switch` scores like the equivalent `if` chain instead of adding 1 no matter how many cases it has, and report the case count in the previously always-zero `switch_cases` metric. A `default` clause adds nothing, matching `else`. Switch-heavy code (reducers, dispatchers, state machines) now scores higher, so some functions cross the medium/high risk thresholds and complexity scores drop; the code did not get worse, it was under-measured. The same fix corrects a decision point that was lost when a branch sat inside a `try` block, so an `if` inside `try` now adds 1 as it does anywhere else

--- a/jscan/cmd/jscan/analyze.go
+++ b/jscan/cmd/jscan/analyze.go
@@ -42,6 +42,8 @@ Examples:
   jscan analyze --select cbo src/                 # CBO coupling analysis only
   jscan analyze --json src/                       # Output JSON to stdout
   jscan analyze --text src/                       # Output text to stdout
+  jscan analyze --format yaml src/                # Output YAML to stdout
+  jscan analyze --format csv src/                 # Output CSV to stdout
   jscan analyze --no-open src/                    # Generate HTML without opening browser
   jscan analyze -o report.html src/               # Custom output path`,
 		RunE: runAnalyze,
@@ -50,7 +52,7 @@ Examples:
 	cmd.Flags().StringSliceVarP(&selectAnalyses, "select", "s", []string{"complexity", "deadcode", "clone", "cbo", "deps"},
 		"Analyses to run (comma-separated): complexity,deadcode,clone,cbo,deps")
 	cmd.Flags().StringVarP(&outputFormat, "format", "f", "html",
-		"Output format: html, json, text (default: html)")
+		"Output format: html, json, text, yaml, csv (default: html)")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false,
 		"Output results as JSON to stdout")
 	cmd.Flags().BoolVar(&textOutput, "text", false,
@@ -72,20 +74,39 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no paths specified")
 	}
 
-	// Determine output format (default: HTML)
-	format := domain.OutputFormatHTML
-	if jsonOutput || outputFormat == "json" {
-		format = domain.OutputFormatJSON
-	} else if textOutput || outputFormat == "text" {
-		format = domain.OutputFormatText
+	if cmd.Flags().Changed("format") {
+		switch outputFormat {
+		case "html", "json", "text", "yaml", "csv":
+		default:
+			return fmt.Errorf("invalid format %q, must be one of: html, json, text, yaml, csv", outputFormat)
+		}
 	}
+
+	// Determine output format (default: HTML)
+	var format domain.OutputFormat
+	switch {
+	case jsonOutput, outputFormat == "json":
+		format = domain.OutputFormatJSON
+	case textOutput, outputFormat == "text":
+		format = domain.OutputFormatText
+	case htmlOutput, outputFormat == "html":
+		format = domain.OutputFormatHTML
+	case outputFormat == "yaml":
+		format = domain.OutputFormatYAML
+	case outputFormat == "csv":
+		format = domain.OutputFormatCSV
+	default:
+		return fmt.Errorf("invalid format %q, must be one of: html, json, text, yaml, csv", outputFormat)
+	}
+
+	isStructured := format == domain.OutputFormatJSON || format == domain.OutputFormatYAML || format == domain.OutputFormatCSV
 
 	// Load configuration
 	cfg, err := loadCommandConfig(configPath, args[0], os.Stderr)
 	if err != nil {
 		return fmt.Errorf("failed to load configuration: %w", err)
 	}
-	if configPath != "" && format != domain.OutputFormatJSON {
+	if configPath != "" && !isStructured {
 		fmt.Printf("Using config: %s\n", configPath)
 	}
 
@@ -103,12 +124,12 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no JavaScript/TypeScript files found")
 	}
 
-	if format != domain.OutputFormatJSON {
+	if !isStructured {
 		fmt.Printf("Analyzing %d files...\n", len(files))
 	}
 
-	// Create progress manager (auto-disabled for JSON output or non-TTY)
-	pm := service.NewProgressManager(format != domain.OutputFormatJSON)
+	// Create progress manager (auto-disabled for structured output or non-TTY)
+	pm := service.NewProgressManager(!isStructured)
 	defer pm.Close()
 
 	// Start timing
@@ -226,19 +247,19 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 	}
 
 	// Handle errors
-	if complexityErr != nil && format != domain.OutputFormatJSON {
+	if complexityErr != nil && !isStructured {
 		fmt.Fprintf(os.Stderr, "Complexity analysis error: %v\n", complexityErr)
 	}
-	if deadCodeErr != nil && format != domain.OutputFormatJSON {
+	if deadCodeErr != nil && !isStructured {
 		fmt.Fprintf(os.Stderr, "Dead code analysis error: %v\n", deadCodeErr)
 	}
-	if cloneErr != nil && format != domain.OutputFormatJSON {
+	if cloneErr != nil && !isStructured {
 		fmt.Fprintf(os.Stderr, "Clone analysis error: %v\n", cloneErr)
 	}
-	if cboErr != nil && format != domain.OutputFormatJSON {
+	if cboErr != nil && !isStructured {
 		fmt.Fprintf(os.Stderr, "CBO analysis error: %v\n", cboErr)
 	}
-	if depsErr != nil && format != domain.OutputFormatJSON {
+	if depsErr != nil && !isStructured {
 		fmt.Fprintf(os.Stderr, "Dependency analysis error: %v\n", depsErr)
 	}
 

--- a/jscan/cmd/jscan/analyze.go
+++ b/jscan/cmd/jscan/analyze.go
@@ -74,29 +74,32 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("no paths specified")
 	}
 
+	// Determine output format (default: HTML)
+	var format domain.OutputFormat
 	if cmd.Flags().Changed("format") {
 		switch outputFormat {
-		case "html", "json", "text", "yaml", "csv":
+		case "html":
+			format = domain.OutputFormatHTML
+		case "json":
+			format = domain.OutputFormatJSON
+		case "text":
+			format = domain.OutputFormatText
+		case "yaml":
+			format = domain.OutputFormatYAML
+		case "csv":
+			format = domain.OutputFormatCSV
 		default:
 			return fmt.Errorf("invalid format %q, must be one of: html, json, text, yaml, csv", outputFormat)
 		}
-	}
-
-	// Determine output format (default: HTML)
-	var format domain.OutputFormat
-	switch {
-	case jsonOutput, outputFormat == "json":
-		format = domain.OutputFormatJSON
-	case textOutput, outputFormat == "text":
-		format = domain.OutputFormatText
-	case htmlOutput, outputFormat == "html":
-		format = domain.OutputFormatHTML
-	case outputFormat == "yaml":
-		format = domain.OutputFormatYAML
-	case outputFormat == "csv":
-		format = domain.OutputFormatCSV
-	default:
-		return fmt.Errorf("invalid format %q, must be one of: html, json, text, yaml, csv", outputFormat)
+	} else {
+		switch {
+		case jsonOutput:
+			format = domain.OutputFormatJSON
+		case textOutput:
+			format = domain.OutputFormatText
+		default:
+			format = domain.OutputFormatHTML
+		}
 	}
 
 	isStructured := format == domain.OutputFormatJSON || format == domain.OutputFormatYAML || format == domain.OutputFormatCSV

--- a/jscan/cmd/jscan/analyze_format_test.go
+++ b/jscan/cmd/jscan/analyze_format_test.go
@@ -255,3 +255,92 @@ func TestAnalyzeCmd_FormatText(t *testing.T) {
 		t.Errorf("expected text output on stdout, got:\n%s", stdout)
 	}
 }
+
+func TestAnalyzeCmd_ExplicitFormatOverridesShorthandFlags(t *testing.T) {
+	tests := []struct {
+		name          string
+		args          []string
+		expectedCheck func(t *testing.T, stdout, stderr string)
+	}{
+		{
+			name: "html flag overridden by format yaml",
+			args: []string{"--html", "--format", "yaml"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				var parsed map[string]interface{}
+				if err := yaml.Unmarshal([]byte(stdout), &parsed); err != nil {
+					t.Fatalf("expected valid YAML output, got: %s", stdout)
+				}
+				if _, ok := parsed["version"]; !ok {
+					t.Errorf("missing version in YAML output: %s", stdout)
+				}
+			},
+		},
+		{
+			name: "html flag overridden by format csv",
+			args: []string{"--html", "--format", "csv"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				if !strings.Contains(stdout, "type,file,function,start_line,end_line") {
+					t.Errorf("expected CSV header on stdout, got: %s", stdout)
+				}
+			},
+		},
+		{
+			name: "html flag overridden by format text",
+			args: []string{"--html", "--format", "text"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				if !strings.Contains(stdout, "Complexity Analysis") {
+					t.Errorf("expected text output on stdout, got: %s", stdout)
+				}
+			},
+		},
+		{
+			name: "html flag overridden by format json",
+			args: []string{"--html", "--format", "json"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				if !strings.Contains(stdout, `"complexity"`) {
+					t.Errorf("expected JSON output on stdout, got: %s", stdout)
+				}
+			},
+		},
+		{
+			name: "text flag overridden by format yaml",
+			args: []string{"--text", "--format", "yaml"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				var parsed map[string]interface{}
+				if err := yaml.Unmarshal([]byte(stdout), &parsed); err != nil {
+					t.Fatalf("expected valid YAML output, got: %s", stdout)
+				}
+			},
+		},
+		{
+			name: "json flag overridden by format csv",
+			args: []string{"--json", "--format", "csv"},
+			expectedCheck: func(t *testing.T, stdout, stderr string) {
+				if !strings.Contains(stdout, "type,file,function,start_line,end_line") {
+					t.Errorf("expected CSV header on stdout, got: %s", stdout)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAnalyzeFlags()
+			dir, _ := writeSampleJSFile(t)
+
+			cmd := analyzeCmd()
+			fullArgs := append(tt.args, dir)
+			cmd.SetArgs(fullArgs)
+
+			stdout, stderr, err := captureStdoutAndStderr(func() error {
+				return cmd.Execute()
+			})
+
+			if err != nil {
+				t.Fatalf("unexpected error for args %v: %v", fullArgs, err)
+			}
+
+			tt.expectedCheck(t, stdout, stderr)
+		})
+	}
+}

--- a/jscan/cmd/jscan/analyze_format_test.go
+++ b/jscan/cmd/jscan/analyze_format_test.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+func resetAnalyzeFlags() {
+	selectAnalyses = []string{"complexity", "deadcode", "clone", "cbo", "deps"}
+	outputFormat = "html"
+	configPath = ""
+	jsonOutput = false
+	htmlOutput = false
+	textOutput = false
+	noOpenBrowser = false
+	outputPath = ""
+}
+
+func writeSampleJSFile(t *testing.T) (string, string) {
+	t.Helper()
+	dir := t.TempDir()
+	filePath := filepath.Join(dir, "index.js")
+	content := `
+function calculateTotal(items) {
+  let total = 0;
+  for (const item of items) {
+    if (item.price > 0) {
+      total += item.price;
+    }
+  }
+  return total;
+}
+`
+	if err := os.WriteFile(filePath, []byte(content), 0o644); err != nil {
+		t.Fatalf("failed to write sample file: %v", err)
+	}
+	return dir, filePath
+}
+
+func captureStdoutAndStderr(f func() error) (stdout string, stderr string, err error) {
+	origStdout := os.Stdout
+	origStderr := os.Stderr
+
+	rOut, wOut, _ := os.Pipe()
+	rErr, wErr, _ := os.Pipe()
+
+	os.Stdout = wOut
+	os.Stderr = wErr
+
+	outChan := make(chan string)
+	errChan := make(chan string)
+
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rOut)
+		outChan <- buf.String()
+	}()
+
+	go func() {
+		var buf bytes.Buffer
+		_, _ = io.Copy(&buf, rErr)
+		errChan <- buf.String()
+	}()
+
+	err = f()
+
+	_ = wOut.Close()
+	_ = wErr.Close()
+
+	os.Stdout = origStdout
+	os.Stderr = origStderr
+
+	stdout = <-outChan
+	stderr = <-errChan
+
+	_ = rOut.Close()
+	_ = rErr.Close()
+
+	return stdout, stderr, err
+}
+
+func TestAnalyzeCmd_FormatFlagHelpText(t *testing.T) {
+	cmd := analyzeCmd()
+	formatFlag := cmd.Flags().Lookup("format")
+	if formatFlag == nil {
+		t.Fatal("expected format flag to exist")
+	}
+	if !strings.Contains(formatFlag.Usage, "yaml") || !strings.Contains(formatFlag.Usage, "csv") {
+		t.Errorf("expected format flag usage to mention yaml and csv, got %q", formatFlag.Usage)
+	}
+}
+
+func TestAnalyzeCmd_InvalidFormatErrors(t *testing.T) {
+	tests := []struct {
+		name       string
+		args       []string
+		errPattern string
+	}{
+		{
+			name:       "unrecognized format foo",
+			args:       []string{"--format", "foo"},
+			errPattern: `invalid format "foo", must be one of: html, json, text, yaml, csv`,
+		},
+		{
+			name:       "uppercase JSON",
+			args:       []string{"--format", "JSON"},
+			errPattern: `invalid format "JSON", must be one of: html, json, text, yaml, csv`,
+		},
+		{
+			name:       "typo jsonn",
+			args:       []string{"--format", "jsonn"},
+			errPattern: `invalid format "jsonn", must be one of: html, json, text, yaml, csv`,
+		},
+		{
+			name:       "invalid format with json flag",
+			args:       []string{"--json", "--format", "invalid"},
+			errPattern: `invalid format "invalid", must be one of: html, json, text, yaml, csv`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			resetAnalyzeFlags()
+			dir, _ := writeSampleJSFile(t)
+
+			cmd := analyzeCmd()
+			fullArgs := append(tt.args, dir)
+			cmd.SetArgs(fullArgs)
+
+			_, _, err := captureStdoutAndStderr(func() error {
+				return cmd.Execute()
+			})
+
+			if err == nil {
+				t.Fatalf("expected error for args %v, got nil", fullArgs)
+			}
+			if !strings.Contains(err.Error(), tt.errPattern) {
+				t.Errorf("expected error containing %q, got %q", tt.errPattern, err.Error())
+			}
+		})
+	}
+}
+
+func TestAnalyzeCmd_FormatYAML(t *testing.T) {
+	resetAnalyzeFlags()
+	dir, _ := writeSampleJSFile(t)
+
+	cmd := analyzeCmd()
+	cmd.SetArgs([]string{"--format", "yaml", dir})
+
+	stdout, stderr, err := captureStdoutAndStderr(func() error {
+		return cmd.Execute()
+	})
+
+	if err != nil {
+		t.Fatalf("analyze --format yaml failed: %v", err)
+	}
+
+	// Verify stdout is valid YAML and not corrupted by terminal messages
+	var parsed map[string]interface{}
+	if err := yaml.Unmarshal([]byte(stdout), &parsed); err != nil {
+		t.Fatalf("stdout is not valid YAML: %v\nOutput was:\n%s", err, stdout)
+	}
+
+	if _, ok := parsed["version"]; !ok {
+		t.Errorf("YAML output missing version field: %s", stdout)
+	}
+	if _, ok := parsed["complexity"]; !ok {
+		t.Errorf("YAML output missing complexity field: %s", stdout)
+	}
+
+	// Verify score summary is written to stderr
+	if !strings.Contains(stderr, "Health Score:") {
+		t.Errorf("expected stderr to contain score summary, got:\n%s", stderr)
+	}
+}
+
+func TestAnalyzeCmd_FormatCSV(t *testing.T) {
+	resetAnalyzeFlags()
+	dir, _ := writeSampleJSFile(t)
+
+	cmd := analyzeCmd()
+	cmd.SetArgs([]string{"--format", "csv", dir})
+
+	stdout, stderr, err := captureStdoutAndStderr(func() error {
+		return cmd.Execute()
+	})
+
+	if err != nil {
+		t.Fatalf("analyze --format csv failed: %v", err)
+	}
+
+	// Verify stdout contains CSV header
+	if !strings.Contains(stdout, "type,file,function,start_line,end_line") {
+		t.Errorf("stdout does not contain expected CSV header, got:\n%s", stdout)
+	}
+
+	// Verify stdout contains CSV data
+	if !strings.Contains(stdout, "calculateTotal") {
+		t.Errorf("stdout does not contain function name in CSV, got:\n%s", stdout)
+	}
+
+	// Verify score summary is written to stderr
+	if !strings.Contains(stderr, "Health Score:") {
+		t.Errorf("expected stderr to contain score summary, got:\n%s", stderr)
+	}
+}
+
+func TestAnalyzeCmd_FormatJSON(t *testing.T) {
+	resetAnalyzeFlags()
+	dir, _ := writeSampleJSFile(t)
+
+	cmd := analyzeCmd()
+	cmd.SetArgs([]string{"--format", "json", dir})
+
+	stdout, stderr, err := captureStdoutAndStderr(func() error {
+		return cmd.Execute()
+	})
+
+	if err != nil {
+		t.Fatalf("analyze --format json failed: %v", err)
+	}
+
+	if !strings.Contains(stdout, `"complexity"`) {
+		t.Errorf("expected JSON output on stdout, got:\n%s", stdout)
+	}
+
+	if !strings.Contains(stderr, "Health Score:") {
+		t.Errorf("expected stderr to contain score summary, got:\n%s", stderr)
+	}
+}
+
+func TestAnalyzeCmd_FormatText(t *testing.T) {
+	resetAnalyzeFlags()
+	dir, _ := writeSampleJSFile(t)
+
+	cmd := analyzeCmd()
+	cmd.SetArgs([]string{"--format", "text", dir})
+
+	stdout, _, err := captureStdoutAndStderr(func() error {
+		return cmd.Execute()
+	})
+
+	if err != nil {
+		t.Fatalf("analyze --format text failed: %v", err)
+	}
+
+	if !strings.Contains(stdout, "Complexity Analysis") {
+		t.Errorf("expected text output on stdout, got:\n%s", stdout)
+	}
+}

--- a/jscan/service/doc.go
+++ b/jscan/service/doc.go
@@ -17,9 +17,7 @@
 // importers were never part of the input.
 //
 // Output is handled by OutputFormatterImpl for text, JSON, YAML, CSV, and HTML,
-// and by DOTFormatter for Graphviz. Note that the CLI reaches only the text,
-// JSON, HTML, and DOT paths today; analyze maps any --format value other than
-// json or text to HTML, leaving the YAML and CSV writers unreachable.
+// and by DOTFormatter for Graphviz.
 //
 // BuildAnalyzeSummary combines the five responses into a domain.AnalyzeSummary
 // and computes the health score. Because a nil response is treated as an

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -26,17 +26,13 @@ jscan analyze src/ test/ scripts/build.ts             # Several paths at once
 | Flag | Short | Default | Description |
 | --- | --- | --- | --- |
 | `--select` | `-s` | `complexity,deadcode,clone,cbo,deps` | Comma-separated list of analyses to run |
-| `--format` | `-f` | `html` | Output format. Accepts `html`, `json`, or `text` |
+| `--format` | `-f` | `html` | Output format. Accepts `html`, `json`, `text`, `yaml`, or `csv` |
 | `--json` | | `false` | Shorthand for `--format json` |
 | `--text` | | `false` | Shorthand for `--format text` |
 | `--html` | | `false` | Shorthand for `--format html`, which is already the default |
 | `--no-open` | | `false` | Write the HTML report without opening a browser |
 | `--output` | `-o` | `jscan-report.html` | Path for the HTML report file |
 | `--config` | `-c` | discovered | Path to a configuration file |
-
-!!! warning "Only three formats are recognized"
-
-    `--format` silently falls back to HTML for any value other than `json` or `text`. Passing `--format csv` or `--format yaml` produces an HTML report rather than an error, so check the flag spelling if you receive HTML unexpectedly.
 
 If both `--json` and `--text` are given, JSON wins.
 
@@ -51,6 +47,14 @@ The format determines where results go and what else is printed.
 === "JSON"
 
     The full result document goes to standard output. The score summary goes to standard error, so that redirecting standard output to a file keeps the JSON valid. Progress bars are suppressed. The [JSON schema page](../output/json-schema.md) documents every field.
+
+=== "YAML"
+
+    The full result document goes to standard output formatted as YAML, matching the JSON response structure. The score summary goes to standard error. Progress bars are suppressed.
+
+=== "CSV"
+
+    Tabular results for complexity, dead code findings, clone pairs, and dependency edges go to standard output in comma-separated format. The score summary goes to standard error. Progress bars are suppressed.
 
 === "Text"
 


### PR DESCRIPTION
## Summary

Closes #42

- Validates `--format` in `jscan analyze` to reject unrecognized or misspelled values (e.g. `--format foo`, `--format JSON`, `--format jsonn`) with an error naming supported formats instead of silently falling back to HTML.
- Exposes `yaml` and `csv` formats in `jscan analyze --format`, enabling existing `OutputFormatterImpl.WriteAnalyze` YAML and CSV writers from the CLI.
- Directs clean structured output to `stdout` for YAML and CSV (suppressing terminal status and progress output) while sending the score summary to `stderr`, matching JSON output behavior.
- Updates documentation in `website/docs/cli/analyze.md`, `jscan/service/doc.go`, and `CHANGELOG.md`.
- Adds unit tests in `jscan/cmd/jscan/analyze_format_test.go`.

## Test Plan

- Ran `go test -count=1 ./...` in both `jscan` and `core` (all tests passing).
- Verified invalid formats return error `invalid format "<val>", must be one of: html, json, text, yaml, csv`.
- Verified `--format yaml` emits valid YAML on stdout and score summary on stderr.
- Verified `--format csv` emits valid CSV on stdout and score summary on stderr.