### PR TITLE
fix(jscan): name unresolved modules from their resolved ID

### DIFF
--- a/jscan/internal/analyzer/dependency_graph.go
+++ b/jscan/internal/analyzer/dependency_graph.go
@@ -90,7 +90,7 @@ func (b *DependencyGraphBuilder) BuildGraph(moduleResult *domain.ModuleAnalysisR
 				// Ensure target node exists (for external or unresolved modules)
 				toID := edge.To
 				if graph.GetNode(toID) == nil {
-					externalNode := b.createExternalNode(toID, imp.Source, imp.SourceType)
+					externalNode := b.createExternalNode(toID, imp.SourceType)
 					graph.AddNode(externalNode)
 				}
 				graph.AddEdge(edge)
@@ -125,16 +125,21 @@ func (b *DependencyGraphBuilder) normalizeModuleID(filePath string) string {
 	return filepath.ToSlash(filePath)
 }
 
-// createModuleNode creates a ModuleNode from file path and module info
-func (b *DependencyGraphBuilder) createModuleNode(filePath string, info *domain.ModuleInfo) *domain.ModuleNode {
-	id := b.normalizeModuleID(filePath)
-	name := filepath.Base(filePath)
-
-	// Remove extension for the name
+// moduleDisplayName derives a module name from a path: the base name without
+// its extension
+func moduleDisplayName(path string) string {
+	name := filepath.Base(path)
 	ext := filepath.Ext(name)
 	if ext != "" {
 		name = strings.TrimSuffix(name, ext)
 	}
+	return name
+}
+
+// createModuleNode creates a ModuleNode from file path and module info
+func (b *DependencyGraphBuilder) createModuleNode(filePath string, info *domain.ModuleInfo) *domain.ModuleNode {
+	id := b.normalizeModuleID(filePath)
+	name := moduleDisplayName(filePath)
 
 	// Extract export names
 	var exports []string
@@ -159,11 +164,21 @@ func (b *DependencyGraphBuilder) createModuleNode(filePath string, info *domain.
 	}
 }
 
-// createExternalNode creates a ModuleNode for an external/unresolved module
-func (b *DependencyGraphBuilder) createExternalNode(id, source string, moduleType domain.ModuleType) *domain.ModuleNode {
+// createExternalNode creates a ModuleNode for an external/unresolved module.
+// The name comes from the resolved ID, not from the importing file's specifier:
+// several files can reach the same unresolved module through different relative
+// specifiers, and the first importer visited depends on map iteration order.
+func (b *DependencyGraphBuilder) createExternalNode(id string, moduleType domain.ModuleType) *domain.ModuleNode {
+	name := id
+	switch moduleType {
+	case domain.ModuleTypeRelative, domain.ModuleTypeAbsolute:
+		// These IDs are paths, so show the file name like project nodes do.
+		name = moduleDisplayName(id)
+	}
+
 	return &domain.ModuleNode{
 		ID:         id,
-		Name:       source,
+		Name:       name,
 		FilePath:   "",
 		ModuleType: moduleType,
 		IsExternal: true,

--- a/jscan/internal/analyzer/dependency_graph_test.go
+++ b/jscan/internal/analyzer/dependency_graph_test.go
@@ -578,6 +578,77 @@ func TestBuildGraphWithExtensionlessImports(t *testing.T) {
 	}
 }
 
+func TestBuildGraphNamesUnresolvedModuleFromItsID(t *testing.T) {
+	// Two files reach the same unresolved module through different relative
+	// specifiers. The node name must not depend on which importer the map
+	// iteration visits first.
+	moduleResult := &domain.ModuleAnalysisResult{
+		Files: map[string]*domain.ModuleInfo{
+			"/project/lib/app.js": {
+				Imports: []*domain.Import{
+					{
+						Source:     "./missing/public",
+						SourceType: domain.ModuleTypeRelative,
+					},
+				},
+			},
+			"/project/lib/missing/router.js": {
+				Imports: []*domain.Import{
+					{
+						Source:     "./public",
+						SourceType: domain.ModuleTypeRelative,
+					},
+				},
+			},
+		},
+	}
+
+	config := DefaultDependencyGraphBuilderConfig()
+	config.ProjectRoot = "/project"
+	builder := NewDependencyGraphBuilder(config)
+
+	for range 50 {
+		graph := builder.BuildGraph(moduleResult)
+
+		node := graph.GetNode("lib/missing/public")
+		if node == nil {
+			t.Fatal("Expected an unresolved node for lib/missing/public")
+		}
+		if node.Name != "public" {
+			t.Fatalf("Expected name %q, got %q", "public", node.Name)
+		}
+	}
+}
+
+func TestBuildGraphNamesUnresolvedPackageFromItsSource(t *testing.T) {
+	moduleResult := &domain.ModuleAnalysisResult{
+		Files: map[string]*domain.ModuleInfo{
+			"/project/lib/app.js": {
+				Imports: []*domain.Import{
+					{
+						Source:     "@scope/pkg/sub",
+						SourceType: domain.ModuleTypePackage,
+					},
+				},
+			},
+		},
+	}
+
+	config := DefaultDependencyGraphBuilderConfig()
+	config.ProjectRoot = "/project"
+	config.IncludeExternal = true
+	builder := NewDependencyGraphBuilder(config)
+	graph := builder.BuildGraph(moduleResult)
+
+	node := graph.GetNode("@scope/pkg/sub")
+	if node == nil {
+		t.Fatal("Expected an external node for @scope/pkg/sub")
+	}
+	if node.Name != "@scope/pkg/sub" {
+		t.Errorf("Expected name %q, got %q", "@scope/pkg/sub", node.Name)
+	}
+}
+
 func TestBuildGraphFromASTs(t *testing.T) {
 	source := `
 import { helper } from './helper';


### PR DESCRIPTION
Fixes #60.

`DependencyGraphBuilder.BuildGraph` iterates a map to create edges, so a node created for an unresolved import took its `name` from whichever importer the iteration reached first. When several files import the same unresolved module through different relative specifiers, the name changed between runs.

The name now comes from the resolved node ID: the base name without extension for path-like IDs (relative, absolute), and the source itself for packages, builtins, and aliases, where the ID already is the source.

Verified on `opencode/packages/opencode/src`: `jscan deps --format json` output is now identical across runs except for `generated_at`, and the node from the issue reports `name: "public"` every time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)