### PR TITLE
feat(polyscan): add clone detection for Go

### DIFF
--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -49,7 +49,7 @@ Risk levels use the thresholds shared by every polyscan analyzer: low up to 9, m
 
 ## Clone detection
 
-Every function of at least 10 lines and 20 syntax nodes is a fragment. Fragments are compared with the APTED tree edit distance over a tree of named syntax nodes, with comments dropped and identifiers, literals and operators carried in the node labels. Pairs are classified the way pyscn and jscan classify them:
+Every function of at least 10 lines of code (blank lines and comments excluded) and 20 syntax nodes is a fragment. Fragments are compared with the APTED tree edit distance over a tree of named syntax nodes, with comments dropped and identifiers, literals and operators carried in the node labels. Pairs are classified the way pyscn and jscan classify them:
 
 | Type | Meaning | Reported when |
 | --- | --- | --- |
@@ -59,7 +59,7 @@ Every function of at least 10 lines and 20 syntax nodes is a fragment. Fragments
 
 Pairs below 0.70 are not reported. Test files (`*_test.go`) are analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs.
 
-Pairs are merged into groups by connected components, and the groups are deduplicated by the shared `core/clone` passes. When there are more than 10,000 candidate pairs, an LSH index over MinHash signatures selects the pairs to compare.
+Pairs are merged into groups by connected components, and the groups are deduplicated by the shared `core/clone` passes. When there are more than 10,000 candidate pairs, only pairs that share a MinHash band are compared, and within a band each function is compared with at most 1,024 of the functions that follow it. Neighbours in a band are always compared, so a large set of near-identical functions still ends up in one group.
 
 ## Adding a language
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-A multi-language code quality analyzer. It detects the language of each file by its extension and currently measures cyclomatic complexity for Go.
+A multi-language code quality analyzer. It detects the language of each file by its extension and currently measures cyclomatic complexity and detects code clones for Go.
 
 ## Installation
 
@@ -23,6 +23,9 @@ polyscan analyze .
 # JSON report to stdout
 polyscan analyze --format json src/
 
+# Clone detection only
+polyscan analyze --select clone .
+
 # List only functions with complexity 10 or higher; the summary still covers every function
 polyscan analyze --min-complexity 10 .
 ```
@@ -44,12 +47,27 @@ Function literals are not reported on their own. Their decision points count tow
 
 Risk levels use the thresholds shared by every polyscan analyzer: low up to 9, medium up to 19, high from 20.
 
+## Clone detection
+
+Every function of at least 10 lines and 20 syntax nodes is a fragment. Fragments are compared with the APTED tree edit distance over a tree of named syntax nodes, with comments dropped and identifiers, literals and operators carried in the node labels. Pairs are classified the way pyscn and jscan classify them:
+
+| Type | Meaning | Reported when |
+| --- | --- | --- |
+| Type-1 | Exact copy apart from whitespace and comments | Similarity ≥ 0.85 and identical text |
+| Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
+| Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
+
+Pairs below 0.70 are not reported. Test files (`*_test.go`) are analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs.
+
+Pairs are merged into groups by connected components, and the groups are deduplicated by the shared `core/clone` passes. When there are more than 10,000 candidate pairs, an LSH index over MinHash signatures selects the pairs to compare.
+
 ## Adding a language
 
 A language is declarative: a tree-sitter grammar and two queries. See `internal/lang/golang/golang.go`.
 
 - The definitions query matches each function once. `@definition.<kind>` spans the function, `@name` its name, and an optional `@receiver` is prefixed to the name. The bundled `queries/tags.scm` of a grammar is the starting point.
 - In the decisions query every capture is one decision point, attributed to the innermost function that contains it and reported under the capture's name.
+- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names the test file globs to exclude from clone detection.
 
 ## Development
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -84,5 +84,8 @@ func parseSelection(selected []string) (analysis.Options, error) {
 			return options, fmt.Errorf("invalid analysis %q, must be one of: complexity, clone", name)
 		}
 	}
+	if !options.Complexity && !options.Clones {
+		return options, fmt.Errorf("no analysis selected")
+	}
 	return options, nil
 }

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -11,8 +11,14 @@ import (
 	"github.com/spf13/cobra"
 )
 
+const (
+	selectComplexity = "complexity"
+	selectClone      = "clone"
+)
+
 func analyzeCmd() *cobra.Command {
 	var (
+		selected      []string
 		format        string
 		minComplexity int
 	)
@@ -20,13 +26,14 @@ func analyzeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "analyze [path...]",
 		Short: "Analyze source files",
-		Long: `Analyze source files for cyclomatic complexity.
+		Long: `Analyze source files for cyclomatic complexity and code clones.
 
 The language of each file is detected from its extension. Supported: Go.
 
 Examples:
   polyscan analyze .                        # Text report to stdout
   polyscan analyze --format json src/       # JSON report to stdout
+  polyscan analyze --select clone .         # Clone detection only
   polyscan analyze --min-complexity 10 .    # List only functions at or above 10`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
@@ -37,9 +44,13 @@ Examples:
 			if minComplexity < 1 {
 				return fmt.Errorf("--min-complexity must be at least 1")
 			}
+			options, err := parseSelection(selected)
+			if err != nil {
+				return err
+			}
 
 			start := time.Now()
-			result, err := analysis.Analyze(args)
+			result, err := analysis.Analyze(args, options)
 			if err != nil {
 				return err
 			}
@@ -48,13 +59,30 @@ Examples:
 				Version:       version.Version,
 				GeneratedAt:   start,
 				DurationMs:    time.Since(start).Milliseconds(),
-				Complexity:    result,
+				Report:        result,
 				MinComplexity: minComplexity,
 			}, outputFormat)
 		},
 	}
 
+	cmd.Flags().StringSliceVarP(&selected, "select", "s", []string{selectComplexity, selectClone},
+		"Analyses to run (comma-separated): complexity,clone")
 	cmd.Flags().StringVarP(&format, "format", "f", "text", "Output format: text, json")
 	cmd.Flags().IntVar(&minComplexity, "min-complexity", 1, "List only functions with at least this complexity")
 	return cmd
