### PR TITLE
feat(polyscan): add the HTML report

### DIFF
--- a/jscan/cmd/jscan/analyze.go
+++ b/jscan/cmd/jscan/analyze.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -298,7 +300,7 @@ func runAnalyze(cmd *cobra.Command, args []string) error {
 
 		// Open in browser unless disabled
 		if !noOpenBrowser && !service.IsSSH() {
-			if err := service.OpenBrowser("file://" + absPath); err != nil {
+			if err := service.OpenBrowser(fileURL(absPath)); err != nil {
 				fmt.Fprintf(os.Stderr, "Warning: Could not open browser: %v\n", err)
 			}
 		}
@@ -539,4 +541,15 @@ func runDepsAnalysisInternal(ctx context.Context, snapshot *service.ProjectSnaps
 		return svc.AnalyzeSnapshot(ctx, snapshot, req)
 	}
 	return svc.Analyze(ctx, req)
+}
+
+// fileURL turns an absolute path into a file URL, escaping characters such
+// as # and ? that would otherwise be read as a fragment or query, and
+// giving Windows drive paths the leading slash the scheme requires.
+func fileURL(absPath string) string {
+	path := filepath.ToSlash(absPath)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }

--- a/jscan/cmd/jscan/cmd_test.go
+++ b/jscan/cmd/jscan/cmd_test.go
@@ -199,3 +199,14 @@ func TestVersionCmd_ExecuteVerbose(t *testing.T) {
 		t.Errorf("versionCmd.Execute(--verbose) error = %v", err)
 	}
 }
