### PR TITLE
feat(core/graph): cancellable, globally ranked dependency chains

### DIFF
--- a/core/README.md
+++ b/core/README.md
@@ -12,7 +12,7 @@ Shared Go module that provides language-agnostic code analysis algorithms for th
 | `clone/` | AST feature extraction, clone classification, 5 clone grouping strategies (Connected, KCore, StarMedoid, CompleteLinkage, Centroid), and group dedup post-passes |
 | `dfa/` | Data-flow analysis framework over CFGs with language-injected variable reference extraction |
 | `domain/` | Shared type definitions, thresholds, and error taxonomy |
-| `graph/` | Directed graph abstraction, Tarjan SCC cycle detection, Robert Martin coupling metrics |
+| `graph/` | Directed graph abstraction, Tarjan SCC cycle detection, longest dependency chains over the SCC condensation, Robert Martin coupling metrics |
 | `lcom/` | LCOM4 lack-of-cohesion metric over method/attribute access maps |
 | `lsh/` | Locality-Sensitive Hashing index and MinHash signatures |
 | `nesting/` | Nesting depth analysis with language-injected nesting classifiers |

--- a/core/graph/cycles.go
+++ b/core/graph/cycles.go
@@ -1,5 +1,7 @@
 package graph
 
+import "context"
+
 // CycleResult holds the result of cycle detection via Tarjan's SCC algorithm.
 type CycleResult struct {
 	// Cycles contains all strongly connected components with more than one node.
@@ -12,6 +14,7 @@ type CycleResult struct {
 
 // CycleDetector finds strongly connected components using Tarjan's algorithm.
 type CycleDetector struct {
+	ctx      context.Context
 	index    int
 	stack    []string
 	onStack  map[string]bool
@@ -32,8 +35,14 @@ func (d *CycleDetector) DetectCycles(g DirectedGraph) *CycleResult {
 		AffectedNodes: make(map[string]bool),
 	}
 
+	// context.Background is never cancelled, so the SCC pass cannot fail here.
+	components, err := StronglyConnectedComponents(context.Background(), g)
+	if err != nil {
+		panic(err)
+	}
+
 	// Only SCCs with more than one node are actual cycles.
-	for _, scc := range StronglyConnectedComponents(g) {
+	for _, scc := range components {
 		if len(scc) <= 1 {
 			continue
 		}
@@ -51,8 +60,12 @@ func (d *CycleDetector) DetectCycles(g DirectedGraph) *CycleResult {
 // including single-node components, using Tarjan's algorithm. Components are
 // returned in reverse topological order: a component appears before any
 // component it depends on.
-func StronglyConnectedComponents(g DirectedGraph) [][]string {
+//
+// The pass checks ctx once per visited node and returns ctx.Err() as soon as
+// the context is cancelled.
+func StronglyConnectedComponents(ctx context.Context, g DirectedGraph) ([][]string, error) {
 	d := &CycleDetector{
+		ctx:      ctx,
 		onStack:  make(map[string]bool),
 		indices:  make(map[string]int),
 		lowlinks: make(map[string]int),
@@ -62,15 +75,22 @@ func StronglyConnectedComponents(g DirectedGraph) [][]string {
 	d.collect = func(scc []string) { components = append(components, scc) }
 
 	for _, nodeID := range g.NodeIDs() {
-		if _, visited := d.indices[nodeID]; !visited {
-			d.strongConnect(g, nodeID)
+		if _, visited := d.indices[nodeID]; visited {
+			continue
+		}
+		if err := d.strongConnect(g, nodeID); err != nil {
+			return nil, err
 		}
 	}
 
-	return components
+	return components, nil
 }
 
-func (d *CycleDetector) strongConnect(g DirectedGraph, v string) {
+func (d *CycleDetector) strongConnect(g DirectedGraph, v string) error {
+	if err := d.ctx.Err(); err != nil {
+		return err
+	}
+
 	d.indices[v] = d.index
 	d.lowlinks[v] = d.index
 	d.index++
@@ -79,7 +99,9 @@ func (d *CycleDetector) strongConnect(g DirectedGraph, v string) {
 
 	for _, w := range g.Successors(v) {
 		if _, visited := d.indices[w]; !visited {
-			d.strongConnect(g, w)
+			if err := d.strongConnect(g, w); err != nil {
+				return err
+			}
 			if d.lowlinks[w] < d.lowlinks[v] {
 				d.lowlinks[v] = d.lowlinks[w]
 			}
@@ -105,4 +127,5 @@ func (d *CycleDetector) strongConnect(g DirectedGraph, v string) {
 			d.collect(scc)
 		}
 	}
+	return nil
 }

--- a/core/graph/paths.go
+++ b/core/graph/paths.go
@@ -1,44 +1,62 @@
 package graph
 
-import "sort"
-
-// noComponent marks the absence of a component index.
-const noComponent = -1
+import (
+	"context"
+	"sort"
+)
 
 // ChainFinder answers longest-dependency-chain queries over a directed graph.
 //
 // Finding the longest simple path in a graph that may contain cycles is
 // NP-hard, so a ChainFinder walks the condensation instead: strongly connected
-// components are collapsed to single vertices and the heaviest path through the
-// resulting DAG is memoized in one linear pass, weighting each component by how
-// many nodes it holds. Each query then expands that component path into a
+// components are collapsed to single vertices and the heaviest chains through
+// the resulting DAG are memoized in one linear pass, weighting each component
+// by how many nodes it holds. Each query then expands a component chain into a
 // concrete route through the members of every component it crosses, so every
 // chain returned is a real simple path in the graph.
 //
-// The chain is maximal in dependency layers: no other simple path crosses more
+// A chain is maximal in dependency layers: no other simple path crosses more
 // strongly connected components. Within a component the route is not guaranteed
 // maximal — the final component is walked greedily through as many members as
 // it can reach, while components the chain passes through are crossed by the
 // shortest route between the edges that enter and leave them. Recovering the
 // longest route through a cycle is the NP-hard problem again.
 //
-// Ties are resolved by traversal order, which is derived from the graph's node
-// ordering, so repeated queries over the same graph return the same chain.
+// Chains are ranked by weight (the node count of the components they cross)
+// and, between equally heavy chains, by the lexicographic order of the
+// components they cross, each component named by its smallest member. That
+// order depends only on the graph, not on traversal, so repeated queries over
+// the same graph return the same chains.
 type ChainFinder struct {
-	dag  *condensation
-	best []componentChain
+	dag *condensation
+	// best is the top-ranked chain starting at each component.
+	best []*rankedChain
 }
 
-// NewChainFinder builds the condensation of g and memoizes the longest chain
+// NewChainFinder builds the condensation of g and memoizes the best chain
 // reachable from every component. Construction is linear in the graph size;
 // each subsequent query is linear in the length of the chain it returns.
-func NewChainFinder(g DirectedGraph) *ChainFinder {
+//
+// The condensation and the memoizing pass check ctx as they go and return
+// ctx.Err() as soon as the context is cancelled.
+func NewChainFinder(ctx context.Context, g DirectedGraph) (*ChainFinder, error) {
 	if g == nil || g.NodeCount() == 0 {
-		return &ChainFinder{}
+		return &ChainFinder{}, nil
 	}
 
-	dag := newCondensation(g)
-	return &ChainFinder{dag: dag, best: dag.longestChainPerComponent()}
+	dag, err := newCondensation(ctx, g)
+	if err != nil {
+		return nil, err
+	}
+	ranked, err := dag.rankedChainsPerComponent(ctx, 1)
+	if err != nil {
+		return nil, err
+	}
+	best := make([]*rankedChain, len(ranked))
+	for index, chains := range ranked {
+		best[index] = chains[0]
+	}
+	return &ChainFinder{dag: dag, best: best}, nil
 }
 
 // LongestChainFrom returns the longest chain that starts at nodeID, or nil if
@@ -51,7 +69,7 @@ func (f *ChainFinder) LongestChainFrom(nodeID string) []string {
 	if !known {
 		return nil
 	}
-	return f.dag.expand(f.componentPathFrom(start), nodeID)
+	return f.dag.expand(f.best[start], nodeID)
 }
 
 // LongestChain returns the longest chain anywhere in the graph.
@@ -60,29 +78,63 @@ func (f *ChainFinder) LongestChain() []string {
 		return nil
 	}
 
-	start, nodes := noComponent, 0
-	for index, chain := range f.best {
-		if chain.nodes > nodes {
-			start, nodes = index, chain.nodes
+	var top *rankedChain
+	for _, chain := range f.best {
+		if top == nil || f.dag.chainLess(chain, top) {
+			top = chain
 		}
 	}
-	if start == noComponent {
-		return nil
-	}
-	return f.dag.expand(f.componentPathFrom(start), "")
+	return f.dag.expand(top, "")
 }
 
-func (f *ChainFinder) componentPathFrom(start int) []int {
-	var path []int
-	for index := start; index != noComponent; index = f.best[index].next {
-		path = append(path, index)
+// LongestChains returns the limit best-ranked chains in the graph, best first.
+// Chains may start anywhere, so a reported chain can be the tail of another.
+// Every chain contains at least one edge: a node that depends on nothing is
+// not a chain, so a graph without edges has none. A limit of zero or less
+// returns nil.
+//
+// The ranking pass is linear in the graph size times limit and checks ctx as it
+// goes, returning ctx.Err() as soon as the context is cancelled.
+func (f *ChainFinder) LongestChains(ctx context.Context, limit int) ([][]string, error) {
+	if f.dag == nil || limit <= 0 {
+		return nil, nil
 	}
-	return path
+
+	ranked, err := f.dag.rankedChainsPerComponent(ctx, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	var candidates []*rankedChain
+	for _, chains := range ranked {
+		for _, chain := range chains {
+			// A lone node weighs 1; anything heavier crosses an edge, either
+			// into another component or around its own cycle.
+			if chain.nodes > 1 {
+				candidates = append(candidates, chain)
+			}
+		}
+	}
+	sort.Slice(candidates, func(i, j int) bool {
+		return f.dag.chainLess(candidates[i], candidates[j])
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	chains := make([][]string, len(candidates))
+	for index, candidate := range candidates {
+		chains[index] = f.dag.expand(candidate, "")
+	}
+	return chains, nil
 }
 
 // condensation is the DAG of strongly connected components of a graph.
 type condensation struct {
-	graph      DirectedGraph
+	graph DirectedGraph
+	// components lists every component's members in sorted order. Components
+	// come in reverse topological order, so every component a chain continues
+	// into has a smaller index than the component it leaves.
 	components [][]string
 	// componentOf maps a node ID to the index of its component.
 	componentOf map[string]int
@@ -93,12 +145,16 @@ type condensation struct {
 	crossing map[[2]int][2]string
 }
 
-func newCondensation(g DirectedGraph) *condensation {
-	components := StronglyConnectedComponents(g)
+func newCondensation(ctx context.Context, g DirectedGraph) (*condensation, error) {
+	components, err := StronglyConnectedComponents(ctx, g)
+	if err != nil {
+		return nil, err
+	}
 	// Sort each component's members so a chain that starts inside a cycle starts
-	// at a predictable node rather than wherever Tarjan happened to pop it.
-	// These slices are this call's own; CycleDetector runs its own SCC pass, so
-	// its reported cycle order is untouched.
+	// at a predictable node rather than wherever Tarjan happened to pop it, and
+	// so component[0] names the component when chains are compared. These
+	// slices are this call's own; CycleDetector runs its own SCC pass, so its
+	// reported cycle order is untouched.
 	for _, component := range components {
 		sort.Strings(component)
 	}
@@ -117,6 +173,9 @@ func newCondensation(g DirectedGraph) *condensation {
 	}
 
 	for index, component := range components {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
 		seen := make(map[int]struct{})
 		for _, nodeID := range component {
 			for _, successor := range g.Successors(nodeID) {
@@ -134,69 +193,101 @@ func newCondensation(g DirectedGraph) *condensation {
 		}
 	}
 
-	return dag
+	return dag, nil
 }
 
-// componentChain is the best chain reachable from one component: how many
-// graph nodes it spans and which component continues it.
-type componentChain struct {
+// rankedChain is one chain through the condensation, stored as a linked list
+// of components so that chains sharing a tail share its storage.
+type rankedChain struct {
+	component int
+	// next continues the chain, or is nil when the chain ends here.
+	next *rankedChain
+	// nodes is the chain's weight: the node count of every component it crosses.
 	nodes int
-	next  int
+	// rank is the chain's position among the ranked chains starting at the same
+	// component, which lets two chains be compared without walking them.
+	rank int
 }
 
-// longestChainPerComponent memoizes, for every component, the heaviest chain
-// starting there, weighting a component by its node count so that a chain
-// through a large cycle outranks an equally deep chain through single modules.
-// The condensation is acyclic, so no component is reachable from itself and a
-// single memoized pass suffices.
-func (dag *condensation) longestChainPerComponent() []componentChain {
-	best := make([]componentChain, len(dag.components))
-	resolved := make([]bool, len(dag.components))
-
-	var longestFrom func(index int) componentChain
-	longestFrom = func(index int) componentChain {
-		if resolved[index] {
-			return best[index]
+// rankedChainsPerComponent memoizes, for every component, the limit best-ranked
+// chains starting there. A component with no successors starts exactly one
+// chain, itself; every other component's chains extend the memoized chains of
+// its successors, so a chain is only ever a top-limit chain from its start when
+// its tail is a top-limit chain from the component that follows. Components
+// come in reverse topological order, so each one is ranked after every
+// component it can continue into.
+func (dag *condensation) rankedChainsPerComponent(ctx context.Context, limit int) ([][]*rankedChain, error) {
+	ranked := make([][]*rankedChain, len(dag.components))
+	for index, component := range dag.components {
+		if err := ctx.Err(); err != nil {
+			return nil, err
 		}
-		resolved[index] = true
 
-		size := len(dag.components[index])
-		chain := componentChain{nodes: size, next: noComponent}
+		size := len(component)
+		var candidates []*rankedChain
+		if len(dag.successors[index]) == 0 {
+			candidates = []*rankedChain{{component: index, nodes: size}}
+		}
 		for _, successor := range dag.successors[index] {
-			if candidate := longestFrom(successor); candidate.nodes+size > chain.nodes {
-				chain = componentChain{nodes: candidate.nodes + size, next: successor}
+			for _, tail := range ranked[successor] {
+				candidates = append(candidates, &rankedChain{
+					component: index,
+					next:      tail,
+					nodes:     size + tail.nodes,
+				})
 			}
 		}
 
-		best[index] = chain
-		return chain
+		sort.Slice(candidates, func(i, j int) bool {
+			return dag.chainLess(candidates[i], candidates[j])
+		})
+		if len(candidates) > limit {
+			candidates = candidates[:limit]
+		}
+		for rank, chain := range candidates {
+			chain.rank = rank
+		}
+		ranked[index] = candidates
 	}
-
-	for index := range dag.components {
-		longestFrom(index)
-	}
-	return best
+	return ranked, nil
 }
 
-// expand turns a component path into a concrete node path, routing through the
+// chainLess orders chains best first: heavier chains before lighter ones, then
+// by the lexicographic order of the components crossed, each named by its
+// smallest member. Two chains that leave the same start component through the
+// same next component are ordered by that tail's rank, which was assigned by
+// this same order, so the comparison never walks a chain.
+func (dag *condensation) chainLess(left, right *rankedChain) bool {
+	if left.nodes != right.nodes {
+		return left.nodes > right.nodes
+	}
+	if left.component != right.component {
+		return dag.components[left.component][0] < dag.components[right.component][0]
+	}
+	if left.next == nil || right.next == nil {
+		return false
+	}
+	if left.next.component != right.next.component {
+		return dag.components[left.next.component][0] < dag.components[right.next.component][0]
+	}
+	return left.next.rank < right.next.rank
+}
+
+// expand turns a component chain into a concrete node path, routing through the
 // members of every component the chain crosses. The path begins at startNode
 // when given, and otherwise at the first component's first member.
-func (dag *condensation) expand(componentPath []int, startNode string) []string {
-	if len(componentPath) == 0 {
-		return nil
-	}
-
+func (dag *condensation) expand(chain *rankedChain, startNode string) []string {
 	var path []string
 	entry := startNode
-	for position, index := range componentPath {
+	for ; chain != nil; chain = chain.next {
 		exit := ""
 		nextEntry := ""
-		if position+1 < len(componentPath) {
-			edge := dag.crossing[[2]int{index, componentPath[position+1]}]
+		if chain.next != nil {
+			edge := dag.crossing[[2]int{chain.component, chain.next.component}]
 			exit, nextEntry = edge[0], edge[1]
 		}
 
-		path = append(path, dag.routeWithin(index, entry, exit)...)
+		path = append(path, dag.routeWithin(chain.component, entry, exit)...)
 		entry = nextEntry
 	}
 

--- a/core/graph/paths_test.go
+++ b/core/graph/paths_test.go
@@ -1,9 +1,36 @@
 package graph
 
 import (
+	"context"
+	"errors"
 	"fmt"
+	"reflect"
 	"testing"
 )
+
+func mustChainFinder(t *testing.T, g DirectedGraph) *ChainFinder {
+	t.Helper()
+	finder, err := NewChainFinder(context.Background(), g)
+	if err != nil {
+		t.Fatalf("NewChainFinder: %v", err)
+	}
+	return finder
+}
+
+func mustLongestChains(t *testing.T, g DirectedGraph, limit int) [][]string {
+	t.Helper()
+	chains, err := mustChainFinder(t, g).LongestChains(context.Background(), limit)
+	if err != nil {
+		t.Fatalf("LongestChains(%d): %v", limit, err)
+	}
+	return chains
+}
+
+func cancelledContext() context.Context {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	return ctx
+}
 
 func chainGraph(edges [][2]string, isolated ...string) *MapGraph {
 	g := NewMapGraph()
@@ -46,16 +73,16 @@ func isSimplePath(g DirectedGraph, path []string) error {
 }
 
 func TestLongestChainEmptyGraph(t *testing.T) {
-	if chain := NewChainFinder(NewMapGraph()).LongestChain(); chain != nil {
+	if chain := mustChainFinder(t, NewMapGraph()).LongestChain(); chain != nil {
 		t.Errorf("LongestChain(empty) = %v, want nil", chain)
 	}
-	if chain := NewChainFinder(nil).LongestChain(); chain != nil {
+	if chain := mustChainFinder(t, nil).LongestChain(); chain != nil {
 		t.Errorf("NewChainFinder(nil).LongestChain() = %v, want nil", chain)
 	}
 }
 
 func TestLongestChainSingleNode(t *testing.T) {
-	chain := NewChainFinder(chainGraph(nil, "only")).LongestChain()
+	chain := mustChainFinder(t, chainGraph(nil, "only")).LongestChain()
 	if len(chain) != 1 || chain[0] != "only" {
 		t.Errorf("LongestChain = %v, want [only]", chain)
 	}
@@ -64,7 +91,7 @@ func TestLongestChainSingleNode(t *testing.T) {
 func TestLongestChainLinearPath(t *testing.T) {
 	g := chainGraph([][2]string{{"a", "b"}, {"b", "c"}, {"c", "d"}})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	want := []string{"a", "b", "c", "d"}
 	if len(chain) != len(want) {
 		t.Fatalf("LongestChain = %v, want %v", chain, want)
@@ -83,7 +110,7 @@ func TestLongestChainPrefersDeeperBranch(t *testing.T) {
 		{"a", "long1"}, {"long1", "long2"}, {"long2", "long3"},
 	})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -100,7 +127,7 @@ func TestLongestChainRoutesThroughCycle(t *testing.T) {
 		{"z", "exit"},
 	})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -112,7 +139,7 @@ func TestLongestChainRoutesThroughCycle(t *testing.T) {
 func TestLongestChainWholeGraphIsOneCycle(t *testing.T) {
 	g := chainGraph([][2]string{{"a", "b"}, {"b", "c"}, {"c", "a"}})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -131,7 +158,7 @@ func TestLongestChainWalksTerminalCycle(t *testing.T) {
 		{"x", "y"}, {"y", "x"},
 	})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -152,7 +179,7 @@ func TestLongestChainPrefersChainThroughCycle(t *testing.T) {
 		{"root", "c1"}, {"c1", "c2"}, {"c2", "c3"}, {"c3", "c1"},
 	})
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -167,9 +194,9 @@ func TestLongestChainIsDeterministic(t *testing.T) {
 		{"e", "f"}, {"f", "d"}, {"e", "g"},
 	})
 
-	first := NewChainFinder(g).LongestChain()
+	first := mustChainFinder(t, g).LongestChain()
 	for i := 0; i < 20; i++ {
-		next := NewChainFinder(g).LongestChain()
+		next := mustChainFinder(t, g).LongestChain()
 		if len(next) != len(first) {
 			t.Fatalf("run %d returned %v, want %v", i, next, first)
 		}
@@ -193,7 +220,7 @@ func TestLongestChainCompletesOnDenseGraph(t *testing.T) {
 		}
 	}
 
-	chain := NewChainFinder(g).LongestChain()
+	chain := mustChainFinder(t, g).LongestChain()
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain is not a simple path: %v", err)
 	}
@@ -207,7 +234,7 @@ func TestLongestChainFromStartsAtRequestedNode(t *testing.T) {
 		{"a", "b"}, {"b", "c"}, {"c", "d"},
 		{"x", "b"},
 	})
-	finder := NewChainFinder(g)
+	finder := mustChainFinder(t, g)
 
 	chain := finder.LongestChainFrom("x")
 	if err := isSimplePath(g, chain); err != nil {
@@ -231,7 +258,7 @@ func TestLongestChainFromInsideCycleStaysSimple(t *testing.T) {
 		{"z", "tail"}, {"tail", "end"},
 	})
 
-	chain := NewChainFinder(g).LongestChainFrom("y")
+	chain := mustChainFinder(t, g).LongestChainFrom("y")
 	if err := isSimplePath(g, chain); err != nil {
 		t.Fatalf("chain %v is not a simple path: %v", chain, err)
 	}
@@ -240,10 +267,187 @@ func TestLongestChainFromInsideCycleStaysSimple(t *testing.T) {
 	}
 }
 
+func TestNewChainFinderHonorsCancellation(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}})
+
+	finder, err := NewChainFinder(cancelledContext(), g)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("NewChainFinder(cancelled) = %v, %v; want context.Canceled", finder, err)
+	}
+}
+
+func TestLongestChainsHonorsCancellation(t *testing.T) {
+	finder := mustChainFinder(t, chainGraph([][2]string{{"a", "b"}}))
+
+	chains, err := finder.LongestChains(cancelledContext(), 1)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("LongestChains(cancelled) = %v, %v; want context.Canceled", chains, err)
+	}
+}
+
+func TestLongestChainsRanksEqualChainsByName(t *testing.T) {
+	// entry reaches leaf through two arms of equal depth.
+	g := chainGraph([][2]string{
+		{"entry", "left"}, {"entry", "right"},
+		{"left", "leaf"}, {"right", "leaf"},
+	})
+
+	want := [][]string{{"entry", "left", "leaf"}, {"entry", "right", "leaf"}}
+	if got := mustLongestChains(t, g, 2); !reflect.DeepEqual(got, want) {
+		t.Errorf("LongestChains(2) = %v, want %v", got, want)
+	}
+}
+
+// TestLongestChainsRanksDeepBranchAboveShallowOnes pins that weight comes
+// before name: many lexicographically earlier shallow arms must not push the
+// one deep arm out of the ranking.
+func TestLongestChainsRanksDeepBranchAboveShallowOnes(t *testing.T) {
+	edges := [][2]string{
+		{"root", "z_deep"}, {"z_deep", "z_middle"}, {"z_middle", "z_leaf"},
+	}
+	for i := 0; i < 10; i++ {
+		edges = append(edges, [2]string{"root", fmt.Sprintf("a_shallow_%02d", i)})
+	}
+	g := chainGraph(edges)
+
+	chains := mustLongestChains(t, g, 10)
+	want := []string{"root", "z_deep", "z_middle", "z_leaf"}
+	if len(chains) == 0 || !reflect.DeepEqual(chains[0], want) {
+		t.Errorf("LongestChains(10)[0] = %v, want %v", chains, want)
+	}
+}
+
+// TestLongestChainsIncludesTails pins that chains may start anywhere: the tail
+// of the best chain is itself a chain, ranked below it.
+func TestLongestChainsIncludesTails(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}, {"b", "c"}, {"c", "d"}})
+
+	want := [][]string{{"a", "b", "c", "d"}, {"b", "c", "d"}, {"c", "d"}}
+	if got := mustLongestChains(t, g, 10); !reflect.DeepEqual(got, want) {
+		t.Errorf("LongestChains(10) = %v, want %v", got, want)
+	}
+}
+
+// TestLongestChainsKeepsSeveralChainsPerComponent pins the per-component
+// ranking: every chain from root shares the start component, and the global
+// top list must hold all of them, ordered by the components they cross, before
+// any lighter tail.
+func TestLongestChainsKeepsSeveralChainsPerComponent(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"root", "a"}, {"root", "b"},
+		{"a", "c"}, {"a", "d"}, {"b", "c"}, {"b", "d"},
+	})
+
+	want := [][]string{
+		{"root", "a", "c"}, {"root", "a", "d"}, {"root", "b", "c"}, {"root", "b", "d"},
+		{"a", "c"}, {"a", "d"},
+	}
+	if got := mustLongestChains(t, g, 6); !reflect.DeepEqual(got, want) {
+		t.Errorf("LongestChains(6) = %v, want %v", got, want)
+	}
+}
+
+func TestLongestChainsExpandsCycleComponents(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"entry", "first_a"}, {"first_a", "first_b"}, {"first_b", "first_a"},
+		{"first_b", "second_a"}, {"second_a", "second_b"}, {"second_b", "second_a"},
+		{"second_b", "leaf"},
+	})
+
+	chains := mustLongestChains(t, g, 1)
+	want := [][]string{{"entry", "first_a", "first_b", "second_a", "second_b", "leaf"}}
+	if !reflect.DeepEqual(chains, want) {
+		t.Errorf("LongestChains(1) = %v, want %v", chains, want)
+	}
+	if err := isSimplePath(g, chains[0]); err != nil {
+		t.Errorf("chain %v is not a simple path: %v", chains[0], err)
+	}
+}
+
+func TestLongestChainsAgreesWithLongestChain(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"a", "b"}, {"a", "c"}, {"b", "d"}, {"c", "d"}, {"d", "e"},
+		{"e", "f"}, {"f", "d"}, {"e", "g"},
+	})
+	finder := mustChainFinder(t, g)
+
+	chains, err := finder.LongestChains(context.Background(), 1)
+	if err != nil {
+		t.Fatalf("LongestChains(1): %v", err)
+	}
+	if len(chains) != 1 || !reflect.DeepEqual(chains[0], finder.LongestChain()) {
+		t.Errorf("LongestChains(1) = %v, want [%v]", chains, finder.LongestChain())
+	}
+}
+
+func TestLongestChainsWithoutLimitOrEdges(t *testing.T) {
+	if chains := mustLongestChains(t, chainGraph([][2]string{{"a", "b"}}), 0); chains != nil {
+		t.Errorf("LongestChains(0) = %v, want nil", chains)
+	}
+	if chains := mustLongestChains(t, NewMapGraph(), 3); chains != nil {
+		t.Errorf("LongestChains(empty graph) = %v, want nil", chains)
+	}
+	// Isolated nodes are not chains, even when the limit has room for them.
+	if chains := mustLongestChains(t, chainGraph(nil, "only", "other"), 3); len(chains) != 0 {
+		t.Errorf("LongestChains(isolated nodes) = %v, want none", chains)
+	}
+}
+
+// TestLongestChainsWholeGraphIsOneCycle pins that a cycle counts as a chain
+// even though it is a single component: its members depend on each other.
+func TestLongestChainsWholeGraphIsOneCycle(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}, {"b", "a"}}, "lonely")
+
+	want := [][]string{{"a", "b"}}
+	if got := mustLongestChains(t, g, 3); !reflect.DeepEqual(got, want) {
+		t.Errorf("LongestChains(3) = %v, want %v", got, want)
+	}
+}
+
+func TestStronglyConnectedComponentsHonorsCancellation(t *testing.T) {
+	g := chainGraph([][2]string{{"a", "b"}})
+
+	components, err := StronglyConnectedComponents(cancelledContext(), g)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("StronglyConnectedComponents(cancelled) = %v, %v; want context.Canceled", components, err)
+	}
+}
+
+// TestStronglyConnectedComponentsAreInReverseTopologicalOrder pins the
+// ordering contract the chain finder relies on: every component appears before
+// any component it depends on, so one forward pass sees each component's
+// successors already ranked.
+func TestStronglyConnectedComponentsAreInReverseTopologicalOrder(t *testing.T) {
+	g := chainGraph([][2]string{
+		{"a", "b"}, {"b", "c"}, {"c", "b"}, {"c", "d"}, {"x", "d"}, {"x", "a"},
+	})
+
+	components, err := StronglyConnectedComponents(context.Background(), g)
+	if err != nil {
+		t.Fatalf("StronglyConnectedComponents: %v", err)
+	}
+	position := make(map[string]int)
+	for index, component := range components {
+		for _, node := range component {
+			position[node] = index
+		}
+	}
+	for _, from := range g.NodeIDs() {
+		for _, to := range g.Successors(from) {
+			if position[to] > position[from] {
+				t.Errorf("component of %q (%d) comes after component of %q (%d)", to, position[to], from, position[from])
+			}
+		}
+	}
+}
+
 func TestStronglyConnectedComponentsIncludesSingletons(t *testing.T) {
 	g := chainGraph([][2]string{{"a", "b"}, {"b", "a"}, {"b", "c"}})
 
-	components := StronglyConnectedComponents(g)
+	components, err := StronglyConnectedComponents(context.Background(), g)
+	if err != nil {
+		t.Fatalf("StronglyConnectedComponents: %v", err)
+	}
 	if len(components) != 2 {
 		t.Fatalf("got %d components (%v), want 2", len(components), components)
 	}

--- a/docs/performance.md
+++ b/docs/performance.md
@@ -230,21 +230,31 @@ Complexities below are in fragment count `n`, fragment size `m`, module count
 | Clone detection without LSH | O(n²) verifications | Exhaustive; the reason LSH auto-enables |
 | `core/graph` SCC | O(V + E) | Tarjan |
 | `core/graph` longest chain | O(V + E) | Condensation plus memoized DAG traversal — see below |
+| `core/graph` top-N chains | O((V + E) · N) | Same condensation; every component keeps its N best chains |
 
-The last row is worth stating explicitly: dependency-chain reporting must never
-enumerate simple paths. On a real import graph with cycles, exhaustive
+The last two rows are worth stating explicitly: dependency-chain reporting must
+never enumerate simple paths. On a real import graph with cycles, exhaustive
 enumeration does not terminate in practical time.
 
 What the chain guarantees, then, is that no other simple path crosses more
 strongly connected components — it is maximal in dependency layers. Components
 are weighted by module count when chains are compared, so a chain through a
-large cycle outranks an equally deep chain through single modules. Within a
+large cycle outranks an equally deep chain through single modules; between
+equally heavy chains, the one whose components sort first by name wins, so the
+ranking depends on the graph alone and not on traversal order. Within a
 component the route is not guaranteed maximal: the component that ends the chain
 is walked greedily through as many members as it can reach, and components the
 chain passes through are crossed by the shortest route between the edges that
 enter and leave them. Recovering the longest route through a cycle is the
 NP-hard problem again. `MaxDepth` counts the edges of that concrete chain, so it
 is always a depth some real import path achieves.
+
+`LongestChains(ctx, N)` ranks chains globally rather than per start node: each
+component memoizes its N best chains, built from the memoized chains of the
+components it depends on, and the global top N is drawn from those lists. A
+chain's tail is a chain in its own right, so a reported list can hold a chain
+and its suffix. Both the condensation and the ranking pass observe context
+cancellation, so a caller with a deadline can abandon the search.
 
 ### `MaxDepth` values changed
 

--- a/jscan/internal/analyzer/coupling_metrics.go
+++ b/jscan/internal/analyzer/coupling_metrics.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"sort"
 
 	coregraph "github.com/ludo-technologies/polyscan/core/graph"
@@ -312,7 +313,8 @@ func (c *CouplingMetricsCalculator) CalculateTransitiveDependencies(nodeID strin
 }
 
 // CalculateMaxDepth calculates the maximum dependency depth in the graph,
-// measured in edges along the longest dependency chain.
+// measured in edges along the longest dependency chain. It fails only when ctx
+// is cancelled during the chain search.
 //
 // The chain comes from core/graph's condensation-based finder over the
 // load-time graph: cycles are collapsed before the search, so the depth is well
@@ -320,11 +322,15 @@ func (c *CouplingMetricsCalculator) CalculateTransitiveDependencies(nodeID strin
 // report shows under LongestChains. Dynamic import() edges are excluded, since
 // depth measures how deeply modules are layered at load time, which is the same
 // contract cycle detection uses.
-func (c *CouplingMetricsCalculator) CalculateMaxDepth(graph *domain.DependencyGraph) int {
+func (c *CouplingMetricsCalculator) CalculateMaxDepth(ctx context.Context, graph *domain.DependencyGraph) (int, error) {
 	if graph == nil || graph.NodeCount() == 0 {
-		return 0
+		return 0, nil
 	}
-	return c.CalculateMaxDepthFrom(coregraph.NewChainFinder(LoadTimeGraph(graph)))
+	finder, err := coregraph.NewChainFinder(ctx, LoadTimeGraph(graph))
+	if err != nil {
+		return 0, err
+	}
+	return c.CalculateMaxDepthFrom(finder), nil
 }
 
 // CalculateMaxDepthFrom is CalculateMaxDepth against a chain finder the caller

--- a/jscan/internal/analyzer/coupling_metrics_test.go
+++ b/jscan/internal/analyzer/coupling_metrics_test.go
@@ -1,6 +1,7 @@
 package analyzer
 
 import (
+	"context"
 	"math"
 	"testing"
 
@@ -256,7 +257,10 @@ func TestCalculateMaxDepth(t *testing.T) {
 	graph.AddEdge(&domain.DependencyEdge{From: "c", To: "d", Weight: 1})
 
 	calc := NewCouplingMetricsCalculator(nil)
-	depth := calc.CalculateMaxDepth(graph)
+	depth, err := calc.CalculateMaxDepth(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("CalculateMaxDepth: %v", err)
+	}
 
 	if depth != 3 {
 		t.Errorf("Expected max depth 3, got %d", depth)
@@ -274,7 +278,10 @@ func TestCalculateMaxDepthWithCycle(t *testing.T) {
 	graph.AddEdge(&domain.DependencyEdge{From: "c", To: "a", Weight: 1})
 
 	calc := NewCouplingMetricsCalculator(nil)
-	depth := calc.CalculateMaxDepth(graph)
+	depth, err := calc.CalculateMaxDepth(context.Background(), graph)
+	if err != nil {
+		t.Fatalf("CalculateMaxDepth: %v", err)
+	}
 
 	// Should handle cycle gracefully
 	if depth < 0 {
@@ -296,14 +303,14 @@ func TestCalculateMaxDepthExcludesDynamicImports(t *testing.T) {
 
 	calc := NewCouplingMetricsCalculator(nil)
 
-	if depth := calc.CalculateMaxDepth(graph); depth != 1 {
-		t.Errorf("the dynamic edge must not count toward depth: got %d, want 1", depth)
+	if depth, err := calc.CalculateMaxDepth(context.Background(), graph); err != nil || depth != 1 {
+		t.Errorf("the dynamic edge must not count toward depth: got %d, %v; want 1", depth, err)
 	}
 
 	// Promoting the same pair to a static import restores the layer.
 	graph.AddEdge(&domain.DependencyEdge{From: "b", To: "c", Weight: 1})
-	if depth := calc.CalculateMaxDepth(graph); depth != 2 {
-		t.Errorf("a static edge alongside the dynamic one is a load-time dependency: got %d, want 2", depth)
+	if depth, err := calc.CalculateMaxDepth(context.Background(), graph); err != nil || depth != 2 {
+		t.Errorf("a static edge alongside the dynamic one is a load-time dependency: got %d, %v; want 2", depth, err)
 	}
 }
 

--- a/jscan/service/dependency_graph_service.go
+++ b/jscan/service/dependency_graph_service.go
@@ -132,7 +132,10 @@ func (s *DependencyGraphServiceImpl) AnalyzeSnapshot(ctx context.Context, snapsh
 	// condensation, so build the finder once and let both read from it. It runs
 	// over the load-time graph, so a dynamic import() cannot add a layer that
 	// the cycle report has already ruled out.
-	chainFinder := coregraph.NewChainFinder(analyzer.LoadTimeGraph(graph))
+	chainFinder, err := coregraph.NewChainFinder(ctx, analyzer.LoadTimeGraph(graph))
+	if err != nil {
+		return nil, fmt.Errorf("dependency chain search cancelled: %w", err)
+	}
 	maxDepth := couplingCalc.CalculateMaxDepthFrom(chainFinder)
 
 	// Build analysis result


### PR DESCRIPTION
Closes #56.

`ChainFinder` gains the two capabilities pyscn's local `dependency_topology.go` had over it, so pyscn can adopt `core/graph` and delete its copy.

- `NewChainFinder(ctx, g)` and `StronglyConnectedComponents(ctx, g)` observe context cancellation: once per visited node in Tarjan, once per component in the condensation and in the ranking pass. `CycleDetector.DetectCycles(g)` keeps its signature.
- `LongestChains(ctx, limit)` returns the `limit` best chains in the whole graph rather than one chain per queried start node. Chains are ranked by weight (node count of the components crossed) and then by component names, so the order depends on the graph alone. Each component memoizes its `limit` best chains from its successors' memoized chains, so the pass is O((V+E)·limit); every chain records its rank in its component's list, so comparing two chains never walks them. Every reported chain contains at least one edge.
- `LongestChain` and `LongestChainFrom` read the same ranking with a limit of one, so ties now resolve by name instead of traversal order.

jscan threads its request context into the finder (`CalculateMaxDepth` now takes a context and returns an error). `jscan deps --format json` output is unchanged before and after on civic-ai (232 files) and opencode/packages/opencode/src (3.3k files).

Semantics pyscn should expect when it adopts this (differences from its local copy): chains are weighted by node count rather than component count, a chain that ends inside a cycle walks the cycle's members instead of stopping at the entry node, and a standalone cycle is a chain. `MaxDepth` is not part of `ChainFinder`; jscan derives it as `len(LongestChain()) - 1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
