### PR TITLE
fix(core): open the browser on Windows without a shell

### DIFF
--- a/core/util/browser.go
+++ b/core/util/browser.go
@@ -45,8 +45,11 @@ func OpenBrowser(url string) error {
 			return fmt.Errorf("no suitable browser opener found for Linux")
 		}
 	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", url}
+		// rundll32 hands the URL to the file protocol handler without a
+		// shell. "cmd /c start" would let cmd.exe parse the URL, where an
+		// & in a path is a command separator.
+		cmd = "rundll32"
+		args = []string{"url.dll,FileProtocolHandler", url}
 	default:
 		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
 	}

--- a/jscan/service/browser.go
+++ b/jscan/service/browser.go
@@ -1,61 +1,19 @@
 package service
 
-import (
-	"fmt"
-	"os"
-	"os/exec"
-	"runtime"
-)
+import "github.com/ludo-technologies/polyscan/core/util"
 
-// IsSSH returns true if the session is running over SSH
+// IsSSH returns true if the session is running over SSH.
 func IsSSH() bool {
-	return os.Getenv("SSH_TTY") != "" || os.Getenv("SSH_CONNECTION") != ""
+	return util.IsSSH()
 }
 
 // IsInteractiveEnvironment returns true if the environment appears to be
-// an interactive TTY session (and not CI)
+// an interactive TTY session (and not CI).
 func IsInteractiveEnvironment() bool {
-	if os.Getenv("CI") != "" {
-		return false
-	}
-	if fi, err := os.Stderr.Stat(); err == nil {
-		return (fi.Mode() & os.ModeCharDevice) != 0
-	}
-	return false
+	return util.IsInteractiveEnvironment()
 }
 
-// OpenBrowser opens the specified URL in the default browser
+// OpenBrowser opens the specified URL in the default browser.
 func OpenBrowser(url string) error {
-	var cmd string
-	var args []string
-
-	switch runtime.GOOS {
-	case "darwin": // macOS
-		cmd = "open"
-		args = []string{url}
-	case "linux":
-		// Try different commands in order of preference
-		for _, openCmd := range []string{"xdg-open", "gnome-open", "kde-open"} {
-			if _, err := exec.LookPath(openCmd); err == nil {
-				cmd = openCmd
-				args = []string{url}
-				break
-			}
-		}
-		if cmd == "" {
-			return fmt.Errorf("no suitable browser opener found for Linux")
-		}
-	case "windows":
-		cmd = "cmd"
-		args = []string{"/c", "start", url}
-	default:
-		return fmt.Errorf("unsupported platform: %s", runtime.GOOS)
-	}
-
-	// Use Start() instead of Run() to avoid waiting for the browser to close
-	if err := exec.Command(cmd, args...).Start(); err != nil {
-		return fmt.Errorf("failed to open browser: %w", err)
-	}
-
-	return nil
+	return util.OpenBrowser(url)
 }


### PR DESCRIPTION
\`cmd /c start <url>\` let cmd.exe parse the report URL, so an \`&\` in a directory or output name split the command and could run what followed. Windows now opens the URL through \`rundll32 url.dll,FileProtocolHandler\`, which takes the URL as an argument without a shell.

jscan's \`service/browser.go\` was a copy of \`core/util/browser.go\`; it now delegates to core. After merging, core needs a \`core/v0.2.5\` tag so polyscan (#76) can pick the fix up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)