### PR TITLE
fix(jscan): inject commit, date, and builder into release version metadata

### DIFF
--- a/.github/workflows/jscan-release.yml
+++ b/.github/workflows/jscan-release.yml
@@ -52,7 +52,15 @@ jobs:
             EXT=".exe"
           fi
 
-          go build -ldflags="-s -w -X github.com/ludo-technologies/polyscan/jscan/internal/version.Version=${VERSION}" -o jscan${EXT} ./cmd/jscan
+          COMMIT=$(git rev-parse --short HEAD)
+          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
+
+          go build -ldflags="-s -w \
+            -X github.com/ludo-technologies/polyscan/jscan/internal/version.Version=${VERSION} \
+            -X github.com/ludo-technologies/polyscan/jscan/internal/version.Commit=${COMMIT} \
+            -X github.com/ludo-technologies/polyscan/jscan/internal/version.Date=${DATE} \
+            -X github.com/ludo-technologies/polyscan/jscan/internal/version.BuiltBy=release" \
+            -o jscan${EXT} ./cmd/jscan
 
           ARCHIVE_NAME="jscan_${VERSION}_${{ matrix.goos }}_${{ matrix.goarch }}"
           if [ "${{ matrix.goos }}" = "windows" ]; then

--- a/.github/workflows/jscan-release.yml
+++ b/.github/workflows/jscan-release.yml
@@ -11,7 +11,25 @@ permissions:
 # jscan depends on tree-sitter (cgo), so binaries must be built natively on
 # each platform's runner — cross-compilation with CGO_ENABLED=0 does not work.
 jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      commit: ${{ steps.meta.outputs.commit }}
+      date: ${{ steps.meta.outputs.date }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute release metadata
+        id: meta
+        shell: bash
+        run: |
+          echo "version=${GITHUB_REF_NAME#jscan/v}" >> "$GITHUB_OUTPUT"
+          echo "commit=$(git rev-parse --short HEAD)" >> "$GITHUB_OUTPUT"
+          echo "date=$(date -u +%Y-%m-%dT%H:%M:%SZ)" >> "$GITHUB_OUTPUT"
+
   build:
+    needs: meta
     strategy:
       matrix:
         include:
@@ -38,22 +56,17 @@ jobs:
         with:
           go-version-file: jscan/go.mod
 
-      - name: Get version
-        id: get_version
-        shell: bash
-        run: echo "version=${GITHUB_REF_NAME#jscan/v}" >> "$GITHUB_OUTPUT"
-
       - name: Build
         shell: bash
+        env:
+          VERSION: ${{ needs.meta.outputs.version }}
+          COMMIT: ${{ needs.meta.outputs.commit }}
+          DATE: ${{ needs.meta.outputs.date }}
         run: |
-          VERSION=${{ steps.get_version.outputs.version }}
           EXT=""
           if [ "${{ matrix.goos }}" = "windows" ]; then
             EXT=".exe"
           fi
-
-          COMMIT=$(git rev-parse --short HEAD)
-          DATE=$(date -u +%Y-%m-%dT%H:%M:%SZ)
 
           go build -ldflags="-s -w \
             -X github.com/ludo-technologies/polyscan/jscan/internal/version.Version=${VERSION} \
@@ -82,14 +95,11 @@ jobs:
           path: jscan/jscan${{ matrix.goos == 'windows' && '.exe' || '' }}
 
   release:
-    needs: build
+    needs: [meta, build]
     runs-on: ubuntu-latest
     outputs:
-      version: ${{ steps.get_version.outputs.version }}
+      version: ${{ needs.meta.outputs.version }}
     steps:
-      - name: Get version
-        id: get_version
-        run: echo "version=${GITHUB_REF_NAME#jscan/v}" >> "$GITHUB_OUTPUT"
 
       - name: Download archive artifacts
         uses: actions/download-artifact@v4

--- a/jscan/cmd/jscan/cmd_test.go
+++ b/jscan/cmd/jscan/cmd_test.go
@@ -183,3 +183,19 @@ func TestVersionCmd_ShortFlag(t *testing.T) {
 		t.Error("Missing short flag -v for --verbose")
 	}
 }