+}
+
+func parseSelection(selected []string) (analysis.Options, error) {
+	var options analysis.Options
+	for _, name := range selected {
+		switch name {
+		case selectComplexity:
+			options.Complexity = true
+		case selectClone:
+			options.Clones = true
+		default:
+			return options, fmt.Errorf("invalid analysis %q, must be one of: complexity, clone", name)
+		}
+	}
+	return options, nil
 }

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -39,14 +39,28 @@ func TestAnalyzeJSON(t *testing.T) {
 	if err := json.Unmarshal([]byte(out), &doc); err != nil {
 		t.Fatalf("invalid JSON: %v\n%s", err, out)
 	}
-	if len(doc.Complexity.Functions) != 2 || doc.Complexity.Summary.TotalFunctions != 6 || doc.Complexity.Summary.SkippedFiles != 0 {
-		t.Errorf("listed %d functions of %d, want 2 of 6", len(doc.Complexity.Functions), doc.Complexity.Summary.TotalFunctions)
+	if len(doc.Complexity.Functions) != 3 || doc.Complexity.Summary.TotalFunctions != 10 || doc.Files.Skipped != 0 {
+		t.Errorf("listed %d functions of %d, want 3 of 10", len(doc.Complexity.Functions), doc.Complexity.Summary.TotalFunctions)
+	}
+	if doc.Clones == nil || doc.Clones.Statistics.TotalClonePairs != 3 {
+		t.Errorf("clones = %+v, want 3 pairs", doc.Clones)
+	}
+}
+
+func TestAnalyzeSelect(t *testing.T) {
+	out, err := run(t, "analyze", "--select", "clone", "../../testdata/go/clones")
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "Complexity Analysis") || !strings.Contains(out, "Clone Detection") {
+		t.Errorf("unexpected output:\n%s", out)
 	}
 }
 
 func TestAnalyzeRejectsBadArguments(t *testing.T) {
 	for _, args := range [][]string{
 		{"analyze"},
+		{"analyze", "--select", "deadcode", "../../testdata/go"},
 		{"analyze", "--format", "html", "../../testdata/go"},
 		{"analyze", "--min-complexity", "0", "../../testdata/go"},
 		{"analyze", "does-not-exist"},

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -61,6 +61,7 @@ func TestAnalyzeRejectsBadArguments(t *testing.T) {
 	for _, args := range [][]string{
 		{"analyze"},
 		{"analyze", "--select", "deadcode", "../../testdata/go"},
+		{"analyze", "--select=", "../../testdata/go"},
 		{"analyze", "--format", "html", "../../testdata/go"},
 		{"analyze", "--min-complexity", "0", "../../testdata/go"},
 		{"analyze", "does-not-exist"},

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -10,8 +10,16 @@ import (
 
 	"github.com/ludo-technologies/polyscan/core/domain"
 	"github.com/ludo-technologies/polyscan/core/source"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang"
 )
+
+// Options selects the analyses to run.
+type Options struct {
+	Complexity bool
+	Clones     bool
+}
 
 // Function is the complexity result for one function.
 type Function struct {
@@ -29,39 +37,48 @@ type Function struct {
 	RiskLevel domain.RiskLevel `json:"risk_level"`
 }
 
-// Summary aggregates every analyzed function. Report filters only limit
-// which functions are listed; they never change these numbers.
-type Summary struct {
+// ComplexitySummary aggregates every analyzed function. Report filters only
+// limit which functions are listed; they never change these numbers.
+type ComplexitySummary struct {
 	TotalFunctions    int     `json:"total_functions"`
 	AverageComplexity float64 `json:"average_complexity"`
 	MaxComplexity     int     `json:"max_complexity"`
 	MinComplexity     int     `json:"min_complexity"`
-	// FilesAnalyzed counts the files that parsed and contributed to the
-	// metrics. TotalFiles counts every file the request covered, and
-	// SkippedFiles the ones that could not be read or parsed. Skipped files
-	// are absent from every metric here.
-	FilesAnalyzed int `json:"files_analyzed"`
-	TotalFiles    int `json:"total_files"`
-	SkippedFiles  int `json:"skipped_files"`
 
 	LowRiskFunctions    int `json:"low_risk_functions"`
 	MediumRiskFunctions int `json:"medium_risk_functions"`
 	HighRiskFunctions   int `json:"high_risk_functions"`
 }
 
-// Report is the complete complexity analysis of a set of paths.
-type Report struct {
+// Complexity is the complexity analysis of a set of paths.
+type Complexity struct {
 	// Functions is sorted by descending complexity, then by location.
-	Functions []Function `json:"functions"`
-	Summary   Summary    `json:"summary"`
+	Functions []Function        `json:"functions"`
+	Summary   ComplexitySummary `json:"summary"`
+}
+
+// Files counts the files a run covered. Skipped files could not be read or
+// parsed and are absent from every metric, so a consumer must read this
+// before trusting the aggregates.
+type Files struct {
+	Total    int `json:"total"`
+	Analyzed int `json:"analyzed"`
+	Skipped  int `json:"skipped"`
+}
+
+// Report is the complete analysis of a set of paths.
+type Report struct {
+	Files      Files         `json:"files"`
+	Complexity *Complexity   `json:"complexity,omitempty"`
+	Clones     *clone.Report `json:"clone,omitempty"`
 	// Errors lists, per skipped file, why it was skipped.
 	Errors []string `json:"errors,omitempty"`
 }
 
-// Analyze collects every supported source file under paths and analyzes it.
-// A file that cannot be read or parsed is skipped and reported in Errors;
-// finding no supported file at all is an error.
-func Analyze(paths []string) (*Report, error) {
+// Analyze collects every supported source file under paths and runs the
+// selected analyses on it. A file that cannot be read or parsed is skipped
+// and reported in Errors; finding no supported file at all is an error.
+func Analyze(paths []string, options Options) (*Report, error) {
 	files, err := source.CollectFiles(paths, source.FileFilter{
 		IncludePatterns: lang.IncludePatterns(),
 		Recursive:       true,
@@ -73,63 +90,114 @@ func Analyze(paths []string) (*Report, error) {
 		return nil, fmt.Errorf("no supported source files found")
 	}
 
-	report := &Report{}
-	report.Summary.TotalFiles = len(files)
+	report := &Report{Files: Files{Total: len(files)}}
+	if options.Complexity {
+		report.Complexity = &Complexity{Functions: []Function{}}
+	}
+	detectors := map[*engine.Language]*clone.Detector{}
+
 	for _, file := range files {
-		functions, err := analyzeFile(file)
+		language, ok := lang.ByPath(file)
+		if !ok {
+			// CollectFiles only returns registered extensions.
+			panic(fmt.Sprintf("no language for %s", file))
+		}
+		display := displayPath(file)
+		functions, err := analyzeFile(language, file)
 		if err != nil {
-			report.Summary.SkippedFiles++
-			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", displayPath(file), err))
+			report.Files.Skipped++
+			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", display, err))
 			continue
 		}
-		report.Summary.FilesAnalyzed++
-		report.Functions = append(report.Functions, functions...)
+		report.Files.Analyzed++
+
+		if options.Complexity {
+			for _, fn := range functions {
+				report.Complexity.Functions = append(report.Complexity.Functions, newFunction(fn, language, display))
+			}
+		}
+		if options.Clones && !source.MatchesAnyPattern(filepath.Base(file), language.TestFiles) {
+			detector, ok := detectors[language]
+			if !ok {
+				detector = clone.NewDetector(language.Clone, clone.DefaultConfig())
+				detectors[language] = detector
+			}
+			for _, fn := range functions {
+				detector.Add(fn, display)
+			}
+		}
 	}
 
-	sort.SliceStable(report.Functions, func(i, j int) bool {
-		a, b := report.Functions[i], report.Functions[j]
-		if a.Complexity != b.Complexity {
-			return a.Complexity > b.Complexity
-		}
-		if a.FilePath != b.FilePath {
-			return a.FilePath < b.FilePath
-		}
-		return a.StartLine < b.StartLine
-	})
-	summarize(report)
+	if options.Complexity {
+		sortFunctions(report.Complexity.Functions)
+		report.Complexity.Summary = summarize(report.Complexity.Functions)
+	}
+	if options.Clones {
+		report.Clones = detectClones(detectors)
+	}
 	return report, nil
 }
 
-func analyzeFile(path string) ([]Function, error) {
-	language, ok := lang.ByPath(path)
-	if !ok {
-		return nil, fmt.Errorf("unsupported file extension")
-	}
+func analyzeFile(language *engine.Language, path string) ([]engine.Function, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err
 	}
-	found, err := language.Analyze(content)
-	if err != nil {
-		return nil, err
-	}
+	return language.Analyze(content)
+}
 
-	display := displayPath(path)
-	functions := make([]Function, 0, len(found))
-	for _, fn := range found {
-		functions = append(functions, Function{
-			Name:        fn.Name,
-			FilePath:    display,
-			Language:    language.Name,
-			StartLine:   fn.StartLine,
-			StartColumn: fn.StartColumn,
-			EndLine:     fn.EndLine,
-			Complexity:  fn.Complexity,
-			Decisions:   fn.Decisions,
-			RiskLevel:   RiskLevel(fn.Complexity),
-		})
+func newFunction(fn engine.Function, language *engine.Language, display string) Function {
+	return Function{
+		Name:        fn.Name,
+		FilePath:    display,
+		Language:    language.Name,
+		StartLine:   fn.StartLine,
+		StartColumn: fn.StartColumn,
+		EndLine:     fn.EndLine,
+		Complexity:  fn.Complexity,
+		Decisions:   fn.Decisions,
+		RiskLevel:   RiskLevel(fn.Complexity),
 	}
-	return functions, nil
+}
+
+// detectClones runs every language's detector and merges the results into
+// one report. Fragments of different languages are never compared.
+func detectClones(detectors map[*engine.Language]*clone.Detector) *clone.Report {
+	merged := &clone.Report{
+		Pairs:      []clone.Pair{},
+		Groups:     []clone.Group{},
+		Statistics: clone.Statistics{ClonesByType: map[string]int{}},
+	}
+	languages := make([]*engine.Language, 0, len(detectors))
+	for language := range detectors {
+		languages = append(languages, language)
+	}
+	sort.Slice(languages, func(i, j int) bool { return languages[i].Name < languages[j].Name })
+
+	totalSimilarity := 0.0
+	for _, language := range languages {
+		report := detectors[language].Detect()
+		for _, pair := range report.Pairs {
+			pair.ID = len(merged.Pairs)
+			merged.Pairs = append(merged.Pairs, pair)
+			totalSimilarity += pair.Similarity
+		}
+		for _, group := range report.Groups {
+			group.ID = len(merged.Groups)
+			merged.Groups = append(merged.Groups, group)
+		}
+		merged.Statistics.TotalFragments += report.Statistics.TotalFragments
+		merged.Statistics.TotalClones += report.Statistics.TotalClones
+		for cloneType, count := range report.Statistics.ClonesByType {
+			merged.Statistics.ClonesByType[cloneType] += count
+		}
+	}
+	merged.Statistics.TotalClonePairs = len(merged.Pairs)
+	merged.Statistics.TotalCloneGroups = len(merged.Groups)
+	if len(merged.Pairs) > 0 {
+		merged.Statistics.AverageSimilarity = totalSimilarity / float64(len(merged.Pairs))
+	}
+	return merged
 }
 
 // RiskLevel classifies a complexity with the thresholds shared by every
@@ -145,15 +213,27 @@ func RiskLevel(complexity int) domain.RiskLevel {
 	}
 }
 
-func summarize(report *Report) {
-	summary := &report.Summary
-	summary.TotalFunctions = len(report.Functions)
-	if summary.TotalFunctions == 0 {
-		return
+func sortFunctions(functions []Function) {
+	sort.SliceStable(functions, func(i, j int) bool {
+		a, b := functions[i], functions[j]
+		if a.Complexity != b.Complexity {
+			return a.Complexity > b.Complexity
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		return a.StartLine < b.StartLine
+	})
+}
+
+func summarize(functions []Function) ComplexitySummary {
+	summary := ComplexitySummary{TotalFunctions: len(functions)}
+	if len(functions) == 0 {
+		return summary
 	}
 	total := 0
-	summary.MinComplexity = report.Functions[0].Complexity
-	for _, fn := range report.Functions {
+	summary.MinComplexity = functions[0].Complexity
+	for _, fn := range functions {
 		total += fn.Complexity
 		summary.MaxComplexity = max(summary.MaxComplexity, fn.Complexity)
 		summary.MinComplexity = min(summary.MinComplexity, fn.Complexity)
@@ -166,7 +246,8 @@ func summarize(report *Report) {
 			summary.HighRiskFunctions++
 		}
 	}
-	summary.AverageComplexity = float64(total) / float64(summary.TotalFunctions)
+	summary.AverageComplexity = float64(total) / float64(len(functions))
+	return summary
 }
 
 // displayPath shortens an absolute path to one relative to the working

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -28,19 +28,23 @@ func fixtures(t *testing.T) string {
 	return dir
 }
 
-func TestAnalyzeTestdata(t *testing.T) {
-	report, err := Analyze([]string{fixtures(t)})
+func TestAnalyzeComplexity(t *testing.T) {
+	report, err := Analyze([]string{fixtures(t)}, Options{Complexity: true})
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
 
-	summary := report.Summary
-	if summary.TotalFiles != 2 || summary.FilesAnalyzed != 1 || summary.SkippedFiles != 1 {
-		t.Errorf("files: total=%d analyzed=%d skipped=%d, want 2/1/1", summary.TotalFiles, summary.FilesAnalyzed, summary.SkippedFiles)
+	if report.Files != (Files{Total: 2, Analyzed: 1, Skipped: 1}) {
+		t.Errorf("files = %+v, want 2/1/1", report.Files)
 	}
 	if len(report.Errors) != 1 || !strings.Contains(report.Errors[0], "broken.go: syntax error") {
 		t.Errorf("errors = %v, want the broken file's syntax error", report.Errors)
 	}
+	if report.Clones != nil {
+		t.Error("clones were not selected but are present")
+	}
+
+	summary := report.Complexity.Summary
 	if summary.TotalFunctions != 6 || summary.MaxComplexity != 8 || summary.MinComplexity != 1 {
 		t.Errorf("summary = %+v", summary)
 	}
@@ -48,22 +52,53 @@ func TestAnalyzeTestdata(t *testing.T) {
 		t.Errorf("risk distribution = %d/%d/%d, want 6/0/0", summary.LowRiskFunctions, summary.MediumRiskFunctions, summary.HighRiskFunctions)
 	}
 
-	first := report.Functions[0]
+	functions := report.Complexity.Functions
+	first := functions[0]
 	if first.Name != "Server.Handle" || first.Complexity != 8 {
 		t.Errorf("first function = %s (%d), want Server.Handle (8)", first.Name, first.Complexity)
 	}
 	if first.Language != "Go" || filepath.Base(first.FilePath) != "sample.go" {
 		t.Errorf("first function language=%q path=%q", first.Language, first.FilePath)
 	}
-	for i := 1; i < len(report.Functions); i++ {
-		if report.Functions[i].Complexity > report.Functions[i-1].Complexity {
+	for i := 1; i < len(functions); i++ {
+		if functions[i].Complexity > functions[i-1].Complexity {
 			t.Errorf("functions are not sorted by descending complexity at %d", i)
 		}
 	}
 }
 
+func TestAnalyzeClones(t *testing.T) {
+	report, err := Analyze([]string{"../../testdata/go/clones"}, Options{Clones: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Complexity != nil {
+		t.Error("complexity was not selected but is present")
+	}
+
+	// sum_test.go holds a third copy but test files are not compared.
+	stats := report.Clones.Statistics
+	if stats.TotalFragments != 3 || stats.TotalClonePairs != 3 || stats.TotalCloneGroups != 1 || stats.TotalClones != 3 {
+		t.Errorf("statistics = %+v", stats)
+	}
+	if stats.ClonesByType["Type-1"] != 1 {
+		t.Errorf("clones by type = %v, want one Type-1 pair for the exact copy", stats.ClonesByType)
+	}
+
+	exact := report.Clones.Pairs[0]
+	if exact.Type != domain.Type1Clone || exact.Fragment1.Name != "SumPositive" || exact.Fragment2.Name != "SumPositive" {
+		t.Errorf("strongest pair = %+v, want the Type-1 SumPositive pair", exact)
+	}
+	if filepath.Dir(exact.Fragment1.FilePath) == filepath.Dir(exact.Fragment2.FilePath) {
+		t.Errorf("pair paths = %q, %q, want the copies in different directories", exact.Fragment1.FilePath, exact.Fragment2.FilePath)
+	}
+	if group := report.Clones.Groups[0]; len(group.Fragments) != 3 {
+		t.Errorf("group = %+v, want all three functions", group)
+	}
+}
+
 func TestAnalyzeWithoutSupportedFiles(t *testing.T) {
-	if _, err := Analyze([]string{t.TempDir()}); err == nil || !strings.Contains(err.Error(), "no supported source files") {
+	if _, err := Analyze([]string{t.TempDir()}, Options{Complexity: true}); err == nil || !strings.Contains(err.Error(), "no supported source files") {
 		t.Errorf("err = %v, want no supported source files", err)
 	}
 }

--- a/polyscan/internal/clone/cost.go
+++ b/polyscan/internal/clone/cost.go
@@ -1,0 +1,117 @@
+package clone
+
+import (
+	"strings"
+
+	"github.com/ludo-technologies/polyscan/core/apted"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+// category is the cost tier of a node type.
+type category int
+
+const (
+	categoryOther category = iota
+	categoryStructural
+	categoryControlFlow
+	categoryExpression
+)
+
+// Cost multipliers per tier. Structural and control-flow nodes carry the
+// shape of the program, so editing them is priced above the default and
+// expression nodes below it.
+const (
+	structuralMultiplier  = 1.5
+	controlFlowMultiplier = 1.3
+	expressionMultiplier  = 0.8
+	defaultMultiplier     = 1.0
+)
+
+// Label similarity tiers, from identical base type down to no relation. A
+// rename costs 1 minus the similarity.
+const (
+	sameBaseTypeSimilarity = 0.8
+	relatedTypeSimilarity  = 0.5
+	sameCategorySimilarity = 0.3
+)
+
+// costModel prices tree edits from a language's CloneSpec, following the
+// cost models of pyscn and jscan.
+type costModel struct {
+	categories map[string]category
+	related    map[[2]string]struct{}
+}
+
+var _ apted.CostModel = (*costModel)(nil)
+
+func newCostModel(spec engine.CloneSpec) *costModel {
+	model := &costModel{
+		categories: map[string]category{},
+		related:    map[[2]string]struct{}{},
+	}
+	for _, name := range spec.Structural {
+		model.categories[name] = categoryStructural
+	}
+	for _, name := range spec.ControlFlow {
+		model.categories[name] = categoryControlFlow
+	}
+	for _, name := range spec.Expressions {
+		model.categories[name] = categoryExpression
+	}
+	for _, pair := range spec.Related {
+		model.related[pair] = struct{}{}
+		model.related[[2]string{pair[1], pair[0]}] = struct{}{}
+	}
+	return model
+}
+
+func (m *costModel) Insert(node *apted.TreeNode) float64 {
+	return m.multiplier(node.Label)
+}
+
+func (m *costModel) Delete(node *apted.TreeNode) float64 {
+	return m.multiplier(node.Label)
+}
+
+func (m *costModel) Rename(node1, node2 *apted.TreeNode) float64 {
+	if node1.Label == node2.Label {
+		return 0
+	}
+	return 1 - m.labelSimilarity(node1.Label, node2.Label)
+}
+
+func (m *costModel) multiplier(label string) float64 {
+	switch m.categories[baseType(label)] {
+	case categoryStructural:
+		return structuralMultiplier
+	case categoryControlFlow:
+		return controlFlowMultiplier
+	case categoryExpression:
+		return expressionMultiplier
+	default:
+		return defaultMultiplier
+	}
+}
+
+func (m *costModel) labelSimilarity(label1, label2 string) float64 {
+	base1, base2 := baseType(label1), baseType(label2)
+	if base1 == base2 {
+		return sameBaseTypeSimilarity
+	}
+	if _, ok := m.related[[2]string{base1, base2}]; ok {
+		return relatedTypeSimilarity
+	}
+	if c := m.categories[base1]; c != categoryOther && c == m.categories[base2] {
+		return sameCategorySimilarity
+	}
+	return 0
+}
+
+// baseType strips the parenthesized detail the engine appends to a label,
+// so "identifier(count)" and "identifier(total)" share a base type.
+func baseType(label string) string {
+	if idx := strings.IndexByte(label, '('); idx >= 0 {
+		return label[:idx]
+	}
+	return label
+}

--- a/polyscan/internal/clone/detector.go
+++ b/polyscan/internal/clone/detector.go
@@ -3,9 +3,10 @@
 package clone
 
 import (
+	"encoding/binary"
+	"hash/fnv"
 	"runtime"
 	"sort"
-	"strconv"
 	"sync"
 
 	"github.com/ludo-technologies/polyscan/core/apted"
@@ -17,7 +18,9 @@ import (
 
 // Config tunes clone detection.
 type Config struct {
-	// MinLines and MinNodes drop fragments too small to be meaningful clones.
+	// MinLines and MinNodes drop fragments too small to be meaningful
+	// clones. Lines are lines of code: blank lines and comments do not
+	// count.
 	MinLines int
 	MinNodes int
 	// Type thresholds classify a pair by its structural similarity, with
@@ -44,7 +47,13 @@ type Config struct {
 	LSH LSHConfig
 }
 
-// LSHConfig configures the MinHash index used on large inputs.
+// LSHConfig configures the MinHash banding used on large inputs. A
+// signature of Hashes values is cut into Bands bands of Rows values each,
+// and two fragments are candidates when any band matches. Within one
+// band's bucket a fragment is paired with at most MaxCandidates of the
+// fragments that follow it, which bounds the work on a bucket that holds
+// hundreds of near-identical functions while still chaining every member
+// to its neighbours, so that grouping recovers the whole set.
 type LSHConfig struct {
 	SimilarityThreshold float64
 	Bands               int
@@ -105,8 +114,9 @@ type Fragment struct {
 	FilePath  string `json:"file_path"`
 	StartLine int    `json:"start_line"`
 	EndLine   int    `json:"end_line"`
-	LineCount int    `json:"line_count"`
-	NodeCount int    `json:"node_count"`
+	// LineCount counts lines of code: blank lines and comments excluded.
+	LineCount int `json:"line_count"`
+	NodeCount int `json:"node_count"`
 }
 
 // Statistics summarizes a detection run.
@@ -172,7 +182,7 @@ func NewDetector(spec engine.CloneSpec, config Config) *Detector {
 // display name is kept for the report.
 func (d *Detector) Add(fn engine.Function, filePath string) {
 	nodeCount := fn.Tree.Size()
-	lineCount := fn.EndLine - fn.StartLine + 1
+	lineCount := fn.CodeLines
 	if nodeCount < d.config.MinNodes || lineCount < d.config.MinLines {
 		return
 	}
@@ -234,9 +244,9 @@ func (d *Detector) Detect() *Report {
 
 // eachCandidate visits every fragment index pair worth comparing, as (i, j)
 // with i < j, each pair once, in a deterministic order. Every pair is a
-// candidate until the count exceeds MaxPairs; past that, only pairs whose
-// MinHash signatures collide in the LSH index and estimate at least the LSH
-// similarity threshold are.
+// candidate until the count exceeds MaxPairs; past that, only pairs that
+// share a MinHash band and estimate at least the LSH similarity threshold
+// are, as described on LSHConfig.
 func (d *Detector) eachCandidate(visit func(i, j int)) {
 	n := len(d.fragments)
 	if n*(n-1)/2 <= d.config.MaxPairs {
@@ -249,57 +259,60 @@ func (d *Detector) eachCandidate(visit func(i, j int)) {
 	}
 
 	hasher := lsh.NewMinHasher(d.config.LSH.Hashes)
-	index := lsh.NewLSHIndex(d.config.LSH.Bands, d.config.LSH.Rows)
 	signatures := make([]*lsh.MinHashSignature, n)
+	buckets := make([]map[uint64][]int, d.config.LSH.Bands)
+	for band := range buckets {
+		buckets[band] = map[uint64][]int{}
+	}
 	for i, fragment := range d.fragments {
 		signatures[i] = hasher.ComputeSignature(fragment.Features)
-		if err := index.AddFragment(strconv.Itoa(i), signatures[i]); err != nil {
-			panic(err) // Only a duplicate ID fails, and IDs are sequential.
+		for band, key := range bandKeys(signatures[i], d.config.LSH) {
+			buckets[band][key] = append(buckets[band][key], i)
 		}
-	}
-	similar := func(i, j int) bool {
-		return hasher.EstimateJaccardSimilarity(signatures[i], signatures[j]) >= d.config.LSH.SimilarityThreshold
 	}
 
-	// Sharing a bucket is symmetric, so an unordered pair shows up in both
-	// members' queries and is visited from the lower index. A query that
-	// hits MaxCandidates lists the lowest indexes of its buckets, though,
-	// and can stop short of a higher index, so the candidates of capped
-	// queries are kept and the higher index visits the pair instead when
-	// the lower one missed it.
-	capped := map[int]map[int]struct{}{}
+	// Buckets hold ascending indexes, so a fragment's candidates are the
+	// members after it in each of its buckets; the union over bands is
+	// deduplicated per fragment, which keeps the bookkeeping bounded by
+	// Bands times MaxCandidates.
 	for i := range d.fragments {
-		ids := index.FindCandidatesLimit(signatures[i], d.config.LSH.MaxCandidates)
-		var mine map[int]struct{}
-		if len(ids) == d.config.LSH.MaxCandidates {
-			mine = make(map[int]struct{}, len(ids))
-		}
-		for _, id := range ids {
-			j, err := strconv.Atoi(id)
-			if err != nil {
-				panic(err)
-			}
-			if mine != nil {
-				mine[j] = struct{}{}
-			}
-			switch {
-			case j == i:
-			case j > i:
-				if similar(i, j) {
-					visit(i, j)
+		seen := map[int]struct{}{}
+		var candidates []int
+		for band, key := range bandKeys(signatures[i], d.config.LSH) {
+			members := buckets[band][key]
+			position := sort.SearchInts(members, i)
+			for _, j := range members[position+1 : min(position+1+d.config.LSH.MaxCandidates, len(members))] {
+				if _, ok := seen[j]; ok {
+					continue
 				}
-			default:
-				if listed, ok := capped[j]; ok {
-					if _, seen := listed[i]; !seen && similar(j, i) {
-						visit(j, i)
-					}
-				}
+				seen[j] = struct{}{}
+				candidates = append(candidates, j)
 			}
 		}
-		if mine != nil {
-			capped[i] = mine
+		sort.Ints(candidates)
+		for _, j := range candidates {
+			if hasher.EstimateJaccardSimilarity(signatures[i], signatures[j]) >= d.config.LSH.SimilarityThreshold {
+				visit(i, j)
+			}
 		}
 	}
+}
+
+// bandKeys hashes each band of a signature, following the banding of
+// core/lsh: band b covers the Rows values from b*Rows.
+func bandKeys(signature *lsh.MinHashSignature, config LSHConfig) []uint64 {
+	values := signature.Signatures()
+	keys := make([]uint64, config.Bands)
+	for band := range keys {
+		hash := fnv.New64a()
+		var buf [8]byte
+		for _, value := range values[band*config.Rows : min((band+1)*config.Rows, len(values))] {
+			binary.LittleEndian.PutUint64(buf[:], value)
+			hash.Write(buf[:])
+		}
+		keys[band] = hash.Sum64()
+	}
+	return keys
 }
 
 // strongest returns the limit strongest pairs in order.

--- a/polyscan/internal/clone/detector.go
+++ b/polyscan/internal/clone/detector.go
@@ -1,0 +1,436 @@
+// Package clone detects duplicated functions with the tree edit distance and
+// classification algorithms of core/clone, over the trees the engine builds.
+package clone
+
+import (
+	"runtime"
+	"sort"
+	"strconv"
+	"sync"
+
+	"github.com/ludo-technologies/polyscan/core/apted"
+	coreclone "github.com/ludo-technologies/polyscan/core/clone"
+	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/core/lsh"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+// Config tunes clone detection.
+type Config struct {
+	// MinLines and MinNodes drop fragments too small to be meaningful clones.
+	MinLines int
+	MinNodes int
+	// Type thresholds classify a pair by its structural similarity, with
+	// Type-1 additionally requiring identical text and Type-2 a matching
+	// normalized syntax tree. Type-4 is not reported: core reserves it for
+	// semantic analysis, which polyscan does not run, and below the Type-3
+	// threshold structural similarity alone mostly finds functions that
+	// merely share a skeleton.
+	Type1Threshold float64
+	Type2Threshold float64
+	Type3Threshold float64
+	// SimilarityThreshold is the lowest similarity reported.
+	SimilarityThreshold float64
+	// MaxEditDistance drops pairs whose raw edit distance exceeds it. Zero
+	// disables the limit.
+	MaxEditDistance float64
+	// MaxPairs bounds the reported pairs to the strongest ones.
+	MaxPairs int
+	// Grouping merges pairs into groups.
+	Grouping coreclone.GroupingConfig
+	// LSH configures candidate generation. It is used when the number of
+	// all fragment pairs exceeds MaxPairs, in which case only pairs whose
+	// MinHash signatures collide are compared.
+	LSH LSHConfig
+}
+
+// LSHConfig configures the MinHash index used on large inputs.
+type LSHConfig struct {
+	SimilarityThreshold float64
+	Bands               int
+	Rows                int
+	Hashes              int
+	MaxCandidates       int
+}
+
+// DefaultConfig returns the thresholds shared by every polyscan analyzer.
+func DefaultConfig() Config {
+	return Config{
+		MinLines:            domain.DefaultCloneMinLines,
+		MinNodes:            domain.DefaultCloneMinNodes,
+		Type1Threshold:      domain.DefaultType1CloneThreshold,
+		Type2Threshold:      domain.DefaultType2CloneThreshold,
+		Type3Threshold:      domain.DefaultType3CloneThreshold,
+		SimilarityThreshold: domain.DefaultType3CloneThreshold,
+		MaxEditDistance:     domain.DefaultCloneMaxEditDistance,
+		MaxPairs:            10000,
+		Grouping: coreclone.GroupingConfig{
+			Mode:      coreclone.ModeConnected,
+			Threshold: domain.DefaultType3CloneThreshold,
+			KCoreK:    2,
+		},
+		LSH: LSHConfig{
+			SimilarityThreshold: domain.DefaultLSHSimilarityThreshold,
+			Bands:               domain.DefaultLSHBands,
+			Rows:                domain.DefaultLSHRows,
+			Hashes:              domain.DefaultLSHHashes,
+			MaxCandidates:       1024,
+		},
+	}
+}
+
+// Pair is a reported clone pair.
+type Pair struct {
+	ID         int              `json:"id"`
+	Type       domain.CloneType `json:"type"`
+	Similarity float64          `json:"similarity"`
+	Distance   float64          `json:"distance"`
+	Confidence float64          `json:"confidence"`
+	Fragment1  Fragment         `json:"fragment1"`
+	Fragment2  Fragment         `json:"fragment2"`
+}
+
+// Group is a set of fragments that are clones of each other.
+type Group struct {
+	ID         int              `json:"id"`
+	Type       domain.CloneType `json:"type"`
+	Similarity float64          `json:"similarity"`
+	Fragments  []Fragment       `json:"fragments"`
+}
+
+// Fragment locates one function that takes part in a clone.
+type Fragment struct {
+	ID        int    `json:"id"`
+	Name      string `json:"name"`
+	FilePath  string `json:"file_path"`
+	StartLine int    `json:"start_line"`
+	EndLine   int    `json:"end_line"`
+	LineCount int    `json:"line_count"`
+	NodeCount int    `json:"node_count"`
+}
+
+// Statistics summarizes a detection run.
+type Statistics struct {
+	// TotalFragments counts the functions large enough to be compared.
+	TotalFragments int `json:"total_fragments"`
+	// TotalClones counts the distinct fragments that appear in a pair or
+	// group.
+	TotalClones       int            `json:"total_clones"`
+	TotalClonePairs   int            `json:"total_clone_pairs"`
+	TotalCloneGroups  int            `json:"total_clone_groups"`
+	ClonesByType      map[string]int `json:"clones_by_type"`
+	AverageSimilarity float64        `json:"average_similarity"`
+}
+
+// Report is the result of a detection run.
+type Report struct {
+	Pairs      []Pair     `json:"pairs"`
+	Groups     []Group    `json:"groups"`
+	Statistics Statistics `json:"statistics"`
+}
+
+// Detector detects clones among fragments of one language.
+type Detector struct {
+	config     Config
+	costModel  apted.CostModel
+	extractor  *coreclone.ASTFeatureExtractor
+	textual    *coreclone.TextualSimilarityAnalyzer
+	classifier *coreclone.PairClassifier
+
+	fragments []*coreclone.CodeFragment
+	names     []string
+}
+
+// NewDetector creates a detector for the language described by spec.
+func NewDetector(spec engine.CloneSpec, config Config) *Detector {
+	extractor := func() *coreclone.ASTFeatureExtractor {
+		return coreclone.NewASTFeatureExtractor().
+			WithPatterns(spec.Patterns).
+			WithLiteralNames(append(append([]string{}, spec.Identifiers...), spec.Literals...))
+	}
+	// The engine already removed comments from the fragment content, so the
+	// textual analyzer needs no comment stripper of its own.
+	textual := coreclone.NewTextualSimilarityAnalyzer(nil)
+	syntactic := coreclone.NewSyntacticSimilarityAnalyzerWithExtractor(extractor().WithOptions(3, 4, true, false))
+	classifier := coreclone.NewPairClassifier(coreclone.ClassifierConfig{
+		Type1Threshold: config.Type1Threshold, Type2Threshold: config.Type2Threshold,
+		Type3Threshold: config.Type3Threshold,
+		EnableType1:    true, EnableType2: true, EnableType3: true,
+		JaccardPreFilterThreshold: 0.10,
+	}, textual, syntactic)
+
+	return &Detector{
+		config:     config,
+		costModel:  newCostModel(spec),
+		extractor:  extractor(),
+		textual:    textual,
+		classifier: classifier,
+	}
+}
+
+// Add registers a function as a fragment when it is large enough. The
+// display name is kept for the report.
+func (d *Detector) Add(fn engine.Function, filePath string) {
+	nodeCount := fn.Tree.Size()
+	lineCount := fn.EndLine - fn.StartLine + 1
+	if nodeCount < d.config.MinNodes || lineCount < d.config.MinLines {
+		return
+	}
+	apted.PrepareTreeForAPTED(fn.Tree)
+	features, err := d.extractor.ExtractFeatures(fn.Tree)
+	if err != nil {
+		// The extractor only fails on a nil tree, which Add never passes.
+		panic(err)
+	}
+	d.fragments = append(d.fragments, &coreclone.CodeFragment{
+		ID:         len(d.fragments),
+		FilePath:   filePath,
+		StartLine:  fn.StartLine,
+		EndLine:    fn.EndLine,
+		StartCol:   fn.StartColumn,
+		EndCol:     fn.EndColumn,
+		Content:    fn.Content,
+		Hash:       d.textual.HashFragmentContent(fn.Content),
+		ASTNode:    fn.Tree,
+		NodeCount:  nodeCount,
+		LineCount:  lineCount,
+		Complexity: fn.Complexity,
+		Features:   features,
+	})
+	d.names = append(d.names, fn.Name)
+}
+
+// Detect compares the registered fragments and reports the clone pairs and
+// groups among them.
+func (d *Detector) Detect() *Report {
+	pairs := d.verify(d.candidates())
+	sort.Slice(pairs, func(i, j int) bool { return pairPrecedes(pairs[i], pairs[j]) })
+	if len(pairs) > d.config.MaxPairs {
+		pairs = pairs[:d.config.MaxPairs]
+	}
+	pairs, groups := d.group(pairs)
+	return d.report(pairs, groups)
+}
+
+// candidates lists the fragment index pairs worth comparing, as (i, j) with
+// i < j in index order. Every pair is a candidate until the count exceeds
+// MaxPairs; past that, only pairs whose MinHash signatures collide in the
+// LSH index and estimate at least the LSH similarity threshold are.
+func (d *Detector) candidates() [][2]int {
+	n := len(d.fragments)
+	if n*(n-1)/2 <= d.config.MaxPairs {
+		var result [][2]int
+		for i := 0; i < n; i++ {
+			for j := i + 1; j < n; j++ {
+				result = append(result, [2]int{i, j})
+			}
+		}
+		return result
+	}
+
+	hasher := lsh.NewMinHasher(d.config.LSH.Hashes)
+	index := lsh.NewLSHIndex(d.config.LSH.Bands, d.config.LSH.Rows)
+	signatures := make([]*lsh.MinHashSignature, n)
+	for i, fragment := range d.fragments {
+		signatures[i] = hasher.ComputeSignature(fragment.Features)
+		if err := index.AddFragment(strconv.Itoa(i), signatures[i]); err != nil {
+			panic(err) // Only a duplicate ID fails, and IDs are sequential.
+		}
+	}
+
+	var result [][2]int
+	for i := range d.fragments {
+		for _, id := range index.FindCandidatesLimit(signatures[i], d.config.LSH.MaxCandidates) {
+			j, err := strconv.Atoi(id)
+			if err != nil {
+				panic(err)
+			}
+			// Each unordered pair is produced by both of its members; keep
+			// the visit from the lower index.
+			if j <= i {
+				continue
+			}
+			if hasher.EstimateJaccardSimilarity(signatures[i], signatures[j]) < d.config.LSH.SimilarityThreshold {
+				continue
+			}
+			result = append(result, [2]int{i, j})
+		}
+	}
+	return result
+}
+
+// measurement is what comparing two fragments yields.
+type measurement struct {
+	distance   float64
+	similarity float64
+	cloneType  domain.CloneType
+	confidence float64
+}
+
+// pair is a candidate that classified as a clone.
+type pair struct {
+	measurement
+	fragment1 *coreclone.CodeFragment
+	fragment2 *coreclone.CodeFragment
+}
+
+// verify runs the tree edit distance over the candidates on every CPU and
+// returns the pairs that classify as clones, in candidate order so that the
+// result does not depend on scheduling.
+func (d *Detector) verify(candidates [][2]int) []*pair {
+	measurements := make([]measurement, len(candidates))
+	accepted := make([]bool, len(candidates))
+
+	workers := min(runtime.NumCPU(), len(candidates))
+	var wg sync.WaitGroup
+	for worker := 0; worker < workers; worker++ {
+		wg.Add(1)
+		go func(offset int) {
+			defer wg.Done()
+			// The analyzer reuses scratch buffers across comparisons, so
+			// each worker needs its own.
+			analyzer := apted.NewAPTEDAnalyzerWithNormalization(d.costModel, apted.NormalizeByMax)
+			for index := offset; index < len(candidates); index += workers {
+				candidate := candidates[index]
+				measurements[index], accepted[index] = d.measure(analyzer, d.fragments[candidate[0]], d.fragments[candidate[1]])
+			}
+		}(worker)
+	}
+	wg.Wait()
+
+	var pairs []*pair
+	for index, candidate := range candidates {
+		if accepted[index] {
+			pairs = append(pairs, &pair{
+				measurement: measurements[index],
+				fragment1:   d.fragments[candidate[0]],
+				fragment2:   d.fragments[candidate[1]],
+			})
+		}
+	}
+	return pairs
+}
+
+// measure compares two fragments. It touches no detector state, so callers
+// may run it concurrently as long as each has its own analyzer.
+func (d *Detector) measure(analyzer *apted.APTEDAnalyzer, f1, f2 *coreclone.CodeFragment) (measurement, bool) {
+	if coreclone.LocationsOverlap(f1.ItemLocation(), f2.ItemLocation()) {
+		return measurement{}, false
+	}
+	if !coreclone.ShouldCompareFragments(f1, f2) || !d.classifier.PassesJaccardPreFilter(f1, f2) {
+		return measurement{}, false
+	}
+
+	distance, similarity := analyzer.ComputeDistanceAndSimilarity(f1.ASTNode, f2.ASTNode)
+	cloneType, similarity := d.classifier.ClassifyPair(f1, f2, similarity)
+	if cloneType == 0 || similarity < d.config.SimilarityThreshold {
+		return measurement{}, false
+	}
+	if d.config.MaxEditDistance > 0 && distance > d.config.MaxEditDistance {
+		return measurement{}, false
+	}
+	return measurement{
+		distance:   distance,
+		similarity: similarity,
+		cloneType:  cloneType,
+		confidence: coreclone.CalculateConfidence(f1, f2, similarity),
+	}, true
+}
+
+// pairPrecedes orders pairs by descending similarity, then by location, so
+// that the MaxPairs cut is the same on every run.
+func pairPrecedes(a, b *pair) bool {
+	if a.similarity != b.similarity {
+		return a.similarity > b.similarity
+	}
+	if a.fragment1.ID != b.fragment1.ID {
+		return a.fragment1.ID < b.fragment1.ID
+	}
+	return a.fragment2.ID < b.fragment2.ID
+}
+
+// group merges pairs into groups with the configured strategy and applies
+// the core dedupe passes, which can also suppress pairs.
+func (d *Detector) group(pairs []*pair) ([]*pair, []*coreclone.ItemGroup[*coreclone.CodeFragment]) {
+	items := make([]*coreclone.ItemPair[*coreclone.CodeFragment], 0, len(pairs))
+	originals := make(map[*coreclone.ItemPair[*coreclone.CodeFragment]]*pair, len(pairs))
+	for _, p := range pairs {
+		item := &coreclone.ItemPair[*coreclone.CodeFragment]{
+			Item1: p.fragment1, Item2: p.fragment2,
+			Similarity: p.similarity, PairType: p.cloneType,
+		}
+		items = append(items, item)
+		originals[item] = p
+	}
+
+	strategy := coreclone.NewGroupingStrategy[*coreclone.CodeFragment](d.config.Grouping)
+	members := coreclone.DedupeStrictSubsetGroupMembers(strategy.GroupItems(items), items)
+	covered := coreclone.DedupeCoveredGroups(members.Groups)
+	groups := coreclone.FilterGroupsWithoutBackingPairs(covered.Groups, items)
+	for key := range members.Suppressed {
+		covered.Suppressed[key] = struct{}{}
+	}
+	items = coreclone.FilterPairsWithSuppressedMembers(items, covered.Suppressed)
+	items = coreclone.FilterSuppressedPairs(items, covered.SuppressedPairs)
+
+	kept := make([]*pair, 0, len(items))
+	for _, item := range items {
+		kept = append(kept, originals[item])
+	}
+	return kept, groups
+}
+
+func (d *Detector) report(pairs []*pair, groups []*coreclone.ItemGroup[*coreclone.CodeFragment]) *Report {
+	report := &Report{
+		Pairs:  []Pair{},
+		Groups: []Group{},
+		Statistics: Statistics{
+			TotalFragments:   len(d.fragments),
+			TotalClonePairs:  len(pairs),
+			TotalCloneGroups: len(groups),
+			ClonesByType:     map[string]int{},
+		},
+	}
+	clones := map[int]struct{}{}
+	totalSimilarity := 0.0
+	for i, p := range pairs {
+		report.Pairs = append(report.Pairs, Pair{
+			ID:         i,
+			Type:       p.cloneType,
+			Similarity: p.similarity,
+			Distance:   p.distance,
+			Confidence: p.confidence,
+			Fragment1:  d.fragment(p.fragment1),
+			Fragment2:  d.fragment(p.fragment2),
+		})
+		report.Statistics.ClonesByType[p.cloneType.String()]++
+		totalSimilarity += p.similarity
+		clones[p.fragment1.ID] = struct{}{}
+		clones[p.fragment2.ID] = struct{}{}
+	}
+	for _, group := range groups {
+		out := Group{ID: group.ID, Type: group.GroupType, Similarity: group.Similarity}
+		for _, item := range group.Items {
+			out.Fragments = append(out.Fragments, d.fragment(item))
+			clones[item.ID] = struct{}{}
+		}
+		report.Groups = append(report.Groups, out)
+	}
+	report.Statistics.TotalClones = len(clones)
+	if len(pairs) > 0 {
+		report.Statistics.AverageSimilarity = totalSimilarity / float64(len(pairs))
+	}
+	return report
+}
+
+func (d *Detector) fragment(f *coreclone.CodeFragment) Fragment {
+	return Fragment{
+		ID:        f.ID,
+		Name:      d.names[f.ID],
+		FilePath:  f.FilePath,
+		StartLine: f.StartLine,
+		EndLine:   f.EndLine,
+		LineCount: f.LineCount,
+		NodeCount: f.NodeCount,
+	}
+}

--- a/polyscan/internal/clone/detector.go
+++ b/polyscan/internal/clone/detector.go
@@ -200,32 +200,52 @@ func (d *Detector) Add(fn engine.Function, filePath string) {
 	d.names = append(d.names, fn.Name)
 }
 
+// candidateChunkSize bounds how many candidate pairs are verified at once,
+// so that the candidate bookkeeping stays a few megabytes however many
+// candidates the index produces.
+const candidateChunkSize = 1 << 16
+
 // Detect compares the registered fragments and reports the clone pairs and
 // groups among them.
 func (d *Detector) Detect() *Report {
-	pairs := d.verify(d.candidates())
-	sort.Slice(pairs, func(i, j int) bool { return pairPrecedes(pairs[i], pairs[j]) })
-	if len(pairs) > d.config.MaxPairs {
-		pairs = pairs[:d.config.MaxPairs]
+	var pairs []*pair
+	chunk := make([][2]int, 0, candidateChunkSize)
+	flush := func() {
+		pairs = append(pairs, d.verify(chunk)...)
+		chunk = chunk[:0]
+		// The strongest MaxPairs of a prefix are among the strongest
+		// MaxPairs overall, so trimming early bounds memory on clone-rich
+		// input without changing the result.
+		if len(pairs) > 2*d.config.MaxPairs {
+			pairs = strongest(pairs, d.config.MaxPairs)
+		}
 	}
+	d.eachCandidate(func(i, j int) {
+		chunk = append(chunk, [2]int{i, j})
+		if len(chunk) == candidateChunkSize {
+			flush()
+		}
+	})
+	flush()
+	pairs = strongest(pairs, d.config.MaxPairs)
 	pairs, groups := d.group(pairs)
 	return d.report(pairs, groups)
 }
 
-// candidates lists the fragment index pairs worth comparing, as (i, j) with
-// i < j in index order. Every pair is a candidate until the count exceeds
-// MaxPairs; past that, only pairs whose MinHash signatures collide in the
-// LSH index and estimate at least the LSH similarity threshold are.
-func (d *Detector) candidates() [][2]int {
+// eachCandidate visits every fragment index pair worth comparing, as (i, j)
+// with i < j, each pair once, in a deterministic order. Every pair is a
+// candidate until the count exceeds MaxPairs; past that, only pairs whose
+// MinHash signatures collide in the LSH index and estimate at least the LSH
+// similarity threshold are.
+func (d *Detector) eachCandidate(visit func(i, j int)) {
 	n := len(d.fragments)
 	if n*(n-1)/2 <= d.config.MaxPairs {
-		var result [][2]int
 		for i := 0; i < n; i++ {
 			for j := i + 1; j < n; j++ {
-				result = append(result, [2]int{i, j})
+				visit(i, j)
 			}
 		}
-		return result
+		return
 	}
 
 	hasher := lsh.NewMinHasher(d.config.LSH.Hashes)
@@ -237,26 +257,58 @@ func (d *Detector) candidates() [][2]int {
 			panic(err) // Only a duplicate ID fails, and IDs are sequential.
 		}
 	}
+	similar := func(i, j int) bool {
+		return hasher.EstimateJaccardSimilarity(signatures[i], signatures[j]) >= d.config.LSH.SimilarityThreshold
+	}
 
-	var result [][2]int
+	// Sharing a bucket is symmetric, so an unordered pair shows up in both
+	// members' queries and is visited from the lower index. A query that
+	// hits MaxCandidates lists the lowest indexes of its buckets, though,
+	// and can stop short of a higher index, so the candidates of capped
+	// queries are kept and the higher index visits the pair instead when
+	// the lower one missed it.
+	capped := map[int]map[int]struct{}{}
 	for i := range d.fragments {
-		for _, id := range index.FindCandidatesLimit(signatures[i], d.config.LSH.MaxCandidates) {
+		ids := index.FindCandidatesLimit(signatures[i], d.config.LSH.MaxCandidates)
+		var mine map[int]struct{}
+		if len(ids) == d.config.LSH.MaxCandidates {
+			mine = make(map[int]struct{}, len(ids))
+		}
+		for _, id := range ids {
 			j, err := strconv.Atoi(id)
 			if err != nil {
 				panic(err)
 			}
-			// Each unordered pair is produced by both of its members; keep
-			// the visit from the lower index.
-			if j <= i {
-				continue
+			if mine != nil {
+				mine[j] = struct{}{}
 			}
-			if hasher.EstimateJaccardSimilarity(signatures[i], signatures[j]) < d.config.LSH.SimilarityThreshold {
-				continue
+			switch {
+			case j == i:
+			case j > i:
+				if similar(i, j) {
+					visit(i, j)
+				}
+			default:
+				if listed, ok := capped[j]; ok {
+					if _, seen := listed[i]; !seen && similar(j, i) {
+						visit(j, i)
+					}
+				}
 			}
-			result = append(result, [2]int{i, j})
+		}
+		if mine != nil {
+			capped[i] = mine
 		}
 	}
-	return result
+}
+
+// strongest returns the limit strongest pairs in order.
+func strongest(pairs []*pair, limit int) []*pair {
+	sort.Slice(pairs, func(i, j int) bool { return pairPrecedes(pairs[i], pairs[j]) })
+	if len(pairs) > limit {
+		return pairs[:limit]
+	}
+	return pairs
 }
 
 // measurement is what comparing two fragments yields.
@@ -278,6 +330,9 @@ type pair struct {
 // returns the pairs that classify as clones, in candidate order so that the
 // result does not depend on scheduling.
 func (d *Detector) verify(candidates [][2]int) []*pair {
+	if len(candidates) == 0 {
+		return nil
+	}
 	measurements := make([]measurement, len(candidates))
 	accepted := make([]bool, len(candidates))
 

--- a/polyscan/internal/clone/detector_test.go
+++ b/polyscan/internal/clone/detector_test.go
@@ -68,7 +68,12 @@ const body = `
 
 func detect(t *testing.T, sources ...string) *Report {
 	t.Helper()
-	detector := NewDetector(golang.Language.Clone, DefaultConfig())
+	return detectWith(t, DefaultConfig(), sources...)
+}
+
+func detectWith(t *testing.T, config Config, sources ...string) *Report {
+	t.Helper()
+	detector := NewDetector(golang.Language.Clone, config)
 	for i, source := range sources {
 		functions, err := golang.Language.Analyze([]byte("package p\n\nimport \"fmt\"\n\n" + source))
 		if err != nil {
@@ -117,5 +122,33 @@ func TestDetectSkipsSmallAndUnrelatedFunctions(t *testing.T) {
 	}
 	if len(report.Pairs) != 0 || len(report.Groups) != 0 {
 		t.Errorf("unexpected clones: %+v", report.Pairs)
+	}
+}
+
+// TestDetectCappedLSHCandidatesReachEveryFragment forces the LSH path with
+// a candidate cap smaller than the number of identical functions. A capped
+// query lists the lowest indexes, so without the reverse visit the later
+// fragments would never be paired with anything.
+func TestDetectCappedLSHCandidatesReachEveryFragment(t *testing.T) {
+	config := DefaultConfig()
+	config.MaxPairs = 10 // Six fragments make 15 pairs, so the LSH path runs.
+	config.LSH.MaxCandidates = 3
+
+	sources := make([]string, 6)
+	for i := range sources {
+		sources[i] = "func Sum(values []int) int {" + body
+	}
+	report := detectWith(t, config, sources...)
+
+	if report.Statistics.TotalClones != 6 {
+		t.Errorf("clones = %d, want every fragment paired", report.Statistics.TotalClones)
+	}
+	if len(report.Pairs) != config.MaxPairs {
+		t.Errorf("pairs = %d, want the MaxPairs strongest", len(report.Pairs))
+	}
+	for _, pair := range report.Pairs {
+		if pair.Type != domain.Type1Clone {
+			t.Errorf("pair = %+v, want Type-1", pair)
+		}
 	}
 }

--- a/polyscan/internal/clone/detector_test.go
+++ b/polyscan/internal/clone/detector_test.go
@@ -1,0 +1,121 @@
+package clone
+
+import (
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/apted"
+	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
+)
+
+func TestCostModelTiers(t *testing.T) {
+	model := newCostModel(engine.CloneSpec{
+		Structural:  []string{"function_declaration"},
+		ControlFlow: []string{"if_statement", "for_statement"},
+		Expressions: []string{"call_expression"},
+		Related:     [][2]string{{"if_statement", "expression_switch_statement"}},
+	})
+	node := func(label string) *apted.TreeNode { return apted.NewTreeNode(0, label) }
+
+	for label, want := range map[string]float64{
+		"function_declaration": structuralMultiplier,
+		"if_statement":         controlFlowMultiplier,
+		"call_expression":      expressionMultiplier,
+		"identifier(x)":        defaultMultiplier,
+	} {
+		if got := model.Insert(node(label)); got != want {
+			t.Errorf("Insert(%s) = %v, want %v", label, got, want)
+		}
+		if got := model.Delete(node(label)); got != want {
+			t.Errorf("Delete(%s) = %v, want %v", label, got, want)
+		}
+	}
+
+	for _, tc := range []struct {
+		a, b string
+		want float64
+	}{
+		{"identifier(x)", "identifier(x)", 0},
+		{"identifier(x)", "identifier(y)", 1 - sameBaseTypeSimilarity},
+		{"if_statement", "expression_switch_statement", 1 - relatedTypeSimilarity},
+		{"if_statement", "for_statement", 1 - sameCategorySimilarity},
+		{"if_statement", "call_expression", 1},
+		{"identifier(x)", "int_literal(1)", 1},
+	} {
+		if got := model.Rename(node(tc.a), node(tc.b)); math.Abs(got-tc.want) > 1e-9 {
+			t.Errorf("Rename(%s, %s) = %v, want %v", tc.a, tc.b, got, tc.want)
+		}
+	}
+}
+
+const body = `
+	total := 0
+	for _, value := range values {
+		if value > 0 {
+			total += value
+		} else if value < -10 {
+			total -= value
+		}
+		fmt.Println(value)
+		fmt.Println(total)
+	}
+	return total
+}
+`
+
+func detect(t *testing.T, sources ...string) *Report {
+	t.Helper()
+	detector := NewDetector(golang.Language.Clone, DefaultConfig())
+	for i, source := range sources {
+		functions, err := golang.Language.Analyze([]byte("package p\n\nimport \"fmt\"\n\n" + source))
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, fn := range functions {
+			detector.Add(fn, "file"+string(rune('a'+i))+".go")
+		}
+	}
+	return detector.Detect()
+}
+
+func TestDetectClassifiesPairs(t *testing.T) {
+	renamed := strings.NewReplacer("total", "sum", "value", "v", "values", "xs").Replace(body)
+	report := detect(t,
+		"func Sum(values []int) int {"+body,
+		"func Sum(values []int) int { // a comment\n"+body,
+		"func Sum(xs []int) int {"+renamed,
+	)
+
+	if len(report.Pairs) != 3 || len(report.Groups) != 1 || len(report.Groups[0].Fragments) != 3 {
+		t.Fatalf("pairs = %+v, groups = %+v", report.Pairs, report.Groups)
+	}
+	exact := report.Pairs[0]
+	if exact.Type != domain.Type1Clone || exact.Similarity != 1 || exact.Fragment1.FilePath != "filea.go" || exact.Fragment2.FilePath != "fileb.go" {
+		t.Errorf("strongest pair = %+v, want the Type-1 pair of the first two files", exact)
+	}
+	for _, pair := range report.Pairs[1:] {
+		if pair.Type != domain.Type2Clone {
+			t.Errorf("renamed pair = %+v, want Type-2", pair)
+		}
+	}
+	if report.Statistics.ClonesByType["Type-1"] != 1 || report.Statistics.ClonesByType["Type-2"] != 2 || report.Statistics.TotalClones != 3 {
+		t.Errorf("statistics = %+v", report.Statistics)
+	}
+}
+
+func TestDetectSkipsSmallAndUnrelatedFunctions(t *testing.T) {
+	report := detect(t,
+		"func Sum(values []int) int {"+body,
+		"func Small(values []int) int {\n\treturn len(values)\n}\n",
+		"func Other(name string) error {\n\tf, err := os.Open(name)\n\tif err != nil {\n\t\treturn err\n\t}\n\tdefer f.Close()\n\tb := make([]byte, 10)\n\t_, err = f.Read(b)\n\tif err != nil {\n\t\treturn err\n\t}\n\tfmt.Println(string(b))\n\treturn nil\n}\n",
+	)
+	if report.Statistics.TotalFragments != 2 {
+		t.Errorf("fragments = %d, want Sum and Other only", report.Statistics.TotalFragments)
+	}
+	if len(report.Pairs) != 0 || len(report.Groups) != 0 {
+		t.Errorf("unexpected clones: %+v", report.Pairs)
+	}
+}

--- a/polyscan/internal/clone/detector_test.go
+++ b/polyscan/internal/clone/detector_test.go
@@ -125,13 +125,14 @@ func TestDetectSkipsSmallAndUnrelatedFunctions(t *testing.T) {
 	}
 }
 
-// TestDetectCappedLSHCandidatesReachEveryFragment forces the LSH path with
-// a candidate cap smaller than the number of identical functions. A capped
-// query lists the lowest indexes, so without the reverse visit the later
-// fragments would never be paired with anything.
-func TestDetectCappedLSHCandidatesReachEveryFragment(t *testing.T) {
+// TestDetectCappedLSHCandidatesChainEveryFragment forces the LSH path with
+// a candidate cap smaller than the number of identical functions. Each
+// fragment is paired with the members that follow it in the bucket, so the
+// last two are compared with each other even though they lie beyond the
+// cap of every earlier fragment.
+func TestDetectCappedLSHCandidatesChainEveryFragment(t *testing.T) {
 	config := DefaultConfig()
-	config.MaxPairs = 10 // Six fragments make 15 pairs, so the LSH path runs.
+	config.MaxPairs = 12 // Six fragments make 15 pairs, so the LSH path runs.
 	config.LSH.MaxCandidates = 3
 
 	sources := make([]string, 6)
@@ -140,15 +141,36 @@ func TestDetectCappedLSHCandidatesReachEveryFragment(t *testing.T) {
 	}
 	report := detectWith(t, config, sources...)
 
-	if report.Statistics.TotalClones != 6 {
-		t.Errorf("clones = %d, want every fragment paired", report.Statistics.TotalClones)
+	// 3+3+3+2+1 pairs: every fragment with the next three.
+	if len(report.Pairs) != 12 || report.Statistics.TotalClones != 6 {
+		t.Errorf("pairs = %d, clones = %d, want 12 and 6", len(report.Pairs), report.Statistics.TotalClones)
 	}
-	if len(report.Pairs) != config.MaxPairs {
-		t.Errorf("pairs = %d, want the MaxPairs strongest", len(report.Pairs))
-	}
+	last := false
 	for _, pair := range report.Pairs {
 		if pair.Type != domain.Type1Clone {
 			t.Errorf("pair = %+v, want Type-1", pair)
 		}
+		if pair.Fragment1.ID == 4 && pair.Fragment2.ID == 5 {
+			last = true
+		}
+	}
+	if !last {
+		t.Error("the last two fragments were not compared with each other")
+	}
+	if len(report.Groups) != 1 || len(report.Groups[0].Fragments) != 6 {
+		t.Errorf("groups = %+v, want one group of six", report.Groups)
+	}
+}
+
+func TestDetectIgnoresCommentsAndSpacing(t *testing.T) {
+	commented := "// Sum adds the values.\n//\n// It skips nothing.\nfunc Sum(values []int) int { // start\n" +
+		strings.ReplaceAll(strings.ReplaceAll(body, "\n\t\t", "\n\t\t// a comment line\n\n\t\t"), "return total", "return/* the result */total")
+	report := detect(t, "func Sum(values []int) int {"+body, commented)
+
+	if len(report.Pairs) != 1 || report.Pairs[0].Type != domain.Type1Clone {
+		t.Fatalf("pairs = %+v, want one Type-1 pair", report.Pairs)
+	}
+	if a, b := report.Pairs[0].Fragment1.LineCount, report.Pairs[0].Fragment2.LineCount; a != b {
+		t.Errorf("line counts %d and %d differ, want lines of code only", a, b)
 	}
 }

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -101,9 +101,12 @@ type Function struct {
 	// Tree is the function's syntax tree in the form the tree edit distance
 	// consumes: named nodes only, comments dropped, labeled per CloneSpec.
 	Tree *apted.TreeNode
-	// Content is the function's source text with comments removed, for
-	// exact-match (Type-1) clone classification.
+	// Content is the function's source text with each comment replaced by
+	// a space, for exact-match (Type-1) clone classification.
 	Content string
+	// CodeLines counts the lines of Content that are not blank, so that
+	// comments and spacing do not change how large a function is.
+	CodeLines int
 
 	startByte uint32
 	endByte   uint32
@@ -218,6 +221,7 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 		converter := treeConverter{language: l, source: source}
 		fn.Tree = converter.convert(node)
 		fn.Content = converter.contentWithoutComments(node)
+		fn.CodeLines = countCodeLines(fn.Content)
 		functions = append(functions, fn)
 	})
 	sort.Slice(functions, func(i, j int) bool {
@@ -272,17 +276,30 @@ func (c *treeConverter) label(node *sitter.Node) string {
 	return nodeType
 }
 
-// contentWithoutComments returns the node's source text with the comments
-// that convert recorded cut out. It must run after convert.
+// contentWithoutComments returns the node's source text with each comment
+// that convert recorded replaced by a space, so that the tokens around a
+// comment stay apart. It must run after convert.
 func (c *treeConverter) contentWithoutComments(node *sitter.Node) string {
 	var b strings.Builder
 	cursor := node.StartByte()
 	for _, comment := range c.comments {
 		b.Write(c.source[cursor:comment[0]])
+		b.WriteByte(' ')
 		cursor = comment[1]
 	}
 	b.Write(c.source[cursor:node.EndByte()])
 	return b.String()
+}
+
+// countCodeLines counts the lines that hold something other than whitespace.
+func countCodeLines(content string) int {
+	lines := 0
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) != "" {
+			lines++
+		}
+	}
+	return lines
 }
 
 func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []Function) {

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -1,7 +1,8 @@
 // Package engine runs declarative, per-language tree-sitter queries and turns
 // their captures into per-function metrics. A language contributes no Go
 // code beyond its Language value: which grammar to load, which query finds
-// its functions, and which query marks its decision points.
+// its functions, which query marks its decision points, and which node
+// types matter for clone detection.
 package engine
 
 import (
@@ -11,6 +12,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ludo-technologies/polyscan/core/apted"
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
@@ -33,11 +35,45 @@ type Language struct {
 	// that contains it and counted under the capture's name, so the capture
 	// names double as the breakdown reported next to the complexity.
 	Decisions string
+	// Clone names the node types clone detection prices and compares.
+	Clone CloneSpec
+	// TestFiles are file name globs of test files. Test files are analyzed
+	// for complexity but excluded from clone detection, where the shared
+	// skeleton of test functions swamps the report.
+	TestFiles []string
 
 	compileOnce sync.Once
 	compileErr  error
 	definitions *sitter.Query
 	decisions   *sitter.Query
+	identifiers map[string]struct{}
+	literals    map[string]struct{}
+}
+
+// CloneSpec names the node types clone detection needs to know about. Node
+// types are the tree-sitter names, such as "if_statement". Anything not
+// listed is handled with the default cost and no special feature.
+type CloneSpec struct {
+	// Identifiers are node types whose text is a name. Their tree label
+	// carries the name, as in "identifier(count)", so an exact structural
+	// match with different names is still told apart from an exact clone.
+	Identifiers []string
+	// Literals are node types whose text is a literal value, labeled the
+	// same way. A literal node becomes a leaf of the tree.
+	Literals []string
+	// Patterns are node types whose presence in a fragment is a structural
+	// feature for similarity hashing and the Jaccard pre-filter.
+	Patterns []string
+	// Structural, ControlFlow and Expressions are the cost tiers of the tree
+	// edit distance: editing a structural or control-flow node is priced
+	// above the default, editing an expression node below it.
+	Structural  []string
+	ControlFlow []string
+	Expressions []string
+	// Related pairs node types that express the same construct in different
+	// syntactic forms, so renaming between them is cheaper than between
+	// unrelated types.
+	Related [][2]string
 }
 
 // Function is one function or method found in a source file.
@@ -47,10 +83,12 @@ type Function struct {
 	// Kind is the suffix of the @definition capture that matched, such as
 	// "function" or "method".
 	Kind string
-	// StartLine, StartColumn and EndLine are 1-based source positions.
+	// StartLine, StartColumn, EndLine and EndColumn are 1-based source
+	// positions.
 	StartLine   int
 	StartColumn int
 	EndLine     int
+	EndColumn   int
 	// Complexity is the McCabe cyclomatic complexity: one plus the number of
 	// decision points, following the same conventions core/cfg applies to a
 	// control flow graph. A two-way branch or loop counts one, a switch
@@ -60,6 +98,12 @@ type Function struct {
 	// Decisions breaks the decision points down by the name of the capture
 	// that produced them.
 	Decisions map[string]int
+	// Tree is the function's syntax tree in the form the tree edit distance
+	// consumes: named nodes only, comments dropped, labeled per CloneSpec.
+	Tree *apted.TreeNode
+	// Content is the function's source text with comments removed, for
+	// exact-match (Type-1) clone classification.
+	Content string
 
 	startByte uint32
 	endByte   uint32
@@ -69,6 +113,7 @@ const (
 	definitionPrefix = "definition."
 	nameCapture      = "name"
 	receiverCapture  = "receiver"
+	operatorField    = "operator"
 )
 
 // Analyze parses source and returns every function the language defines,
@@ -124,8 +169,18 @@ func (l *Language) compile() error {
 		}
 		l.definitions = definitions
 		l.decisions = decisions
+		l.identifiers = set(l.Clone.Identifiers)
+		l.literals = set(l.Clone.Literals)
 	})
 	return l.compileErr
+}
+
+func set(names []string) map[string]struct{} {
+	result := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		result[name] = struct{}{}
+	}
+	return result
 }
 
 func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function {
@@ -155,15 +210,79 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 		fn.StartLine = int(node.StartPoint().Row) + 1
 		fn.StartColumn = int(node.StartPoint().Column) + 1
 		fn.EndLine = int(node.EndPoint().Row) + 1
+		fn.EndColumn = int(node.EndPoint().Column) + 1
 		fn.startByte = node.StartByte()
 		fn.endByte = node.EndByte()
 		fn.Decisions = map[string]int{}
+
+		converter := treeConverter{language: l, source: source}
+		fn.Tree = converter.convert(node)
+		fn.Content = converter.contentWithoutComments(node)
 		functions = append(functions, fn)
 	})
 	sort.Slice(functions, func(i, j int) bool {
 		return functions[i].startByte < functions[j].startByte
 	})
 	return functions
+}
+
+// treeConverter builds the tree edit distance tree of one function and
+// remembers where its comments were.
+type treeConverter struct {
+	language *Language
+	source   []byte
+	nextID   int
+	comments [][2]uint32
+}
+
+// convert turns a syntax node into a labeled tree of its named descendants.
+// Comments, which tree-sitter marks as extra nodes, are left out and their
+// byte ranges recorded. A literal becomes a leaf because its label already
+// carries the value.
+func (c *treeConverter) convert(node *sitter.Node) *apted.TreeNode {
+	tree := apted.NewTreeNode(c.nextID, c.label(node))
+	c.nextID++
+	if _, isLiteral := c.language.literals[node.Type()]; isLiteral {
+		return tree
+	}
+	for i := 0; i < int(node.NamedChildCount()); i++ {
+		child := node.NamedChild(i)
+		if child.IsExtra() {
+			c.comments = append(c.comments, [2]uint32{child.StartByte(), child.EndByte()})
+			continue
+		}
+		tree.AddChild(c.convert(child))
+	}
+	return tree
+}
+
+// label is the node type, carrying the text of identifiers and literals and
+// the operator of any node that has one, as in "binary_expression(+)".
+func (c *treeConverter) label(node *sitter.Node) string {
+	nodeType := node.Type()
+	if _, ok := c.language.identifiers[nodeType]; ok {
+		return nodeType + "(" + node.Content(c.source) + ")"
+	}
+	if _, ok := c.language.literals[nodeType]; ok {
+		return nodeType + "(" + node.Content(c.source) + ")"
+	}
+	if operator := node.ChildByFieldName(operatorField); operator != nil {
+		return nodeType + "(" + operator.Type() + ")"
+	}
+	return nodeType
+}
+
+// contentWithoutComments returns the node's source text with the comments
+// that convert recorded cut out. It must run after convert.
+func (c *treeConverter) contentWithoutComments(node *sitter.Node) string {
+	var b strings.Builder
+	cursor := node.StartByte()
+	for _, comment := range c.comments {
+		b.Write(c.source[cursor:comment[0]])
+		cursor = comment[1]
+	}
+	b.Write(c.source[cursor:node.EndByte()])
+	return b.String()
 }
 
 func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []Function) {

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -13,6 +13,7 @@ var Language = &engine.Language{
 	Name:       "Go",
 	Extensions: []string{".go"},
 	Grammar:    tsgo.GetLanguage(),
+	TestFiles:  []string{"*_test.go"},
 	// The definition patterns of tree-sitter-go's queries/tags.scm, with the
 	// receiver captured so methods report as "Type.Method". The Go
 	// specification allows a receiver type of T or *T, where T may carry
@@ -49,4 +50,51 @@ var Language = &engine.Language{
 (communication_case) @case
 (binary_expression operator: ["&&" "||"]) @logical_operator
 `,
+	Clone: engine.CloneSpec{
+		Identifiers: []string{"identifier", "field_identifier", "type_identifier", "package_identifier", "label_name"},
+		Literals: []string{
+			"int_literal", "float_literal", "imaginary_literal", "rune_literal",
+			"interpreted_string_literal", "raw_string_literal",
+			"true", "false", "nil", "iota",
+		},
+		Patterns: []string{
+			"if_statement", "for_statement", "expression_switch_statement", "type_switch_statement",
+			"select_statement", "return_statement", "defer_statement", "go_statement",
+			"break_statement", "continue_statement", "labeled_statement", "send_statement",
+			"func_literal", "call_expression", "selector_expression", "index_expression",
+			"slice_expression", "type_assertion_expression", "binary_expression", "unary_expression",
+			"assignment_statement", "short_var_declaration", "var_declaration", "const_declaration",
+			"composite_literal",
+		},
+		Structural: []string{
+			"source_file", "function_declaration", "method_declaration", "func_literal",
+			"type_declaration", "type_spec", "struct_type", "interface_type",
+		},
+		ControlFlow: []string{
+			"if_statement", "for_statement", "for_clause", "range_clause",
+			"expression_switch_statement", "type_switch_statement", "select_statement",
+			"expression_case", "type_case", "communication_case", "default_case",
+			"return_statement", "break_statement", "continue_statement", "goto_statement",
+			"fallthrough_statement", "defer_statement", "go_statement", "labeled_statement",
+		},
+		Expressions: []string{
+			"binary_expression", "unary_expression", "call_expression", "selector_expression",
+			"index_expression", "slice_expression", "type_assertion_expression",
+			"type_conversion_expression", "type_instantiation_expression", "parenthesized_expression",
+			"composite_literal", "literal_value", "keyed_element",
+			"assignment_statement", "short_var_declaration", "inc_statement", "dec_statement",
+			"send_statement",
+		},
+		Related: [][2]string{
+			{"expression_switch_statement", "type_switch_statement"},
+			{"expression_case", "type_case"},
+			{"expression_case", "communication_case"},
+			{"assignment_statement", "short_var_declaration"},
+			{"var_declaration", "short_var_declaration"},
+			{"for_clause", "range_clause"},
+			{"binary_expression", "unary_expression"},
+			{"inc_statement", "dec_statement"},
+			{"go_statement", "defer_statement"},
+		},
+	},
 }

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -131,3 +131,14 @@ func TestSyntaxErrorIsReported(t *testing.T) {
 		t.Errorf("error = %q, want the first error line", err)
 	}
 }
+
+func TestContentDropsCommentsButKeepsTokensApart(t *testing.T) {
+	fn := analyze(t, "package p\n\n// F returns one.\nfunc F() int {\n\t// a line comment\n\n\treturn/* one */1 /* trailing */\n}\n")["F"]
+	want := "func F() int {\n\t \n\n\treturn 1  \n}"
+	if fn.Content != want {
+		t.Errorf("content = %q, want %q", fn.Content, want)
+	}
+	if fn.CodeLines != 3 {
+		t.Errorf("code lines = %d, want 3", fn.CodeLines)
+	}
+}

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -9,19 +9,24 @@ import (
 
 	"github.com/ludo-technologies/polyscan/core/domain"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/analysis"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 )
 
 // Document is the report together with the metadata of the run that
 // produced it.
 type Document struct {
-	Version     string           `json:"version"`
-	GeneratedAt time.Time        `json:"generated_at"`
-	DurationMs  int64            `json:"duration_ms"`
-	Complexity  *analysis.Report `json:"complexity"`
+	Version     string    `json:"version"`
+	GeneratedAt time.Time `json:"generated_at"`
+	DurationMs  int64     `json:"duration_ms"`
+	*analysis.Report
 	// MinComplexity is the filter applied to the listed functions. The
 	// summary always covers every analyzed function.
 	MinComplexity int `json:"-"`
 }
+
+// textPairLimit bounds the clone pairs the text report lists; the JSON
+// report carries them all.
+const textPairLimit = 10
 
 // Write renders the document in the given format.
 func Write(w io.Writer, doc *Document, format domain.OutputFormat) error {
@@ -29,34 +34,55 @@ func Write(w io.Writer, doc *Document, format domain.OutputFormat) error {
 	case domain.OutputFormatJSON:
 		return writeJSON(w, doc)
 	case domain.OutputFormatText:
-		return writeText(w, doc)
+		writeText(w, doc)
+		return nil
 	default:
 		return fmt.Errorf("unsupported output format %q", format)
 	}
 }
 
 func writeJSON(w io.Writer, doc *Document) error {
-	filtered := *doc.Complexity
-	filtered.Functions = listed(doc)
 	out := *doc
-	out.Complexity = &filtered
-
+	if doc.Complexity != nil {
+		filtered := *doc.Complexity
+		filtered.Functions = listed(doc)
+		report := *doc.Report
+		report.Complexity = &filtered
+		out.Report = &report
+	}
 	encoder := json.NewEncoder(w)
 	encoder.SetIndent("", "  ")
 	return encoder.Encode(out)
 }
 
-func writeText(w io.Writer, doc *Document) error {
+func writeText(w io.Writer, doc *Document) {
+	fmt.Fprintf(w, "\n=== polyscan ===\n\n")
+	fmt.Fprintf(w, "Generated: %s\n", doc.GeneratedAt.Format(time.RFC3339))
+	fmt.Fprintf(w, "Version: %s\n", doc.Version)
+	fmt.Fprintf(w, "Files analyzed: %d\n", doc.Files.Analyzed)
+	if doc.Files.Skipped > 0 {
+		fmt.Fprintf(w, "Files skipped: %d\n", doc.Files.Skipped)
+	}
+
+	if doc.Complexity != nil {
+		writeComplexityText(w, doc)
+	}
+	if doc.Clones != nil {
+		writeCloneText(w, doc.Clones)
+	}
+
+	if len(doc.Errors) > 0 {
+		fmt.Fprintf(w, "\nErrors:\n")
+		for _, e := range doc.Errors {
+			fmt.Fprintf(w, "  - %s\n", e)
+		}
+	}
+}
+
+func writeComplexityText(w io.Writer, doc *Document) {
 	summary := doc.Complexity.Summary
 	fmt.Fprintf(w, "\n=== Complexity Analysis ===\n\n")
-	fmt.Fprintf(w, "Generated: %s\n", doc.GeneratedAt.Format(time.RFC3339))
-	fmt.Fprintf(w, "Version: %s\n\n", doc.Version)
-
 	fmt.Fprintf(w, "Summary:\n")
-	fmt.Fprintf(w, "  Files analyzed: %d\n", summary.FilesAnalyzed)
-	if summary.SkippedFiles > 0 {
-		fmt.Fprintf(w, "  Files skipped: %d\n", summary.SkippedFiles)
-	}
 	fmt.Fprintf(w, "  Total functions: %d\n", summary.TotalFunctions)
 	fmt.Fprintf(w, "  Average complexity: %.2f\n", summary.AverageComplexity)
 	fmt.Fprintf(w, "  Max complexity: %d\n", summary.MaxComplexity)
@@ -68,32 +94,66 @@ func writeText(w io.Writer, doc *Document) error {
 	fmt.Fprintf(w, "  Low risk: %d\n", summary.LowRiskFunctions)
 
 	functions := listed(doc)
-	if len(functions) > 0 {
-		if doc.MinComplexity > 1 {
-			fmt.Fprintf(w, "\nFunctions (complexity >= %d):\n", doc.MinComplexity)
-		} else {
-			fmt.Fprintf(w, "\nFunctions:\n")
+	if len(functions) == 0 {
+		return
+	}
+	if doc.MinComplexity > 1 {
+		fmt.Fprintf(w, "\nFunctions (complexity >= %d):\n", doc.MinComplexity)
+	} else {
+		fmt.Fprintf(w, "\nFunctions:\n")
+	}
+	for _, fn := range functions {
+		indicator := ""
+		switch fn.RiskLevel {
+		case domain.RiskLevelHigh:
+			indicator = " [HIGH]"
+		case domain.RiskLevelMedium:
+			indicator = " [MEDIUM]"
 		}
-		for _, fn := range functions {
-			indicator := ""
-			switch fn.RiskLevel {
-			case domain.RiskLevelHigh:
-				indicator = " [HIGH]"
-			case domain.RiskLevelMedium:
-				indicator = " [MEDIUM]"
+		fmt.Fprintf(w, "  %s: %d%s\n", fn.Name, fn.Complexity, indicator)
+		fmt.Fprintf(w, "    File: %s:%d-%d\n", fn.FilePath, fn.StartLine, fn.EndLine)
+	}
+}
+
+func writeCloneText(w io.Writer, clones *clone.Report) {
+	stats := clones.Statistics
+	fmt.Fprintf(w, "\n=== Clone Detection ===\n\n")
+	fmt.Fprintf(w, "Statistics:\n")
+	fmt.Fprintf(w, "  Fragments compared: %d\n", stats.TotalFragments)
+	fmt.Fprintf(w, "  Total clone pairs: %d\n", stats.TotalClonePairs)
+	fmt.Fprintf(w, "  Total clone groups: %d\n", stats.TotalCloneGroups)
+	fmt.Fprintf(w, "  Average similarity: %.2f\n", stats.AverageSimilarity)
+	if len(stats.ClonesByType) > 0 {
+		fmt.Fprintf(w, "\nClone Types:\n")
+		for _, cloneType := range []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone, domain.Type4Clone} {
+			if count := stats.ClonesByType[cloneType.String()]; count > 0 {
+				fmt.Fprintf(w, "  %s: %d\n", cloneType, count)
 			}
-			fmt.Fprintf(w, "  %s: %d%s\n", fn.Name, fn.Complexity, indicator)
-			fmt.Fprintf(w, "    File: %s:%d-%d\n", fn.FilePath, fn.StartLine, fn.EndLine)
 		}
 	}
 
-	if len(doc.Complexity.Errors) > 0 {
-		fmt.Fprintf(w, "\nErrors:\n")
-		for _, e := range doc.Complexity.Errors {
-			fmt.Fprintf(w, "  - %s\n", e)
+	if len(clones.Groups) > 0 {
+		fmt.Fprintf(w, "\nClone Groups:\n")
+		for _, group := range clones.Groups {
+			fmt.Fprintf(w, "  Group %d: %s, %d fragments, %.1f%% similar\n", group.ID+1, group.Type, len(group.Fragments), group.Similarity*100)
+			for _, fragment := range group.Fragments {
+				fmt.Fprintf(w, "    %s (%s:%d-%d)\n", fragment.Name, fragment.FilePath, fragment.StartLine, fragment.EndLine)
+			}
 		}
 	}
-	return nil
+
+	if len(clones.Pairs) == 0 {
+		fmt.Fprintf(w, "\nNo code clones detected.\n")
+		return
+	}
+	fmt.Fprintf(w, "\nTop Clone Pairs:\n")
+	for _, pair := range clones.Pairs[:min(textPairLimit, len(clones.Pairs))] {
+		fmt.Fprintf(w, "  %s: %s (%s:%d-%d) <-> %s (%s:%d-%d) (%.1f%% similar)\n",
+			pair.Type,
+			pair.Fragment1.Name, pair.Fragment1.FilePath, pair.Fragment1.StartLine, pair.Fragment1.EndLine,
+			pair.Fragment2.Name, pair.Fragment2.FilePath, pair.Fragment2.StartLine, pair.Fragment2.EndLine,
+			pair.Similarity*100)
+	}
 }
 
 // listed returns the functions that pass the report filter, in the order

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -9,19 +9,30 @@ import (
 
 	"github.com/ludo-technologies/polyscan/core/domain"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/analysis"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 )
 
 func document(minComplexity int) *Document {
+	a := clone.Fragment{ID: 0, Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, LineCount: 40, NodeCount: 90}
+	b := clone.Fragment{ID: 1, Name: "Copy", FilePath: "c.go", StartLine: 10, EndLine: 49, LineCount: 40, NodeCount: 90}
 	return &Document{
 		Version:     "test",
 		GeneratedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
-		Complexity: &analysis.Report{
-			Functions: []analysis.Function{
-				{Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, Complexity: 25, Decisions: map[string]int{"branch": 24}, RiskLevel: domain.RiskLevelHigh},
-				{Name: "Small", FilePath: "b.go", StartLine: 3, EndLine: 5, Complexity: 1, Decisions: map[string]int{}, RiskLevel: domain.RiskLevelLow},
+		Report: &analysis.Report{
+			Files: analysis.Files{Total: 3, Analyzed: 2, Skipped: 1},
+			Complexity: &analysis.Complexity{
+				Functions: []analysis.Function{
+					{Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, Complexity: 25, Decisions: map[string]int{"branch": 24}, RiskLevel: domain.RiskLevelHigh},
+					{Name: "Small", FilePath: "b.go", StartLine: 3, EndLine: 5, Complexity: 1, Decisions: map[string]int{}, RiskLevel: domain.RiskLevelLow},
+				},
+				Summary: analysis.ComplexitySummary{TotalFunctions: 2, AverageComplexity: 13, MaxComplexity: 25, MinComplexity: 1, LowRiskFunctions: 1, HighRiskFunctions: 1},
 			},
-			Summary: analysis.Summary{TotalFunctions: 2, AverageComplexity: 13, MaxComplexity: 25, MinComplexity: 1, FilesAnalyzed: 2, TotalFiles: 3, SkippedFiles: 1, LowRiskFunctions: 1, HighRiskFunctions: 1},
-			Errors:  []string{"c.go: syntax error at line 9"},
+			Clones: &clone.Report{
+				Pairs:      []clone.Pair{{ID: 0, Type: domain.Type1Clone, Similarity: 1, Confidence: 1, Fragment1: a, Fragment2: b}},
+				Groups:     []clone.Group{{ID: 0, Type: domain.Type1Clone, Similarity: 1, Fragments: []clone.Fragment{a, b}}},
+				Statistics: clone.Statistics{TotalFragments: 2, TotalClones: 2, TotalClonePairs: 1, TotalCloneGroups: 1, ClonesByType: map[string]int{"Type-1": 1}, AverageSimilarity: 1},
+			},
+			Errors: []string{"d.go: syntax error at line 9"},
 		},
 		MinComplexity: minComplexity,
 	}
@@ -33,13 +44,17 @@ func TestWriteText(t *testing.T) {
 		t.Fatal(err)
 	}
 	for _, want := range []string{
-		"=== Complexity Analysis ===",
 		"Generated: 2026-01-02T03:04:05Z",
-		"Files analyzed: 2",
-		"Files skipped: 1",
+		"Files analyzed: 2\nFiles skipped: 1\n",
+		"=== Complexity Analysis ===",
 		"High risk: 1",
 		"Functions:\n  Big: 25 [HIGH]\n    File: a.go:1-40\n  Small: 1\n    File: b.go:3-5\n",
-		"Errors:\n  - c.go: syntax error at line 9\n",
+		"=== Clone Detection ===",
+		"Total clone pairs: 1",
+		"Clone Types:\n  Type-1: 1\n",
+		"Group 1: Type-1, 2 fragments, 100.0% similar\n    Big (a.go:1-40)\n    Copy (c.go:10-49)\n",
+		"Top Clone Pairs:\n  Type-1: Big (a.go:1-40) <-> Copy (c.go:10-49) (100.0% similar)\n",
+		"Errors:\n  - d.go: syntax error at line 9\n",
 	} {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("text output lacks %q:\n%s", want, buf.String())
@@ -61,6 +76,18 @@ func TestWriteTextFiltersListedFunctionsOnly(t *testing.T) {
 	}
 }
 
+func TestWriteTextWithoutClones(t *testing.T) {
+	doc := document(1)
+	doc.Clones = nil
+	var buf bytes.Buffer
+	if err := Write(&buf, doc, domain.OutputFormatText); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(buf.String(), "Clone Detection") {
+		t.Errorf("unselected clone section is present:\n%s", buf.String())
+	}
+}
+
 func TestWriteJSON(t *testing.T) {
 	var buf bytes.Buffer
 	if err := Write(&buf, document(10), domain.OutputFormatJSON); err != nil {
@@ -73,11 +100,16 @@ func TestWriteJSON(t *testing.T) {
 	if len(decoded.Complexity.Functions) != 1 || decoded.Complexity.Functions[0].Name != "Big" {
 		t.Errorf("functions = %+v, want only Big", decoded.Complexity.Functions)
 	}
-	if decoded.Complexity.Summary.TotalFunctions != 2 {
-		t.Errorf("summary total = %d, want 2", decoded.Complexity.Summary.TotalFunctions)
+	if decoded.Complexity.Summary.TotalFunctions != 2 || decoded.Files.Skipped != 1 {
+		t.Errorf("summary total = %d, files = %+v", decoded.Complexity.Summary.TotalFunctions, decoded.Files)
 	}
-	if !strings.Contains(buf.String(), `"decisions": {`) || !strings.Contains(buf.String(), `"risk_level": "high"`) {
-		t.Errorf("JSON lacks expected fields:\n%s", buf.String())
+	if len(decoded.Clones.Pairs) != 1 || decoded.Clones.Pairs[0].Fragment2.Name != "Copy" {
+		t.Errorf("clone pairs = %+v", decoded.Clones.Pairs)
+	}
+	for _, want := range []string{`"decisions": {`, `"risk_level": "high"`, `"clone": {`, `"clones_by_type": {`} {
+		if !strings.Contains(buf.String(), want) {
+			t.Errorf("JSON lacks %s:\n%s", want, buf.String())
+		}
 	}
 }
 

--- a/polyscan/testdata/go/clones/other/sum.go
+++ b/polyscan/testdata/go/clones/other/sum.go
@@ -1,0 +1,18 @@
+package other
+
+import "fmt"
+
+// SumPositive is an exact copy, apart from this comment and the spacing.
+func SumPositive(values []int) (int, int) {
+	total := 0
+	count := 0
+
+	for _, value := range values {
+		if value > 0 { // inline comment
+			total += value
+			count++
+		}
+	}
+	fmt.Printf("%d positive values\n", count)
+	return total, count
+}

--- a/polyscan/testdata/go/clones/sum.go
+++ b/polyscan/testdata/go/clones/sum.go
@@ -1,0 +1,31 @@
+package clones
+
+import "fmt"
+
+// SumPositive adds the positive values and reports how many there were.
+func SumPositive(values []int) (int, int) {
+	total := 0
+	count := 0
+	for _, value := range values {
+		if value > 0 {
+			total += value
+			count++
+		}
+	}
+	fmt.Printf("%d positive values\n", count)
+	return total, count
+}
+
+// SumNegative is SumPositive with the names and the comparison changed.
+func SumNegative(numbers []int) (int, int) {
+	sum := 0
+	seen := 0
+	for _, number := range numbers {
+		if number < 0 {
+			sum += number
+			seen++
+		}
+	}
+	fmt.Printf("%d negative values\n", seen)
+	return sum, seen
+}

--- a/polyscan/testdata/go/clones/sum_test.go
+++ b/polyscan/testdata/go/clones/sum_test.go
@@ -1,0 +1,20 @@
+package clones
+
+import "testing"
+
+// TestSumPositive is another copy of SumPositive. Test files are excluded
+// from clone detection, so it must not be reported.
+func TestSumPositive(t *testing.T) {
+	values := []int{1, -2, 3}
+	total := 0
+	count := 0
+	for _, value := range values {
+		if value > 0 {
+			total += value
+			count++
+		}
+	}
+	if total != 4 || count != 2 {
+		t.Fatalf("got %d, %d", total, count)
+	}
+}


### PR DESCRIPTION
Part of #69, for #71. The HTML report follows in a separate PR.

- The engine builds the tree edit distance tree of every function from named syntax nodes, dropping comments and labeling identifiers, literals and operators, so a language only declares node types (`CloneSpec`)
- Detection reuses `core/clone` end to end: feature extraction, Jaccard pre-filter, APTED with a cost model built from the language's tiers, Type-1 to Type-3 classification, connected grouping and dedupe, LSH candidates above 10,000 pairs
- Tuning on this repository, cobra and golang.org/x/text: Type-4 is not reported (core reserves it for semantic analysis, which polyscan does not run) and test files are excluded from clone detection, which removed the 92% of pairs that were test functions sharing a skeleton. `if err != nil` did not show up as a source of false positives
- Report: clone section in text and JSON, top-level `files` summary, `--select complexity,clone`

Results: this repository 648 fragments → 259 pairs / 47 groups in 1.2s; cobra finds the `Gen*TreeCustom`, `MarkFlags*` and `validate*FlagGroups` families; x/text 3,339 functions in 17s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)