+
+func TestFileURL(t *testing.T) {
+	for path, want := range map[string]string{
+		"/tmp/report.html":        "file:///tmp/report.html",
+		"/tmp/a b#1/report?.html": "file:///tmp/a%20b%231/report%3F.html",
+	} {
+		if got := fileURL(path); got != want {
+			t.Errorf("fileURL(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -17,11 +17,15 @@ go install github.com/ludo-technologies/polyscan/polyscan/cmd/polyscan@latest
 ## Usage
 
 ```bash
-# Text report to stdout
+# HTML report, written to polyscan-report.html and opened in the browser
 polyscan analyze .
 
-# JSON report to stdout
+# HTML report to a chosen path, without opening the browser
+polyscan analyze --no-open -o report.html .
+
+# JSON or text report to stdout
 polyscan analyze --format json src/
+polyscan analyze --format text src/
 
 # Clone detection only
 polyscan analyze --select clone .

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -2,9 +2,12 @@ package main
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/core/util"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/analysis"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/report"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/version"
@@ -14,12 +17,16 @@ import (
 const (
 	selectComplexity = "complexity"
 	selectClone      = "clone"
+
+	defaultReportPath = "polyscan-report.html"
 )
 
 func analyzeCmd() *cobra.Command {
 	var (
 		selected      []string
 		format        string
+		outputPath    string
+		noOpen        bool
 		minComplexity int
 	)
 
@@ -30,16 +37,22 @@ func analyzeCmd() *cobra.Command {
 
 The language of each file is detected from its extension. Supported: Go.
 
+By default, generates an HTML report and opens it in your browser.
+
 Examples:
-  polyscan analyze .                        # Text report to stdout
+  polyscan analyze .                        # HTML report, opened in the browser
+  polyscan analyze --no-open -o out.html .  # HTML report written to out.html
   polyscan analyze --format json src/       # JSON report to stdout
+  polyscan analyze --format text src/       # Text report to stdout
   polyscan analyze --select clone .         # Clone detection only
   polyscan analyze --min-complexity 10 .    # List only functions at or above 10`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat := domain.OutputFormat(format)
-			if outputFormat != domain.OutputFormatText && outputFormat != domain.OutputFormatJSON {
-				return fmt.Errorf("invalid format %q, must be one of: text, json", format)
+			switch outputFormat {
+			case domain.OutputFormatHTML, domain.OutputFormatJSON, domain.OutputFormatText:
+			default:
+				return fmt.Errorf("invalid format %q, must be one of: html, json, text", format)
 			}
 			if minComplexity < 1 {
 				return fmt.Errorf("--min-complexity must be at least 1")
@@ -54,22 +67,57 @@ Examples:
 			if err != nil {
 				return err
 			}
-
-			return report.Write(cmd.OutOrStdout(), &report.Document{
+			doc := &report.Document{
 				Version:       version.Version,
 				GeneratedAt:   start,
 				DurationMs:    time.Since(start).Milliseconds(),
 				Report:        result,
 				MinComplexity: minComplexity,
-			}, outputFormat)
+			}
+
+			if outputFormat != domain.OutputFormatHTML {
+				return report.Write(cmd.OutOrStdout(), doc, outputFormat)
+			}
+			if outputPath == "" {
+				outputPath = defaultReportPath
+			}
+			if err := writeReportFile(outputPath, doc); err != nil {
+				return err
+			}
+			absPath, err := filepath.Abs(outputPath)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintf(cmd.OutOrStdout(), "HTML report written to %s\n", absPath)
+			if noOpen || util.IsSSH() {
+				return nil
+			}
+			if err := util.OpenBrowser("file://" + absPath); err != nil {
+				fmt.Fprintf(cmd.ErrOrStderr(), "Could not open the browser: %v\n", err)
+			}
+			return nil
 		},
 	}
 
 	cmd.Flags().StringSliceVarP(&selected, "select", "s", []string{selectComplexity, selectClone},
 		"Analyses to run (comma-separated): complexity,clone")
-	cmd.Flags().StringVarP(&format, "format", "f", "text", "Output format: text, json")
+	cmd.Flags().StringVarP(&format, "format", "f", "html", "Output format: html, json, text")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "HTML report path (default: "+defaultReportPath+")")
+	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
 	cmd.Flags().IntVar(&minComplexity, "min-complexity", 1, "List only functions with at least this complexity")
 	return cmd
+}
+
+func writeReportFile(path string, doc *report.Document) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create HTML report: %w", err)
+	}
+	if err := report.Write(file, doc, domain.OutputFormatHTML); err != nil {
+		file.Close()
+		return err
+	}
+	return file.Close()
 }
 
 func parseSelection(selected []string) (analysis.Options, error) {

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -2,8 +2,10 @@ package main
 
 import (
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
@@ -92,7 +94,7 @@ Examples:
 			if noOpen || util.IsSSH() {
 				return nil
 			}
-			if err := util.OpenBrowser("file://" + absPath); err != nil {
+			if err := util.OpenBrowser(fileURL(absPath)); err != nil {
 				fmt.Fprintf(cmd.ErrOrStderr(), "Could not open the browser: %v\n", err)
 			}
 			return nil
@@ -106,6 +108,17 @@ Examples:
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
 	cmd.Flags().IntVar(&minComplexity, "min-complexity", 1, "List only functions with at least this complexity")
 	return cmd
+}
+
+// fileURL turns an absolute path into a file URL, escaping characters such
+// as # and ? that would otherwise be read as a fragment or query, and
+// giving Windows drive paths the leading slash the scheme requires.
+func fileURL(absPath string) string {
+	path := filepath.ToSlash(absPath)
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
 func writeReportFile(path string, doc *report.Document) error {

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -103,3 +103,14 @@ func TestVersion(t *testing.T) {
 		t.Errorf("unexpected output %q", out)
 	}
 }
+
+func TestFileURL(t *testing.T) {
+	for path, want := range map[string]string{
+		"/tmp/report.html":        "file:///tmp/report.html",
+		"/tmp/a b#1/report?.html": "file:///tmp/a%20b%231/report%3F.html",
+	} {
+		if got := fileURL(path); got != want {
+			t.Errorf("fileURL(%q) = %q, want %q", path, got, want)
+		}
+	}
+}

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -21,7 +23,7 @@ func run(t *testing.T, args ...string) (string, error) {
 }
 
 func TestAnalyzeText(t *testing.T) {
-	out, err := run(t, "analyze", "../../testdata/go/sample.go")
+	out, err := run(t, "analyze", "--format", "text", "../../testdata/go/sample.go")
 	if err != nil {
 		t.Fatalf("analyze: %v\n%s", err, out)
 	}
@@ -47,8 +49,28 @@ func TestAnalyzeJSON(t *testing.T) {
 	}
 }
 
+func TestAnalyzeHTML(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "report.html")
+	out, err := run(t, "analyze", "--no-open", "-o", path, "../../testdata/go")
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "HTML report written to ") {
+		t.Errorf("unexpected output:\n%s", out)
+	}
+	html, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"<title>polyscan report</title>", "Server.Handle", "Clone groups", "SumPositive"} {
+		if !strings.Contains(string(html), want) {
+			t.Errorf("HTML report lacks %q", want)
+		}
+	}
+}
+
 func TestAnalyzeSelect(t *testing.T) {
-	out, err := run(t, "analyze", "--select", "clone", "../../testdata/go/clones")
+	out, err := run(t, "analyze", "--format", "text", "--select", "clone", "../../testdata/go/clones")
 	if err != nil {
 		t.Fatalf("analyze: %v\n%s", err, out)
 	}
@@ -62,7 +84,7 @@ func TestAnalyzeRejectsBadArguments(t *testing.T) {
 		{"analyze"},
 		{"analyze", "--select", "deadcode", "../../testdata/go"},
 		{"analyze", "--select=", "../../testdata/go"},
-		{"analyze", "--format", "html", "../../testdata/go"},
+		{"analyze", "--format", "yaml", "../../testdata/go"},
 		{"analyze", "--min-complexity", "0", "../../testdata/go"},
 		{"analyze", "does-not-exist"},
 	} {

--- a/polyscan/go.mod
+++ b/polyscan/go.mod
@@ -3,7 +3,7 @@ module github.com/ludo-technologies/polyscan/polyscan
 go 1.24.6
 
 require (
-	github.com/ludo-technologies/polyscan/core v0.2.4
+	github.com/ludo-technologies/polyscan/core v0.2.5
 	github.com/smacker/go-tree-sitter v0.0.0-20240827094217-dd81d9e9be82
 	github.com/spf13/cobra v1.10.1
 )

--- a/polyscan/go.sum
+++ b/polyscan/go.sum
@@ -3,8 +3,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
-github.com/ludo-technologies/polyscan/core v0.2.4 h1:fYI+12cLH4wQi6o0r8VZTovqfAThexyOIlwmb4gp6Mw=
-github.com/ludo-technologies/polyscan/core v0.2.4/go.mod h1:l3sHFjhyrJSZECb10hA9cX1OtqnJfXU1CT5eNiQ8eF4=
+github.com/ludo-technologies/polyscan/core v0.2.5 h1:/mEJ3qVr9ufvvJ/+x77FaR2GJdgv3iuGxU7jxsI3v+0=
+github.com/ludo-technologies/polyscan/core v0.2.5/go.mod h1:l3sHFjhyrJSZECb10hA9cX1OtqnJfXU1CT5eNiQ8eF4=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=

--- a/polyscan/internal/clone/detector.go
+++ b/polyscan/internal/clone/detector.go
@@ -117,6 +117,9 @@ type Fragment struct {
 	// LineCount counts lines of code: blank lines and comments excluded.
 	LineCount int `json:"line_count"`
 	NodeCount int `json:"node_count"`
+	// Content is the fragment's source text with comments removed, for
+	// previews. It is not part of the JSON report.
+	Content string `json:"-"`
 }
 
 // Statistics summarizes a detection run.
@@ -500,5 +503,6 @@ func (d *Detector) fragment(f *coreclone.CodeFragment) Fragment {
 		EndLine:   f.EndLine,
 		LineCount: f.LineCount,
 		NodeCount: f.NodeCount,
+		Content:   f.Content,
 	}
 }

--- a/polyscan/internal/report/html.go
+++ b/polyscan/internal/report/html.go
@@ -1,0 +1,236 @@
+package report
+
+import (
+	"embed"
+	"fmt"
+	"html/template"
+	"io"
+	"strings"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/analysis"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
+)
+
+//go:embed templates/*
+var templates embed.FS
+
+var htmlTemplate = template.Must(
+	template.New("report.html").
+		Funcs(template.FuncMap{
+			"add":      func(a, b int) int { return a + b },
+			"sub":      func(a, b int) int { return a - b },
+			"addf":     func(a, b float64) float64 { return a + b },
+			"divf":     func(a, b float64) float64 { return a / b },
+			"int":      func(t domain.CloneType) int { return int(t) },
+			"percent":  func(ratio float64) string { return fmt.Sprintf("%.1f%%", ratio*100) },
+			"lineSpan": func(fn analysis.Function) int { return fn.EndLine - fn.StartLine + 1 },
+			"preview":  preview,
+		}).
+		ParseFS(templates, "templates/report.html"),
+)
+
+var css = func() template.CSS {
+	data, err := templates.ReadFile("templates/report.css")
+	if err != nil {
+		panic(err)
+	}
+	return template.CSS(data)
+}()
+
+// Limits on what the HTML report lists; the JSON report carries everything.
+const (
+	htmlFunctionLimit = 20
+	htmlGroupLimit    = 10
+	previewLines      = 8
+)
+
+// htmlView is the data handed to the template: the document plus the
+// pre-computed blocks, so the template stays free of arithmetic.
+type htmlView struct {
+	CSS template.CSS
+	*Document
+	// Functions is the head of the listed functions and ListedFunctions
+	// how many passed the filter in total.
+	Functions       []analysis.Function
+	ListedFunctions int
+	Histogram       *histogram
+	Duplication     []share
+	Groups          []clone.Group
+}
+
+// share is one clone type's slice of the pairs.
+type share struct {
+	Label   string
+	Percent float64
+	Class   string
+}
+
+func writeHTML(w io.Writer, doc *Document) error {
+	view := htmlView{CSS: css, Document: doc}
+	if doc.Complexity != nil {
+		functions := listed(doc)
+		view.ListedFunctions = len(functions)
+		view.Functions = functions[:min(htmlFunctionLimit, len(functions))]
+		view.Histogram = buildHistogram(doc.Complexity.Functions)
+	}
+	if doc.Clones != nil {
+		view.Duplication = buildDuplication(doc.Clones)
+		view.Groups = doc.Clones.Groups[:min(htmlGroupLimit, len(doc.Clones.Groups))]
+	}
+	if err := htmlTemplate.Execute(w, view); err != nil {
+		return fmt.Errorf("render HTML report: %w", err)
+	}
+	return nil
+}
+
+func buildDuplication(clones *clone.Report) []share {
+	if len(clones.Pairs) == 0 {
+		return nil
+	}
+	var shares []share
+	for _, cloneType := range []domain.CloneType{domain.Type1Clone, domain.Type2Clone, domain.Type3Clone} {
+		count := clones.Statistics.ClonesByType[cloneType.String()]
+		if count == 0 {
+			continue
+		}
+		shares = append(shares, share{
+			Label:   fmt.Sprintf("%s %s · %d pairs", cloneType, domain.CloneTypeNames[cloneType], count),
+			Percent: float64(count) * 100 / float64(len(clones.Pairs)),
+			Class:   fmt.Sprintf("t%d", int(cloneType)),
+		})
+	}
+	return shares
+}
+
+// preview returns the first lines of a fragment.
+func preview(fragment clone.Fragment) string {
+	lines := strings.Split(fragment.Content, "\n")
+	if len(lines) <= previewLines {
+		return fragment.Content
+	}
+	return strings.Join(lines[:previewLines], "\n") + "\n..."
+}
+
+// Histogram geometry, in the 420x190 viewBox of the chart.
+const (
+	histLeft      = 48.0
+	histRight     = 412.0
+	histTop       = 18.0
+	histBaseline  = 150.0
+	histBarFill   = 0.72
+	histTickCount = 3
+)
+
+type histogram struct {
+	Total int
+	Bins  []histogramBin
+	Ticks []histogramTick
+}
+
+type histogramBin struct {
+	Label  string
+	Count  int
+	X      float64
+	Y      float64
+	Width  float64
+	Height float64
+	Band   string
+}
+
+type histogramTick struct {
+	Label string
+	Y     float64
+}
+
+// histogramBins follows the risk thresholds: 1 | 2–5 | 6–low | low+1–medium
+// | medium+1+, so that each bucket carries a single risk color.
+func histogramBins() []histogramBin {
+	low, medium := domain.DefaultComplexityLowThreshold, domain.DefaultComplexityMediumThreshold
+	return []histogramBin{
+		{Label: "1"},
+		{Label: "2–5"},
+		{Label: fmt.Sprintf("6–%d", low)},
+		{Label: fmt.Sprintf("%d–%d", low+1, medium), Band: "warn"},
+		{Label: fmt.Sprintf("%d+", medium+1), Band: "bad"},
+	}
+}
+
+func binIndex(complexity int) int {
+	switch {
+	case complexity <= 1:
+		return 0
+	case complexity <= 5:
+		return 1
+	case complexity <= domain.DefaultComplexityLowThreshold:
+		return 2
+	case complexity <= domain.DefaultComplexityMediumThreshold:
+		return 3
+	default:
+		return 4
+	}
+}
+
+// buildHistogram plots the complete analyzed population, whatever the
+// report filter lists.
+func buildHistogram(functions []analysis.Function) *histogram {
+	if len(functions) == 0 {
+		return nil
+	}
+	bins := histogramBins()
+	for _, fn := range functions {
+		bins[binIndex(fn.Complexity)].Count++
+	}
+
+	maxCount := 1
+	for _, bin := range bins {
+		maxCount = max(maxCount, bin.Count)
+	}
+	niceMax := niceCeiling(maxCount)
+	scale := (histBaseline - histTop) / float64(niceMax)
+
+	slot := (histRight - histLeft) / float64(len(bins))
+	barWidth := slot * histBarFill
+	hist := &histogram{Total: len(functions)}
+	for i, bin := range bins {
+		height := float64(bin.Count) * scale
+		if bin.Count > 0 && height < 1 {
+			height = 1
+		}
+		bin.X = round1(histLeft + slot*float64(i) + (slot-barWidth)/2)
+		bin.Y = round1(histBaseline - height)
+		bin.Width = round1(barWidth)
+		bin.Height = round1(height)
+		hist.Bins = append(hist.Bins, bin)
+	}
+	for i := 0; i <= histTickCount; i++ {
+		value := niceMax * i / histTickCount
+		hist.Ticks = append(hist.Ticks, histogramTick{
+			Label: fmt.Sprint(value),
+			Y:     round1(histBaseline - float64(value)*scale),
+		})
+	}
+	return hist
+}
+
+// niceCeiling rounds n up to a tidy axis maximum so ticks land on round
+// numbers.
+func niceCeiling(n int) int {
+	if n <= 3 {
+		return 3
+	}
+	magnitude := 1
+	for n/magnitude >= 10 {
+		magnitude *= 10
+	}
+	for _, step := range []int{1, 2, 3, 5, 6, 10} {
+		if candidate := step * magnitude; candidate >= n {
+			return candidate
+		}
+	}
+	return magnitude * 10
+}
+
+func round1(v float64) float64 {
+	return float64(int(v*10+0.5)) / 10
+}

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -36,6 +36,8 @@ func Write(w io.Writer, doc *Document, format domain.OutputFormat) error {
 	case domain.OutputFormatText:
 		writeText(w, doc)
 		return nil
+	case domain.OutputFormatHTML:
+		return writeHTML(w, doc)
 	default:
 		return fmt.Errorf("unsupported output format %q", format)
 	}

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func document(minComplexity int) *Document {
-	a := clone.Fragment{ID: 0, Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, LineCount: 40, NodeCount: 90}
+	a := clone.Fragment{ID: 0, Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, LineCount: 40, NodeCount: 90, Content: "func Big() {\n\tif a < b {\n\t}\n}"}
 	b := clone.Fragment{ID: 1, Name: "Copy", FilePath: "c.go", StartLine: 10, EndLine: 49, LineCount: 40, NodeCount: 90}
 	return &Document{
 		Version:     "test",
@@ -113,8 +113,52 @@ func TestWriteJSON(t *testing.T) {
 	}
 }
 
+func TestWriteHTML(t *testing.T) {
+	var buf bytes.Buffer
+	if err := Write(&buf, document(10), domain.OutputFormatHTML); err != nil {
+		t.Fatal(err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		"<title>polyscan report</title>",
+		"2 of 3 files analyzed, 1 skipped",
+		`<td class="mono">Big</td>`,
+		"complexity 10 and above",
+		"Type-1 Exact · 1 pairs",
+		"Group 1",
+		"if a &lt; b {", // the preview is escaped
+		"d.go: syntax error at line 9",
+		"CC 20&#43;: 1 functions", // html/template escapes the plus
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("HTML lacks %q:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "Small") {
+		t.Errorf("HTML lists a function below the filter:\n%s", out)
+	}
+}
+
 func TestWriteRejectsUnknownFormat(t *testing.T) {
-	if err := Write(&bytes.Buffer{}, document(1), domain.OutputFormatHTML); err == nil {
-		t.Error("expected an error for html")
+	if err := Write(&bytes.Buffer{}, document(1), domain.OutputFormatYAML); err == nil {
+		t.Error("expected an error for yaml")
+	}
+}
+
+func TestHistogramBins(t *testing.T) {
+	functions := []analysis.Function{{Complexity: 1}, {Complexity: 3}, {Complexity: 9}, {Complexity: 10}, {Complexity: 19}, {Complexity: 20}, {Complexity: 20}}
+	hist := buildHistogram(functions)
+	counts := []int{}
+	for _, bin := range hist.Bins {
+		counts = append(counts, bin.Count)
+	}
+	if want := []int{1, 1, 1, 2, 2}; len(counts) != len(want) || counts[0] != 1 || counts[1] != 1 || counts[2] != 1 || counts[3] != 2 || counts[4] != 2 {
+		t.Errorf("bin counts = %v, want %v", counts, want)
+	}
+	if hist.Bins[3].Band != "warn" || hist.Bins[4].Band != "bad" || hist.Bins[2].Band != "" {
+		t.Errorf("bands = %+v", hist.Bins)
+	}
+	if buildHistogram(nil) != nil {
+		t.Error("empty population must have no histogram")
 	}
 }

--- a/polyscan/internal/report/templates/report.css
+++ b/polyscan/internal/report/templates/report.css
@@ -1,0 +1,150 @@
+/* polyscan report styles, adapted from the jscan report. Self-contained: no external fonts or scripts. */
+:root {
+  color-scheme: light;
+  --page: #f3f5f8;
+  --surface: #ffffff;
+  --surface-2: #f8fafc;
+  --ink: #0f172a;
+  --ink-2: #475569;
+  --muted: #7c8797;
+  --line: #e3e8ef;
+  --accent: #00add8;
+  --accent-ink: #007d9c;
+  --violet: #7c3aed;
+  --good: #15803d;
+  --good-soft: #e3f4e8;
+  --warn: #b45309;
+  --warn-soft: #fdf0dc;
+  --bad: #b91c1c;
+  --bad-soft: #fde8e8;
+  --info-soft: #e6eefc;
+  --track: #e6eaf0;
+  --shadow: 0 1px 2px rgba(15, 23, 42, .05), 0 1px 1px rgba(15, 23, 42, .03);
+  --mono: ui-monospace, "SF Mono", "JetBrains Mono", Menlo, Consolas, monospace;
+  --sans: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+}
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]) {
+    color-scheme: dark;
+    --page: #0e1218;
+    --surface: #161c25;
+    --surface-2: #1c232e;
+    --ink: #e8edf4;
+    --ink-2: #b1bccb;
+    --muted: #7f8ca0;
+    --line: #263040;
+    --accent: #5dc9e2;
+    --accent-ink: #8fd9ec;
+    --violet: #a78bfa;
+    --good: #4ade80;
+    --good-soft: #14301f;
+    --warn: #fbbf24;
+    --warn-soft: #3a2a0c;
+    --bad: #f87171;
+    --bad-soft: #3d1717;
+    --info-soft: #1b2a45;
+    --track: #263040;
+    --shadow: none;
+  }
+}
+
+* { box-sizing: border-box; }
+body {
+  margin: 0;
+  background: var(--page);
+  color: var(--ink);
+  font-family: var(--sans);
+  font-size: 14px;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+}
+a { color: inherit; }
+h1, h2, h3 { margin: 0; font-weight: 650; letter-spacing: -.01em; }
+h3 { font-size: 14px; margin: 22px 0 10px; }
+.num { font-variant-numeric: tabular-nums; }
+.mono { font-family: var(--mono); font-size: 12.5px; }
+.muted { color: var(--muted); }
+.small { font-size: 12px; }
+.wrap { white-space: normal !important; word-break: break-word; }
+.warn { color: var(--warn); }
+.bad  { color: var(--bad); }
+
+/* ---------- top bar ---------- */
+.topbar { background: var(--surface); border-bottom: 1px solid var(--line); }
+.topbar-inner {
+  max-width: 1200px; margin: 0 auto; padding: 14px 24px;
+  display: flex; align-items: center; gap: 20px; flex-wrap: wrap;
+}
+.brand { font-family: var(--mono); font-weight: 700; font-size: 18px; letter-spacing: -.01em; }
+.brand .ver { font-weight: 400; font-size: 12px; color: var(--muted); margin-left: 2px; }
+.meta { margin-left: auto; color: var(--muted); font-size: 12px; display: flex; gap: 14px; }
+
+main { max-width: 1200px; margin: 0 auto; padding: 24px 24px 40px; }
+.section-h { display: flex; align-items: baseline; justify-content: space-between; gap: 16px; flex-wrap: wrap; margin: 8px 0 16px; }
+.section-h h2 { font-size: 20px; }
+.card {
+  background: var(--surface); border: 1px solid var(--line); border-radius: 12px; box-shadow: var(--shadow);
+  padding: 18px 20px; min-width: 0; margin-bottom: 20px;
+}
+.card-h { display: flex; align-items: baseline; justify-content: space-between; margin-bottom: 14px; gap: 12px; }
+.card-h h2 { font-size: 13px; font-weight: 600; letter-spacing: .04em; text-transform: uppercase; color: var(--ink-2); }
+.note { margin: 12px 0 0; }
+.ok-msg { color: var(--good); font-weight: 600; margin: 8px 0 0; }
+.callout { margin-top: 14px; padding: 12px 14px; border-radius: 8px; font-size: 13px; background: var(--bad-soft); color: var(--ink); }
+.callout ul { margin: 6px 0 0; padding-left: 20px; }
+
+/* ---------- tables ---------- */
+.tbl-wrap { overflow-x: auto; }
+.tbl { width: 100%; border-collapse: collapse; font-size: 13px; }
+.tbl th { text-align: left; font-weight: 500; font-size: 11.5px; letter-spacing: .03em; text-transform: uppercase; color: var(--muted); padding: 0 10px 8px 0; border-bottom: 1px solid var(--line); white-space: nowrap; }
+.tbl th.r, .tbl td.r { text-align: right; }
+.tbl td { padding: 8px 10px 8px 0; border-bottom: 1px solid var(--line); vertical-align: middle; white-space: nowrap; }
+.tbl td:last-child, .tbl th:last-child { padding-right: 0; }
+.tbl tbody tr:last-child td { border-bottom: 0; }
+.tbl tbody tr:hover td { background: var(--surface-2); }
+.tbl.compact td { padding-top: 5px; padding-bottom: 5px; }
+.tbl tr.preview-row td { white-space: normal; padding-top: 0; }
+.tbl tr.preview-row:hover td { background: transparent; }
+.pill { display: inline-block; min-width: 22px; text-align: center; font-family: var(--mono); font-size: 12px; padding: 1px 6px; border-radius: 6px; background: var(--surface-2); color: var(--muted); }
+.pill.risk-high { background: var(--bad-soft); color: var(--bad); }
+.pill.risk-medium { background: var(--warn-soft); color: var(--warn); }
+.pill.risk-low { background: var(--good-soft); color: var(--good); }
+.pill.t1 { background: var(--good-soft); color: var(--good); }
+.pill.t2 { background: color-mix(in srgb, var(--violet) 15%, transparent); color: var(--violet); }
+.pill.t3 { background: var(--info-soft); color: var(--accent-ink); }
+
+/* ---------- charts ---------- */
+.chart { width: 100%; max-width: 520px; height: auto; display: block; overflow: visible; }
+.chart text { font-family: var(--sans); fill: var(--muted); font-size: 11px; }
+.chart .lbl { fill: var(--ink-2); font-weight: 600; font-size: 11.5px; }
+.chart .lbl.warn { fill: var(--warn); }
+.chart .lbl.bad { fill: var(--bad); }
+.chart .grid line { stroke: var(--line); }
+.chart .b { fill: var(--accent); }
+.chart .b.warn { fill: var(--warn); }
+.chart .b.bad { fill: var(--bad); }
+.legend { display: flex; gap: 14px; flex-wrap: wrap; font-size: 12px; color: var(--ink-2); margin-top: 8px; }
+.legend i { display: inline-block; width: 10px; height: 10px; border-radius: 2px; margin-right: 6px; vertical-align: -1px; }
+.stack { display: flex; height: 10px; border-radius: 5px; overflow: hidden; gap: 2px; background: var(--track); margin-top: 10px; max-width: 520px; }
+.stack > i { display: block; height: 100%; }
+.t1 { background: var(--good); }
+.t2 { background: var(--violet); }
+.t3 { background: var(--accent); }
+
+/* ---------- metric strip ---------- */
+.strip { display: flex; flex-wrap: wrap; gap: 8px 0; margin-bottom: 6px; }
+.strip .s { padding: 4px 20px; border-left: 1px solid var(--line); min-width: 120px; }
+.strip .s:first-child { padding-left: 0; border-left: 0; }
+.strip .v { font-size: 22px; font-weight: 650; letter-spacing: -.02em; line-height: 1.1; }
+.strip .v small { font-size: 13px; font-weight: 500; color: var(--muted); }
+.strip .l { font-size: 12px; color: var(--muted); margin-top: 3px; }
+
+/* ---------- clone groups & previews ---------- */
+.clone-group { border: 1px solid var(--line); border-radius: 10px; padding: 12px 14px; margin-bottom: 12px; background: var(--surface-2); }
+.clone-group-h { display: flex; align-items: center; gap: 10px; margin-bottom: 8px; font-size: 13px; }
+.code-preview-card { margin: 4px 0 8px; border: 1px solid var(--line); border-radius: 8px; background: var(--surface); overflow: hidden; }
+.code-preview-title { font-size: 11px; letter-spacing: .04em; text-transform: uppercase; color: var(--muted); padding: 6px 10px; border-bottom: 1px solid var(--line); }
+.code-preview { margin: 0; padding: 10px; font-family: var(--mono); font-size: 12px; line-height: 1.5; overflow-x: auto; color: var(--ink); }
+
+footer { max-width: 1200px; margin: 0 auto; padding: 0 24px 40px; color: var(--muted); font-size: 12px; display: flex; justify-content: space-between; gap: 12px; flex-wrap: wrap; }
+footer a { color: var(--ink-2); }

--- a/polyscan/internal/report/templates/report.html
+++ b/polyscan/internal/report/templates/report.html
@@ -1,0 +1,157 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>polyscan report</title>
+<style>{{.CSS}}</style>
+</head>
+<body>
+
+<header class="topbar">
+  <div class="topbar-inner">
+    <div class="brand">polyscan{{if .Version}} <span class="ver">{{.Version}}</span>{{end}}</div>
+    <div class="meta">
+      <span>{{.GeneratedAt.Format "2006-01-02 15:04"}}</span>
+      <span>{{if .Files.Skipped}}<span class="bad">{{.Files.Analyzed}} of {{.Files.Total}} files analyzed, {{.Files.Skipped}} skipped</span>{{else}}{{.Files.Total}} files{{end}} in {{.DurationMs}}ms</span>
+    </div>
+  </div>
+</header>
+
+<main>
+
+{{with .Complexity}}
+<div class="section-h"><h2>Complexity</h2></div>
+<div class="card">
+  <div class="strip">
+    <div class="s"><div class="v num">{{.Summary.TotalFunctions}}</div><div class="l">functions</div></div>
+    <div class="s"><div class="v num">{{printf "%.2f" .Summary.AverageComplexity}}</div><div class="l">average CC</div></div>
+    <div class="s"><div class="v num">{{.Summary.MaxComplexity}}</div><div class="l">max CC</div></div>
+    <div class="s"><div class="v num{{if .Summary.HighRiskFunctions}} bad{{end}}">{{.Summary.HighRiskFunctions}}</div><div class="l">high risk</div></div>
+    <div class="s"><div class="v num{{if .Summary.MediumRiskFunctions}} warn{{end}}">{{.Summary.MediumRiskFunctions}}</div><div class="l">medium risk</div></div>
+  </div>
+</div>
+
+{{with $.Histogram}}
+<div class="card">
+  <div class="card-h"><h2>Complexity distribution</h2><span class="muted small">{{.Total}} functions</span></div>
+  <svg class="chart" viewBox="0 0 420 190" role="img" aria-label="Histogram of cyclomatic complexity">
+    <g class="grid">{{range .Ticks}}<line x1="44" y1="{{.Y}}" x2="412" y2="{{.Y}}"/>{{end}}</g>
+    {{range .Ticks}}<text x="38" y="{{printf "%.1f" (addf .Y 3.5)}}" text-anchor="end">{{.Label}}</text>{{end}}
+    {{range .Bins}}<rect class="b {{.Band}}" x="{{.X}}" y="{{.Y}}" width="{{.Width}}" height="{{.Height}}" rx="3"><title>CC {{.Label}}: {{.Count}} functions</title></rect>{{end}}
+    {{range .Bins}}<text class="lbl {{.Band}}" x="{{printf "%.1f" (addf .X (divf .Width 2))}}" y="{{printf "%.1f" (addf .Y -6)}}" text-anchor="middle">{{.Count}}</text>{{end}}
+    {{range .Bins}}<text x="{{printf "%.1f" (addf .X (divf .Width 2))}}" y="170" text-anchor="middle">{{.Label}}</text>{{end}}
+    <text x="228" y="186" text-anchor="middle">cyclomatic complexity</text>
+  </svg>
+</div>
+{{end}}
+
+{{if $.Functions}}
+<div class="card">
+  <div class="card-h"><h2>Most complex functions</h2><span class="muted small">{{if gt $.MinComplexity 1}}complexity {{$.MinComplexity}} and above{{end}}</span></div>
+  <div class="tbl-wrap">
+    <table class="tbl">
+      <thead><tr><th>Function</th><th>File</th><th class="r">CC</th><th class="r">Lines</th><th>Risk</th></tr></thead>
+      <tbody>
+        {{range $.Functions}}
+        <tr>
+          <td class="mono">{{.Name}}</td>
+          <td class="mono muted">{{.FilePath}}:{{.StartLine}}</td>
+          <td class="r num">{{.Complexity}}</td>
+          <td class="r num">{{lineSpan .}}</td>
+          <td><span class="pill risk-{{.RiskLevel}}">{{.RiskLevel}}</span></td>
+        </tr>
+        {{end}}
+      </tbody>
+    </table>
+  </div>
+  {{if gt $.ListedFunctions (len $.Functions)}}<p class="muted small note">Showing top {{len $.Functions}} of {{$.ListedFunctions}} functions. Use --format json or --format text for the complete list.</p>{{end}}
+</div>
+{{end}}
+{{end}}
+
+{{with .Clones}}
+<div class="section-h"><h2>Duplication</h2><span class="muted small">test files are not compared</span></div>
+<div class="card">
+  <div class="strip">
+    <div class="s"><div class="v num">{{.Statistics.TotalClones}}<small> / {{.Statistics.TotalFragments}}</small></div><div class="l">fragments cloned</div></div>
+    <div class="s"><div class="v num">{{.Statistics.TotalCloneGroups}}</div><div class="l">clone groups</div></div>
+    <div class="s"><div class="v num">{{.Statistics.TotalClonePairs}}</div><div class="l">clone pairs</div></div>
+    <div class="s"><div class="v num">{{percent .Statistics.AverageSimilarity}}</div><div class="l">avg similarity</div></div>
+  </div>
+  {{if $.Duplication}}
+  <div class="stack" role="img" aria-label="Clone pairs by type">{{range $.Duplication}}<i class="{{.Class}}" style="width:{{printf "%.1f" .Percent}}%" title="{{.Label}}"></i>{{end}}</div>
+  <div class="legend">{{range $.Duplication}}<span><i class="{{.Class}}"></i>{{.Label}}</span>{{end}}</div>
+  {{end}}
+</div>
+
+{{if .Groups}}
+<div class="card">
+  <div class="card-h"><h2>Clone groups</h2><span class="muted small">functions grouped by similarity</span></div>
+  {{range $.Groups}}
+  <div class="clone-group">
+    <div class="clone-group-h">
+      <span class="pill t{{int .Type}}">{{.Type}}</span>
+      <b>Group {{add .ID 1}}</b>
+      <span class="muted">{{len .Fragments}} fragments · similarity {{percent .Similarity}}</span>
+    </div>
+    <div class="tbl-wrap">
+      <table class="tbl compact">
+        <thead><tr><th>Function</th><th>File</th><th class="r">Lines</th></tr></thead>
+        <tbody>
+          {{range $j, $fragment := .Fragments}}{{if lt $j 10}}
+          <tr>
+            <td class="mono">{{$fragment.Name}}</td>
+            <td class="mono muted">{{$fragment.FilePath}}</td>
+            <td class="r num">{{$fragment.StartLine}}-{{$fragment.EndLine}}</td>
+          </tr>
+          {{with preview $fragment}}
+          <tr class="preview-row"><td colspan="3">
+            <div class="code-preview-card"><div class="code-preview-title">Code preview</div><pre class="code-preview">{{.}}</pre></div>
+          </td></tr>
+          {{end}}
+          {{end}}{{end}}
+          {{if gt (len .Fragments) 10}}<tr><td colspan="3" class="muted">... and {{sub (len .Fragments) 10}} more fragments</td></tr>{{end}}
+        </tbody>
+      </table>
+    </div>
+  </div>
+  {{end}}
+  {{if gt (len .Groups) (len $.Groups)}}<p class="muted small note">Showing top {{len $.Groups}} of {{len .Groups}} clone groups. Use --format json for the complete list.</p>{{end}}
+</div>
+{{else if .Pairs}}
+<div class="card">
+  <div class="card-h"><h2>Clone pairs</h2><span class="muted small">no groups formed, showing individual pairs</span></div>
+  <div class="tbl-wrap">
+    <table class="tbl">
+      <thead><tr><th>Function 1</th><th>Function 2</th><th class="r">Similarity</th><th>Type</th></tr></thead>
+      <tbody>
+        {{range $i, $pair := .Pairs}}{{if lt $i 20}}
+        <tr>
+          <td class="mono">{{$pair.Fragment1.Name}} <span class="muted">{{$pair.Fragment1.FilePath}}:{{$pair.Fragment1.StartLine}}</span></td>
+          <td class="mono">{{$pair.Fragment2.Name}} <span class="muted">{{$pair.Fragment2.FilePath}}:{{$pair.Fragment2.StartLine}}</span></td>
+          <td class="r num">{{percent $pair.Similarity}}</td>
+          <td><span class="pill t{{int $pair.Type}}">{{$pair.Type}}</span></td>
+        </tr>
+        {{end}}{{end}}
+      </tbody>
+    </table>
+  </div>
+</div>
+{{else}}
+<div class="card"><p class="ok-msg">No code clones detected</p></div>
+{{end}}
+{{end}}
+
+{{if .Errors}}
+<div class="callout"><b>{{len .Errors}} {{if eq (len .Errors) 1}}file was{{else}}files were{{end}} skipped</b><ul>{{range .Errors}}<li class="mono">{{.}}</li>{{end}}</ul></div>
+{{end}}
+
+</main>
+
+<footer>
+  <span>Generated by polyscan{{if .Version}} {{.Version}}{{end}} · {{.GeneratedAt.Format "2006-01-02 15:04:05"}}</span>
+  <a href="https://github.com/ludo-technologies/polyscan" target="_blank" rel="noopener noreferrer">polyscan on GitHub</a>
+</footer>
+</body>
+</html>

--- a/polyscan/npm/README.md
+++ b/polyscan/npm/README.md
@@ -17,7 +17,7 @@ npx polyscan analyze .
 ## Usage
 
 ```bash
-# Text report
+# HTML report, opened in the browser
 polyscan analyze .
 
 # JSON report


### PR DESCRIPTION
Part of #69, closes #71. Replaces #76, which GitHub closed when its base branch (#75) was deleted.

- `polyscan analyze` now defaults to a self-contained HTML report: complexity summary, complexity histogram, most complex functions, duplication summary with the clone type breakdown, and clone groups with code previews
- Written to `polyscan-report.html` and opened in the browser; `--output` names the file and `--no-open` skips the browser. `--format json|text` unchanged
- Markup and styles adapted from the jscan report, without the health score and tabs that polyscan has no data for
- The report file URL is built with escaping (jscan gets the same fix) and core is bumped to v0.2.5 for the shell-free browser opener

🤖 Generated with [Claude Code](https://claude.com/claude-code)