### PR TITLE
fix(jscan): detect dynamic import() calls (#58)

### DIFF
--- a/jscan/internal/analyzer/dependency_graph_test.go
+++ b/jscan/internal/analyzer/dependency_graph_test.go
@@ -113,18 +113,11 @@ const module = await import('./dynamic-module');
 
 	edges := graph.GetOutgoingEdges("/src/app.js")
 
-	// Dynamic imports may or may not be detected depending on tree-sitter grammar
-	// If detected, verify edge type is set correctly
-	for _, edge := range edges {
-		if edge.EdgeType == domain.EdgeTypeDynamic {
-			// Dynamic edge found, test passes
-			return
-		}
+	if len(edges) != 1 {
+		t.Fatalf("Expected 1 edge, got %d", len(edges))
 	}
-
-	// If no edges at all, check if module analyzer detected any imports
-	if len(moduleInfo.Imports) == 0 {
-		t.Skip("Dynamic imports not detected by parser - this is parser-dependent")
+	if edges[0].EdgeType != domain.EdgeTypeDynamic {
+		t.Errorf("Expected edge type %q, got %q", domain.EdgeTypeDynamic, edges[0].EdgeType)
 	}
 }
 

--- a/jscan/internal/analyzer/module_analyzer.go
+++ b/jscan/internal/analyzer/module_analyzer.go
@@ -217,13 +217,18 @@ func (ma *ModuleAnalyzer) extractImports(ast *parser.Node, info *domain.ModuleIn
 	})
 }
 
-// nodeLocationKey creates a unique key for a node based on its location
+// nodeLocationKey creates a unique key for a node based on its location.
+// The end position is part of the key because nested nodes of the same type
+// can share a start position, as in `import('./m.js').then(...)` where the
+// dynamic import and the `.then()` call are both call expressions starting at
+// the same offset.
 func nodeLocationKey(node *parser.Node) string {
 	if node == nil {
 		return ""
 	}
-	return fmt.Sprintf("%s:%s:%d:%d", node.Type, node.Location.File,
-		node.Location.StartLine, node.Location.StartCol)
+	return fmt.Sprintf("%s:%s:%d:%d:%d:%d", node.Type, node.Location.File,
+		node.Location.StartLine, node.Location.StartCol,
+		node.Location.EndLine, node.Location.EndCol)
 }
 
 // extractExports walks the AST and extracts all export statements