+
+func TestVersionCmd_Execute(t *testing.T) {
+	cmd := versionCmd()
+	cmd.SetArgs([]string{})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("versionCmd.Execute() error = %v", err)
+	}
+}
+
+func TestVersionCmd_ExecuteVerbose(t *testing.T) {
+	cmd := versionCmd()
+	cmd.SetArgs([]string{"--verbose"})
+	if err := cmd.Execute(); err != nil {
+		t.Errorf("versionCmd.Execute(--verbose) error = %v", err)
+	}
+}

--- a/jscan/docs/DEVELOPMENT.md
+++ b/jscan/docs/DEVELOPMENT.md
@@ -65,10 +65,9 @@ The build injects version metadata via linker flags (`-ldflags`):
 - `Version` - from `git describe --tags --always --dirty`
 - `Commit` - from `git rev-parse --short HEAD`
 - `Date` - build date
-- `BuiltBy` - set to `make` when built via Makefile
+- `BuiltBy` - set to `make` when built via Makefile, or `release` when built via the release workflow
 
-The release workflow injects only `Version`, so a released binary reports
-`unknown` for the commit and date and `source` as its builder.
+The release workflow injects all four fields (`Version`, `Commit`, `Date`, and `BuiltBy=release`). Binaries built with a bare `go build` retain the placeholder values (`dev`, `unknown`, `unknown`, `source`).
 
 ## Cross-compilation does not work
 

--- a/jscan/internal/version/doc.go
+++ b/jscan/internal/version/doc.go
@@ -4,8 +4,7 @@
 // placeholders otherwise: Version defaults to "dev", Commit and Date to
 // "unknown", and BuiltBy to "source".
 //
-// The Makefile populates all four. The release workflow sets only Version, so
-// an official release binary still reports "unknown" for the commit and date
-// and "source" as its builder. Anything that reads those fields should treat
-// them as unpopulated rather than as evidence about how the binary was built.
+// Both the Makefile (BuiltBy="make") and the release workflow (BuiltBy="release")
+// populate all four variables. A binary built directly via "go build" without
+// linker flags retains the default placeholder values.
 package version

--- a/jscan/internal/version/version_test.go
+++ b/jscan/internal/version/version_test.go
@@ -1,0 +1,87 @@
+package version
+
+import (
+	"testing"
+)
+
+func TestDefaultVersion(t *testing.T) {
+	// Verify default values
+	origVersion, origCommit, origDate, origBuiltBy := Version, Commit, Date, BuiltBy
+	t.Cleanup(func() {
+		Version, Commit, Date, BuiltBy = origVersion, origCommit, origDate, origBuiltBy
+	})
+
+	Version = "dev"
+	Commit = "unknown"
+	Date = "unknown"
+	BuiltBy = "source"
+
+	if got := GetVersion(); got != "dev" {
+		t.Errorf("GetVersion() = %q, want %q", got, "dev")
+	}
+	if got := Short(); got != "dev" {
+		t.Errorf("Short() = %q, want %q", got, "dev")
+	}
+	if got := GetCommit(); got != "unknown" {
+		t.Errorf("GetCommit() = %q, want %q", got, "unknown")
+	}
+	if got := GetDate(); got != "unknown" {
+		t.Errorf("GetDate() = %q, want %q", got, "unknown")
+	}
+	if got := GetBuiltBy(); got != "source" {
+		t.Errorf("GetBuiltBy() = %q, want %q", got, "source")
+	}
+
+	expectedFull := "dev (commit: unknown, built: unknown, by: source)"
+	if got := GetFullVersion(); got != expectedFull {
+		t.Errorf("GetFullVersion() = %q, want %q", got, expectedFull)
+	}
+}
+
+func TestEmptyVersionDefaultsToDev(t *testing.T) {
+	origVersion := Version
+	t.Cleanup(func() {
+		Version = origVersion
+	})
+
+	Version = ""
+	if got := GetVersion(); got != "dev" {
+		t.Errorf("GetVersion() = %q, want %q", got, "dev")
+	}
+	if got := Short(); got != "dev" {
+		t.Errorf("Short() = %q, want %q", got, "dev")
+	}
+}
+
+func TestCustomVersionMetadata(t *testing.T) {
+	origVersion, origCommit, origDate, origBuiltBy := Version, Commit, Date, BuiltBy
+	t.Cleanup(func() {
+		Version, Commit, Date, BuiltBy = origVersion, origCommit, origDate, origBuiltBy
+	})
+
+	Version = "1.2.3"
+	Commit = "abc1234"
+	Date = "2026-08-14T07:40:09Z"
+	BuiltBy = "release"
+
+	if got := GetVersion(); got != "1.2.3" {
+		t.Errorf("GetVersion() = %q, want %q", got, "1.2.3")
+	}
+	if got := Short(); got != "1.2.3" {
+		t.Errorf("Short() = %q, want %q", got, "1.2.3")
+	}
+	if got := GetCommit(); got != "abc1234" {
+		t.Errorf("GetCommit() = %q, want %q", got, "abc1234")
+	}
+	if got := GetDate(); got != "2026-08-14T07:40:09Z" {
+		t.Errorf("GetDate() = %q, want %q", got, "2026-08-14T07:40:09Z")
+	}
+	if got := GetBuiltBy(); got != "release" {
+		t.Errorf("GetBuiltBy() = %q, want %q", got, "release")
+	}
+
+	expectedFull := "1.2.3 (commit: abc1234, built: 2026-08-14T07:40:09Z, by: release)"
+	if got := GetFullVersion(); got != expectedFull {
+		t.Errorf("GetFullVersion() = %q, want %q", got, expectedFull)
+	}
+}

