### PR TITLE
refactor(core/domain): extract the parse-error health-score penalty

### DIFF
--- a/core/domain/scoring.go
+++ b/core/domain/scoring.go
@@ -57,6 +57,13 @@ const (
 	ScoreThresholdFair      = 60 // Fair: 60-74
 	// Poor: 0-59 (below ScoreThresholdFair)
 
+	// Files that fail to parse are absent from every metric, so without a
+	// penalty they score better than working code. The bounds are anchored to
+	// the grade thresholds: a single unanalyzable file forfeits an A, and a
+	// target where nothing parses cannot rank above F.
+	MinParseErrorPenalty = 100 - GradeAThreshold + 1
+	MaxParseErrorPenalty = 100 - GradeDThreshold + 1
+
 	// Other constants
 	MinimumScore                = 0 // Allow truly low scores for severely problematic code
 	HealthyThreshold            = 70
@@ -98,6 +105,24 @@ func DuplicationPenalty(duplicationPercent float64) int {
 	}
 
 	return int(math.Round(penalty))
+}
+
+// ParseErrorPenalty charges the health score for files that could not be
+// analyzed at all. Such a file yields no functions, no dead code, no clones and
+// no coupling, so without this term corrupting a file raises the score. The
+// penalty grows with the unanalyzed fraction and never drops below
+// MinParseErrorPenalty, so one broken file in a large tree still costs a grade.
+func ParseErrorPenalty(skippedFiles, totalFiles int) int {
+	if skippedFiles <= 0 || totalFiles <= 0 {
+		return 0
+	}
+
+	ratio := float64(skippedFiles) / float64(totalFiles)
+	if ratio > 1 {
+		ratio = 1
+	}
+
+	return max(int(math.Round(ratio*float64(MaxParseErrorPenalty))), MinParseErrorPenalty)
 }
 
 // CouplingPenalty calculates the penalty for class coupling (max 20) from the

--- a/core/domain/scoring_test.go
+++ b/core/domain/scoring_test.go
@@ -38,6 +38,34 @@ func TestDuplicationPenalty(t *testing.T) {
 	}
 }
 
+func TestParseErrorPenalty(t *testing.T) {
+	if p := ParseErrorPenalty(0, 100); p != 0 {
+		t.Errorf("nothing skipped: got %d, want 0", p)
+	}
+	if p := ParseErrorPenalty(5, 0); p != 0 {
+		t.Errorf("no files at all: got %d, want 0", p)
+	}
+	// One file in a large tree rounds to zero, so the floor is what makes it cost the A.
+	if p := ParseErrorPenalty(1, 500); p != MinParseErrorPenalty {
+		t.Errorf("one skipped file: got %d, want %d", p, MinParseErrorPenalty)
+	}
+	if 100-ParseErrorPenalty(1, 500) >= GradeAThreshold {
+		t.Error("one skipped file must forfeit an A")
+	}
+	if p := ParseErrorPenalty(10, 10); p != MaxParseErrorPenalty {
+		t.Errorf("nothing parsed: got %d, want %d", p, MaxParseErrorPenalty)
+	}
+	if 100-ParseErrorPenalty(10, 10) >= GradeDThreshold {
+		t.Error("a wholly unparseable target must rank F")
+	}
+	if half, few := ParseErrorPenalty(50, 100), ParseErrorPenalty(5, 100); half <= few {
+		t.Errorf("penalty must grow with the unanalyzed fraction: %d vs %d", half, few)
+	}
+	if p := ParseErrorPenalty(20, 10); p != MaxParseErrorPenalty {
+		t.Errorf("more skipped than total: got %d, want %d (capped)", p, MaxParseErrorPenalty)
+	}
+}
+
 func TestCouplingPenalty(t *testing.T) {
 	if p := CouplingPenalty(0, 0, 0); p != 0 {
 		t.Errorf("no classes: got %d, want 0", p)

--- a/jscan/domain/analyze.go
+++ b/jscan/domain/analyze.go
@@ -60,12 +60,9 @@ const (
 	ScoreThresholdFair      = coredomain.ScoreThresholdFair
 	// Poor: 0-59 (below ScoreThresholdFair)
 
-	// Files that fail to parse are absent from every metric, so without a
-	// penalty they score better than working code. The bounds are anchored to
-	// the grade thresholds: a single unanalyzable file forfeits an A, and a
-	// target where nothing parses cannot rank above F.
-	MinParseErrorPenalty = 100 - coredomain.GradeAThreshold + 1
-	MaxParseErrorPenalty = 100 - coredomain.GradeDThreshold + 1
+	// Parse-error penalty bounds
+	MinParseErrorPenalty = coredomain.MinParseErrorPenalty
+	MaxParseErrorPenalty = coredomain.MaxParseErrorPenalty
 
 	// Other constants
 	MinimumScore                = coredomain.MinimumScore
@@ -238,17 +235,9 @@ func (s *AnalyzeSummary) Validate() error {
 }
 
 // calculateParseErrorPenalty charges the health score for files that could not
-// be analyzed at all. Such a file yields no functions, no dead code, no clones
-// and no coupling, so without this term corrupting a file raises the score.
-// The penalty grows with the unanalyzed fraction and never drops below
-// MinParseErrorPenalty, so one broken file in a large tree still costs a grade.
+// be analyzed at all (max MaxParseErrorPenalty)
 func (s *AnalyzeSummary) calculateParseErrorPenalty() int {
-	if s.SkippedFiles <= 0 || s.TotalFiles <= 0 {
-		return 0
-	}
-
-	ratio := float64(s.SkippedFiles) / float64(s.TotalFiles)
-	return max(int(math.Round(ratio*float64(MaxParseErrorPenalty))), MinParseErrorPenalty)
+	return coredomain.ParseErrorPenalty(s.SkippedFiles, s.TotalFiles)
 }
 
 // calculateComplexityPenalty calculates the penalty for complexity (max 20)


### PR DESCRIPTION
Closes #57.

`calculateParseErrorPenalty` was language-independent scoring policy duplicated in jscan and pyscn: its bounds come from `coredomain.GradeAThreshold`/`GradeDThreshold`, so one skipped file forfeits an A and a wholly unparseable target cannot rank above F.

- `core/domain`: adds `ParseErrorPenalty(skippedFiles, totalFiles)` plus `MinParseErrorPenalty`/`MaxParseErrorPenalty`. It also clamps a skipped count above the total, so the documented maximum holds for any input (neither tool can reach that — both validate the counts first).
- `jscan/domain`: the method and constants are now thin wrappers over core, matching the other penalty calculators. No score changes.

pyscn adopts this in its own repo once a `core/vX.Y.Z` tag is published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)