@@ -347,16 +352,11 @@ func (ma *ModuleAnalyzer) processImportDeclaration(node *parser.Node) *domain.Im
 
 // processDynamicImport checks if a call expression is a dynamic import
 func (ma *ModuleAnalyzer) processDynamicImport(node *parser.Node) *domain.Import {
-	if node.Callee == nil {
+	if node.Callee == nil || node.Callee.Type != parser.NodeImport {
 		return nil
 	}
 
-	// Check if callee is 'import' (dynamic import)
-	// Tree-sitter may represent it as an identifier or use Raw
-	isImportCall := (node.Callee.Type == parser.NodeIdentifier && node.Callee.Name == "import") ||
-		node.Callee.Raw == "import"
-
-	if !isImportCall || len(node.Arguments) == 0 {
+	if len(node.Arguments) == 0 {
 		return nil
 	}
 
@@ -523,6 +523,18 @@ func (ma *ModuleAnalyzer) extractSourceValue(node *parser.Node) string {
 
 	// The source is typically a string literal
 	switch node.Type {
+	case parser.NodeTemplateLiteral:
+		// Only a template without substitutions names a fixed module; anything
+		// interpolated is not statically resolvable.
+		raw := node.Raw
+		if strings.Contains(raw, "${") {
+			return ""
+		}
+		if len(raw) >= 2 && raw[0] == '`' && raw[len(raw)-1] == '`' {
+			return raw[1 : len(raw)-1]
+		}
+		return ""
+
 	case parser.NodeStringLiteral, parser.NodeLiteral:
 		// Remove quotes from the raw value
 		raw := node.Raw

--- a/jscan/internal/analyzer/module_analyzer_test.go
+++ b/jscan/internal/analyzer/module_analyzer_test.go
@@ -263,22 +263,107 @@ func TestDynamicImport(t *testing.T) {
 		t.Fatalf("Failed to analyze: %v", err)
 	}
 
-	// Dynamic imports may or may not be detected depending on tree-sitter grammar
-	// We check that if detected, it has correct properties
-	for _, imp := range info.Imports {
-		if imp.IsDynamic {
-			if imp.ImportType != domain.ImportTypeDynamic {
-				t.Errorf("Expected import type 'dynamic', got %v", imp.ImportType)
-			}
-			if imp.Source != "./lazy-module" {
-				t.Errorf("Expected source './lazy-module', got %q", imp.Source)
-			}
-			return // Found and validated
-		}
+	if len(info.Imports) != 1 {
+		t.Fatalf("Expected 1 import, got %d", len(info.Imports))
 	}
-	// Note: Dynamic import detection depends on tree-sitter grammar
-	// If not detected, this is acceptable for now
-	t.Log("Dynamic import not detected (tree-sitter grammar limitation)")
+
+	imp := info.Imports[0]
+	if !imp.IsDynamic {
+		t.Error("Expected import to be dynamic")
+	}
+	if imp.ImportType != domain.ImportTypeDynamic {
+		t.Errorf("Expected import type 'dynamic', got %v", imp.ImportType)
+	}
+	if imp.Source != "./lazy-module" {
+		t.Errorf("Expected source './lazy-module', got %q", imp.Source)
+	}
+	if imp.SourceType != domain.ModuleTypeRelative {
+		t.Errorf("Expected source type 'relative', got %v", imp.SourceType)
+	}
+}
+
+func TestDynamicImportForms(t *testing.T) {
+	tests := []struct {
+		name   string
+		source string
+		want   []string
+	}{
+		{
+			name:   "awaited",
+			source: "async function load() { return await import('./awaited.js'); }",
+			want:   []string{"./awaited.js"},
+		},
+		{
+			name:   "returned from exported function",
+			source: "export function b() { return import('./returned.js'); }",
+			want:   []string{"./returned.js"},
+		},
+		{
+			name:   "chained with then",
+			source: "import('./chained.js').then(m => m.run());",
+			want:   []string{"./chained.js"},
+		},
+		{
+			name:   "template literal without substitution",
+			source: "const m = import(`./template.js`);",
+			want:   []string{"./template.js"},
+		},
+		{
+			name:   "template literal with substitution is not resolvable",
+			source: "const m = import(`./locales/${lang}.js`);",
+			want:   nil,
+		},
+		{
+			name:   "package specifier",
+			source: "const m = import('lodash');",
+			want:   []string{"lodash"},
+		},
+		{
+			name:   "several in one file",
+			source: "import('./one.js');\nimport('./two.js').catch(() => {});\n",
+			want:   []string{"./one.js", "./two.js"},
+		},
+		{
+			name:   "import.meta is not an import",
+			source: "const url = import.meta.url;",
+			want:   nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			p := parser.NewParser()
+			defer p.Close()
+
+			ast, err := p.ParseString(tt.source)
+			if err != nil {
+				t.Fatalf("Failed to parse: %v", err)
+			}
+
+			analyzer := NewModuleAnalyzer(DefaultModuleAnalyzerConfig())
+			info, err := analyzer.AnalyzeFile(ast, "test.js")
+			if err != nil {
+				t.Fatalf("Failed to analyze: %v", err)
+			}
+
+			var got []string
+			for _, imp := range info.Imports {
+				if !imp.IsDynamic {
+					t.Errorf("Expected every detected import to be dynamic, got %v for %q", imp.ImportType, imp.Source)
+				}
+				got = append(got, imp.Source)
+			}
+
+			if len(got) != len(tt.want) {
+				t.Fatalf("Expected sources %v, got %v", tt.want, got)
+			}
+			for i, want := range tt.want {
+				if got[i] != want {
+					t.Errorf("Expected source %q at index %d, got %q", want, i, got[i])
+				}
+			}
+		})
+	}
 }
 
 func TestExportNamedDeclaration(t *testing.T) {

--- a/jscan/internal/parser/ast.go
+++ b/jscan/internal/parser/ast.go
@@ -77,6 +77,9 @@ const (
 	NodeProperty         NodeType = "Property"
 
 	// Module system (ESM)
+	// NodeImport is the `import` keyword used as an expression, either as the
+	// callee of a dynamic import call or as the object of `import.meta`.
+	NodeImport                   NodeType = "Import"
 	NodeImportDeclaration        NodeType = "ImportDeclaration"
 	NodeImportSpecifier          NodeType = "ImportSpecifier"
 	NodeImportDefaultSpecifier   NodeType = "ImportDefaultSpecifier"

--- a/jscan/internal/parser/ast_builder.go
+++ b/jscan/internal/parser/ast_builder.go
@@ -126,6 +126,15 @@ func (b *ASTBuilder) buildNode(tsNode *sitter.Node) *Node {
 		return b.buildIdentifier(tsNode)
 	case "string", "number", "true", "false", "null":
 		return b.buildLiteral(tsNode)
+	case "template_string":
+		return b.buildTemplateLiteral(tsNode)
+	case "import":
+		// The `import` keyword in expression position: `import('./m.js')` or
+		// `import.meta`. Tree-sitter nests a second `import` token inside it,
+		// which carries no extra information.
+		node := NewNode(NodeImport)
+		node.Location = b.getLocation(tsNode)
+		return node
 	case "import_statement":
 		return b.buildImportStatement(tsNode)
 	case "export_statement":
@@ -917,6 +926,27 @@ func (b *ASTBuilder) buildLiteral(tsNode *sitter.Node) *Node {
 		node.Type = NodeBooleanLiteral
 	case "null":
 		node.Type = NodeNullLiteral
+	}
+
+	return node
+}
+
+// buildTemplateLiteral builds a template literal node. Raw keeps the whole
+// literal, backticks included, so callers can tell a fixed template apart from
+// one with substitutions; children keep the interpolated expressions walkable.
+func (b *ASTBuilder) buildTemplateLiteral(tsNode *sitter.Node) *Node {
+	node := NewNode(NodeTemplateLiteral)
+	node.Location = b.getLocation(tsNode)
+	node.Raw = tsNode.Content(b.source)
+
+	for i := 0; i < int(tsNode.ChildCount()); i++ {
+		child := tsNode.Child(i)
+		if child != nil && !b.isTrivia(child) {
+			childNode := b.buildNode(child)
+			if childNode != nil {
+				node.AddChild(childNode)
+			}
+		}
 	}
 
 	return node

--- a/jscan/internal/parser/parser_test.go
+++ b/jscan/internal/parser/parser_test.go
@@ -786,18 +786,55 @@ func TestParseTemplateLiteral(t *testing.T) {
 		t.Fatalf("Parse failed: %v", err)
 	}
 
-	// Template literals may be parsed as various node types
-	found := false
+	var template *Node
 	ast.Walk(func(n *Node) bool {
 		if n.Type == NodeTemplateLiteral {
-			found = true
+			template = n
 			return false
 		}
 		return true
 	})
 
-	// Template literal parsing verified - specific node type may vary
-	t.Logf("Template literal node found: %v (node types may vary)", found)
+	if template == nil {
+		t.Fatal("Expected a template literal node")
+	}
+	if template.Raw != "`Hello, ${name}!`" {
+		t.Errorf("Expected raw to keep the whole literal, got %q", template.Raw)
+	}
+}
+
+func TestParseDynamicImportCallee(t *testing.T) {
+	code := "const m = import('./lazy.js');"
+
+	parser := NewParser()
+	defer parser.Close()
+
+	ast, err := parser.ParseString(code)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	var call *Node
+	ast.Walk(func(n *Node) bool {
+		if n.Type == NodeCallExpression {
+			call = n
+			return false
+		}
+		return true
+	})
+
+	if call == nil {
+		t.Fatal("Expected a call expression node")
+	}
+	if call.Callee == nil || call.Callee.Type != NodeImport {
+		t.Fatalf("Expected callee of type %q, got %v", NodeImport, call.Callee)
+	}
+	if len(call.Arguments) != 1 {
+		t.Fatalf("Expected 1 argument, got %d", len(call.Arguments))
+	}
+	if call.Arguments[0].Raw != "'./lazy.js'" {
+		t.Errorf("Expected argument raw \"'./lazy.js'\", got %q", call.Arguments[0].Raw)
+	}
 }
 
 // AST Node tests


### PR DESCRIPTION
`ModuleAnalyzer.processDynamicImport` never fired, so no `EdgeTypeDynamic` edge was ever built and both the lazy-edge exclusion in circular detection and the load-time depth and chain metrics were unreachable end to end.

Three fixes:

- The AST builder left the `import` keyword of a dynamic import as a generic node. It is now built as a dedicated `Import` node, which `processDynamicImport` matches.
- `nodeLocationKey` keyed only on the start position, so in `import('./m.js').then(...)` the inner call shared a key with the outer one and was skipped as a duplicate. The key now includes the end position.
- A template literal argument built as a generic node carried no text, so ``import(`./m.js`)`` resolved to an empty source. Template literals are now built as `TemplateLiteral` nodes keeping their raw text; a template with substitutions resolves to no source because it names no fixed module.

The skipped test in `dependency_graph_test.go` now asserts a dynamic edge, and `TestDynamicImport` no longer passes when nothing is detected.

Fixes #58