### PR TITLE
docs: add polyscan for GitHub section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,17 @@ Every analyzer scores your codebase (0-100 with an A-F grade) and generates an H
 
 **Built with Go + tree-sitter** — fast enough to run on every commit.
 
+## polyscan for GitHub
+
+Want this running continuously? The polyscan GitHub App runs the same analyzers on your repositories automatically:
+
+- 📅 **Weekly code audit** — scores the entire codebase once a week and files the report as a GitHub Issue (free while in beta)
+- 🔍 **PR code review** — on every pull request, analyzes the changed files with the static analyzers and posts AI-generated improvement suggestions (Pro)
+
+Unlike diff-only review bots, reports are grounded in the quantitative metrics above — complexity, clones, dead code, dependencies. Configured with a single YAML file: report language (en / ja / zh / ko / es / fr / de / pt), target directories, and audit interval.
+
+**[Get started at codescan.dev →](https://codescan.dev/pyscn-bot)**
+
 ## AI Agent Integration
 
 The analyzers ship Agent Skills that teach AI coding agents when and how to run each analysis: health checks, refactoring, architecture review, and CI-friendly reports.

--- a/README.md
+++ b/README.md
@@ -45,9 +45,9 @@ Every analyzer scores your codebase (0-100 with an A-F grade) and generates an H
 
 **Built with Go + tree-sitter** — fast enough to run on every commit.
 
-## polyscan for GitHub
+## Polyscan for GitHub
 
-Want this running continuously? The polyscan GitHub App runs the same analyzers on your repositories automatically:
+Want this running continuously? The Polyscan App runs the same analyzers on your repositories automatically:
 
 - 📅 **Weekly code audit** — scores the entire codebase once a week and files the report as a GitHub Issue (free while in beta)
 - 🔍 **PR code review** — on every pull request, analyzes the changed files with the static analyzers and posts AI-generated improvement suggestions (Pro)


### PR DESCRIPTION
Adds a hosted-service section between "What You Get" and "AI Agent Integration": weekly audit + PR review, grounded-in-metrics differentiator, and a CTA to codescan.dev/pyscn-bot.

Part of unifying the service under the polyscan name and making this repo the funnel. The CTA link goes through the landing page (not `apps/pyscn-bot`) so it survives the upcoming GitHub App rename.

🤖 Generated with [Claude Code](https://claude.com/claude-code)