--- a/website/docs/cli/version.md
+++ b/website/docs/cli/version.md
@@ -19,12 +19,12 @@ jscan version 0.4.1
 
 ```console
 $ jscan version --verbose
-0.4.1 (commit: unknown, built: unknown, by: source)
+0.4.1 (commit: 7b3d1e2, built: 2026-08-14T07:40:09Z, by: release)
 ```
 
-The release pipeline injects only the version number through linker flags, so the other three fields keep their placeholder values even on an official release build. Treat `commit`, `built`, and `by` as unpopulated rather than as a sign that something went wrong with your install.
+Official release builds inject the version tag, commit hash, build timestamp in UTC, and `by: release`.
 
-A binary you compiled yourself reports `dev` as its version, for the same reason. That is the expected output of `go build` without the release flags.
+A binary you compiled yourself using bare `go build` reports placeholder values (`dev`, commit `unknown`, built `unknown`, by `source`). Building via `make` sets `by: make` and local git metadata.
 
 ## The root flag
 

--- a/website/docs/getting-started/installation.md
+++ b/website/docs/getting-started/installation.md
@@ -82,10 +82,10 @@ Adding `--verbose` prints the same version together with three build metadata fi
 
 ```console
 $ jscan version --verbose
-0.4.1 (commit: unknown, built: unknown, by: source)
+0.4.1 (commit: 7b3d1e2, built: 2026-08-14T07:40:09Z, by: release)
 ```
 
-The release pipeline currently injects only the version number, so the commit, build date, and builder fields keep their placeholder values on official builds as well.
+Official release binaries include the commit hash, the build timestamp in UTC, and `release` as the builder.
 
 ## Next step
 


### PR DESCRIPTION
Closes #43

## Summary

`jscan version --verbose` previously reported placeholder values (`commit: unknown, built: unknown, by: source`) on release binaries because `.github/workflows/jscan-release.yml` only set `Version` via ldflags.

This PR updates the release workflow and documentation:
- Adds a `meta` job in `.github/workflows/jscan-release.yml` that computes `version`, `commit`, and `date` once on `ubuntu-latest` and passes them to the matrix `build` jobs as environment variables, ensuring identical build timestamps across all platform binaries (Linux, macOS, Windows).
- Injects `Version`, `Commit`, `Date`, and `BuiltBy=release` via `-ldflags` into `github.com/ludo-technologies/polyscan/jscan/internal/version`.
- Updates documentation in `jscan/internal/version/doc.go`, `jscan/docs/DEVELOPMENT.md`, `website/docs/cli/version.md`, and `website/docs/getting-started/installation.md`.
- Adds unit tests in `jscan/internal/version/version_test.go` and execution tests for `versionCmd` in `jscan/cmd/jscan/cmd_test.go`.

## Verification

- `go test -race ./...` and `go vet ./...` in `jscan/` pass cleanly.
- `core` and `benchmarks` checks pass.
- Verified `jscan version` and `jscan version --verbose` output with release ldflags.