### PR TITLE
feat(polyscan): add Rust support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uvx pyscn@latest analyze .
 
 See: [**pyscn**](https://github.com/ludo-technologies/pyscn)
 
-### Go
+### Go / Rust
 ```
 npx polyscan analyze .
 ```
@@ -38,7 +38,7 @@ npx polyscan analyze .
 See: [**polyscan**](polyscan/)
 
 ### Others
-We are also planning to support other languages (Rust, C++, and more).
+We are also planning to support other languages (C++ and more).
 
 ## What You Get
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -51,8 +51,9 @@ Cyclomatic complexity is one plus the number of decision points in a function, c
 | --- | --- |
 | `if`, `else if`, `if let` | 1 each |
 | `for`, `while`, `while let`, `loop` | 1 each |
-| `match` | 1 per arm except the last, which is the path the other arms branch away from |
-| `&&`, `\|\|` | 1 each |
+| `match` | 1 per arm except the last, which is the path the other arms branch away from, plus 1 per arm guard |
+| `let ... else` | 1 |
+| `&&`, `\|\|`, including `&&` in a let chain | 1 each |
 | `?` | 1, the early return that `core/cfg` counts as an exception edge |
 
 Function literals and closures are not reported on their own. Their decision points count toward the enclosing function, so the Go numbers match gocyclo.
@@ -69,7 +70,7 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules and `tests.rs` files, the conventional name of a test module split into its own file.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules, `tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
 
 Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
 
@@ -81,7 +82,7 @@ A language is declarative: a tree-sitter grammar and two queries. See `internal/
 
 - The definitions query matches each function once. `@definition.<kind>` spans the function, `@name` its name, and an optional `@receiver` is prefixed to the name. The bundled `queries/tags.scm` of a grammar is the starting point.
 - In the decisions query every capture is one decision point, attributed to the innermost function that contains it and reported under the capture's name.
-- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names the test file globs and `TestCode` is a query capturing test code inside a file; both are excluded from clone detection.
+- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names test files by file name glob or, with a trailing slash, by directory, and `TestCode` is a query capturing test code inside a file; both are excluded from clone detection.
 
 ## Development
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -70,7 +70,7 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules, `tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
 
 Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -70,7 +70,7 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, items under `#[cfg(test)]` or `#[cfg(all(test, ...))]`, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
 
 Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -69,7 +69,7 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions and `#[cfg(test)]` modules.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, `#[cfg(test)]` modules and `tests.rs` files, the conventional name of a test module split into its own file.
 
 Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-A multi-language code quality analyzer. It detects the language of each file by its extension and currently measures cyclomatic complexity and detects code clones for Go.
+A multi-language code quality analyzer. It detects the language of each file by its extension and measures cyclomatic complexity and detects code clones for Go and Rust.
 
 ## Installation
 
@@ -47,7 +47,15 @@ Cyclomatic complexity is one plus the number of decision points in a function, c
 | `switch`, type switch, `select` | 1 per `case`, `default` excluded |
 | `&&`, `\|\|` | 1 each |
 
-Function literals are not reported on their own. Their decision points count toward the enclosing function, so the numbers match gocyclo.
+| Rust construct | Decision points |
+| --- | --- |
+| `if`, `else if`, `if let` | 1 each |
+| `for`, `while`, `while let`, `loop` | 1 each |
+| `match` | 1 per arm except the last, which is the path the other arms branch away from |
+| `&&`, `\|\|` | 1 each |
+| `?` | 1, the early return that `core/cfg` counts as an exception edge |
+
+Function literals and closures are not reported on their own. Their decision points count toward the enclosing function, so the Go numbers match gocyclo.
 
 Risk levels use the thresholds shared by every polyscan analyzer: low up to 9, medium up to 19, high from 20.
 
@@ -61,7 +69,9 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test files (`*_test.go`) are analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions and `#[cfg(test)]` modules.
+
+Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
 
 Pairs are merged into groups by connected components, and the groups are deduplicated by the shared `core/clone` passes. When there are more than 10,000 candidate pairs, only pairs that share a MinHash band are compared, and within a band each function is compared with at most 1,024 of the functions that follow it. Neighbours in a band are always compared, so a large set of near-identical functions still ends up in one group.
 
@@ -71,7 +81,7 @@ A language is declarative: a tree-sitter grammar and two queries. See `internal/
 
 - The definitions query matches each function once. `@definition.<kind>` spans the function, `@name` its name, and an optional `@receiver` is prefixed to the name. The bundled `queries/tags.scm` of a grammar is the starting point.
 - In the decisions query every capture is one decision point, attributed to the innermost function that contains it and reported under the capture's name.
-- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names the test file globs to exclude from clone detection.
+- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names the test file globs and `TestCode` is a query capturing test code inside a file; both are excluded from clone detection.
 
 ## Development
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -37,7 +37,7 @@ func analyzeCmd() *cobra.Command {
 		Short: "Analyze source files",
 		Long: `Analyze source files for cyclomatic complexity and code clones.
 
-The language of each file is detected from its extension. Supported: Go.
+The language of each file is detected from its extension. Supported: Go, Rust.
 
 By default, generates an HTML report and opens it in your browser.
 

--- a/polyscan/cmd/polyscan/main.go
+++ b/polyscan/cmd/polyscan/main.go
@@ -24,7 +24,7 @@ func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "polyscan",
 		Short:   "polyscan - multi-language static analyzer",
-		Long:    "polyscan is a static analyzer that measures code quality across languages.\nIt currently analyzes cyclomatic complexity for Go.",
+		Long:    "polyscan is a static analyzer that measures code quality across languages.\nIt currently analyzes cyclomatic complexity and code clones for Go and Rust.",
 		Version: version.Version,
 	}
 	cmd.AddCommand(analyzeCmd())

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -123,7 +123,9 @@ func Analyze(paths []string, options Options) (*Report, error) {
 				detectors[language] = detector
 			}
 			for _, fn := range functions {
-				detector.Add(fn, display)
+				if !fn.IsTest {
+					detector.Add(fn, display)
+				}
 			}
 		}
 	}

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -116,7 +116,7 @@ func Analyze(paths []string, options Options) (*Report, error) {
 				report.Complexity.Functions = append(report.Complexity.Functions, newFunction(fn, language, display))
 			}
 		}
-		if options.Clones && !source.MatchesAnyPattern(filepath.Base(file), language.TestFiles) {
+		if options.Clones && !language.IsTestFile(display) {
 			detector, ok := detectors[language]
 			if !ok {
 				detector = clone.NewDetector(language.Clone, clone.DefaultConfig())
@@ -179,13 +179,23 @@ func detectClones(detectors map[*engine.Language]*clone.Detector) *clone.Report 
 	totalSimilarity := 0.0
 	for _, language := range languages {
 		report := detectors[language].Detect()
+		// Each detector numbers its fragments from zero, so they are
+		// rebased to stay unique across languages.
+		offset := merged.Statistics.TotalFragments
+		rebase := func(fragment *clone.Fragment) {
+			fragment.ID += offset
+			fragment.Language = language.Name
+		}
 		for _, pair := range report.Pairs {
-			pair.ID = len(merged.Pairs)
+			rebase(&pair.Fragment1)
+			rebase(&pair.Fragment2)
 			merged.Pairs = append(merged.Pairs, pair)
 			totalSimilarity += pair.Similarity
 		}
 		for _, group := range report.Groups {
-			group.ID = len(merged.Groups)
+			for i := range group.Fragments {
+				rebase(&group.Fragments[i])
+			}
 			merged.Groups = append(merged.Groups, group)
 		}
 		merged.Statistics.TotalFragments += report.Statistics.TotalFragments
@@ -194,12 +204,41 @@ func detectClones(detectors map[*engine.Language]*clone.Detector) *clone.Report 
 			merged.Statistics.ClonesByType[cloneType] += count
 		}
 	}
+
+	// Rank across languages the way each detector ranks within one.
+	sort.SliceStable(merged.Pairs, func(i, j int) bool {
+		a, b := merged.Pairs[i], merged.Pairs[j]
+		if a.Similarity != b.Similarity {
+			return a.Similarity > b.Similarity
+		}
+		return fragmentPrecedes(a.Fragment1, b.Fragment1) || a.Fragment1 == b.Fragment1 && fragmentPrecedes(a.Fragment2, b.Fragment2)
+	})
+	sort.SliceStable(merged.Groups, func(i, j int) bool {
+		a, b := merged.Groups[i], merged.Groups[j]
+		if a.Similarity != b.Similarity {
+			return a.Similarity > b.Similarity
+		}
+		return fragmentPrecedes(a.Fragments[0], b.Fragments[0])
+	})
+	for i := range merged.Pairs {
+		merged.Pairs[i].ID = i
+	}
+	for i := range merged.Groups {
+		merged.Groups[i].ID = i
+	}
 	merged.Statistics.TotalClonePairs = len(merged.Pairs)
 	merged.Statistics.TotalCloneGroups = len(merged.Groups)
 	if len(merged.Pairs) > 0 {
 		merged.Statistics.AverageSimilarity = totalSimilarity / float64(len(merged.Pairs))
 	}
 	return merged
+}
+
+func fragmentPrecedes(a, b clone.Fragment) bool {
+	if a.FilePath != b.FilePath {
+		return a.FilePath < b.FilePath
+	}
+	return a.StartLine < b.StartLine
 }
 
 // RiskLevel classifies a complexity with the thresholds shared by every

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -4,6 +4,7 @@ package analysis
 
 import (
 	"fmt"
+	"math"
 	"os"
 	"path/filepath"
 	"sort"
@@ -205,33 +206,49 @@ func detectClones(detectors map[*engine.Language]*clone.Detector) *clone.Report 
 		}
 	}
 
-	// Rank across languages the way each detector ranks within one.
-	sort.SliceStable(merged.Pairs, func(i, j int) bool {
-		a, b := merged.Pairs[i], merged.Pairs[j]
-		if a.Similarity != b.Similarity {
-			return a.Similarity > b.Similarity
-		}
-		return fragmentPrecedes(a.Fragment1, b.Fragment1) || a.Fragment1 == b.Fragment1 && fragmentPrecedes(a.Fragment2, b.Fragment2)
-	})
-	sort.SliceStable(merged.Groups, func(i, j int) bool {
-		a, b := merged.Groups[i], merged.Groups[j]
-		if a.Similarity != b.Similarity {
-			return a.Similarity > b.Similarity
-		}
-		return fragmentPrecedes(a.Fragments[0], b.Fragments[0])
-	})
-	for i := range merged.Pairs {
-		merged.Pairs[i].ID = i
-	}
-	for i := range merged.Groups {
-		merged.Groups[i].ID = i
-	}
+	rank(merged)
 	merged.Statistics.TotalClonePairs = len(merged.Pairs)
 	merged.Statistics.TotalCloneGroups = len(merged.Groups)
 	if len(merged.Pairs) > 0 {
 		merged.Statistics.AverageSimilarity = totalSimilarity / float64(len(merged.Pairs))
 	}
 	return merged
+}
+
+// rank orders pairs and groups across languages the way core/clone orders
+// them within one: by similarity, then larger groups first, then by
+// location. IDs follow the order.
+func rank(report *clone.Report) {
+	sort.SliceStable(report.Pairs, func(i, j int) bool {
+		a, b := report.Pairs[i], report.Pairs[j]
+		if !almostEqual(a.Similarity, b.Similarity) {
+			return a.Similarity > b.Similarity
+		}
+		if a.Fragment1.FilePath != b.Fragment1.FilePath || a.Fragment1.StartLine != b.Fragment1.StartLine {
+			return fragmentPrecedes(a.Fragment1, b.Fragment1)
+		}
+		return fragmentPrecedes(a.Fragment2, b.Fragment2)
+	})
+	sort.SliceStable(report.Groups, func(i, j int) bool {
+		a, b := report.Groups[i], report.Groups[j]
+		if !almostEqual(a.Similarity, b.Similarity) {
+			return a.Similarity > b.Similarity
+		}
+		if len(a.Fragments) != len(b.Fragments) {
+			return len(a.Fragments) > len(b.Fragments)
+		}
+		return fragmentPrecedes(a.Fragments[0], b.Fragments[0])
+	})
+	for i := range report.Pairs {
+		report.Pairs[i].ID = i
+	}
+	for i := range report.Groups {
+		report.Groups[i].ID = i
+	}
+}
+
+func almostEqual(a, b float64) bool {
+	return math.Abs(a-b) < 1e-9
 }
 
 func fragmentPrecedes(a, b clone.Fragment) bool {

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -133,7 +133,12 @@ func TestAnalyzeRust(t *testing.T) {
 		t.Error("test functions must still be analyzed for complexity")
 	}
 
-	// sums_positive_values is a copy of sum_positive but lies in #[cfg(test)].
+	if _, ok := byName["roundtrip"]; !ok {
+		t.Error("functions in tests.rs must still be analyzed for complexity")
+	}
+
+	// sums_positive_values is a copy of sum_positive but lies in #[cfg(test)],
+	// and roundtrip is another copy but lies in tests.rs.
 	stats := report.Clones.Statistics
 	if stats.TotalFragments != 3 || stats.TotalClonePairs != 1 || stats.ClonesByType["Type-2"] != 1 {
 		t.Errorf("statistics = %+v, want one Type-2 pair among three fragments", stats)

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -115,3 +115,27 @@ func TestRiskLevel(t *testing.T) {
 		}
 	}
 }
+
+func TestAnalyzeRust(t *testing.T) {
+	report, err := Analyze([]string{"../../testdata/rust"}, Options{Complexity: true, Clones: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+
+	byName := map[string]Function{}
+	for _, fn := range report.Complexity.Functions {
+		byName[fn.Name] = fn
+	}
+	if fn := byName["Server.handle"]; fn.Complexity != 8 || fn.Language != "Rust" {
+		t.Errorf("Server.handle = %+v, want complexity 8 in Rust", fn)
+	}
+	if _, ok := byName["sums_positive_values"]; !ok {
+		t.Error("test functions must still be analyzed for complexity")
+	}
+
+	// sums_positive_values is a copy of sum_positive but lies in #[cfg(test)].
+	stats := report.Clones.Statistics
+	if stats.TotalFragments != 3 || stats.TotalClonePairs != 1 || stats.ClonesByType["Type-2"] != 1 {
+		t.Errorf("statistics = %+v, want one Type-2 pair among three fragments", stats)
+	}
+}

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 )
 
 // fixtures copies the Go fixtures into a temporary directory and adds a
@@ -142,5 +143,40 @@ func TestAnalyzeRust(t *testing.T) {
 	stats := report.Clones.Statistics
 	if stats.TotalFragments != 3 || stats.TotalClonePairs != 1 || stats.ClonesByType["Type-2"] != 1 {
 		t.Errorf("statistics = %+v, want one Type-2 pair among three fragments", stats)
+	}
+}
+
+func TestAnalyzeMergesLanguages(t *testing.T) {
+	report, err := Analyze([]string{"../../testdata/go/clones", "../../testdata/rust"}, Options{Clones: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	pairs := report.Clones.Pairs
+	if len(pairs) != 4 || report.Clones.Statistics.TotalFragments != 6 {
+		t.Fatalf("pairs = %d, fragments = %d, want 4 and 6", len(pairs), report.Clones.Statistics.TotalFragments)
+	}
+	// The Type-1 Go pair outranks the Type-2 pairs whatever the language order.
+	if pairs[0].Type != domain.Type1Clone || pairs[0].Fragment1.Language != "Go" {
+		t.Errorf("first pair = %+v, want the Go Type-1 pair", pairs[0])
+	}
+	seen := map[int]string{}
+	for i, pair := range pairs {
+		if pair.ID != i || i > 0 && pair.Similarity > pairs[i-1].Similarity {
+			t.Errorf("pair %d is out of order: %+v", i, pair)
+		}
+		for _, fragment := range []clone.Fragment{pair.Fragment1, pair.Fragment2} {
+			if name, ok := seen[fragment.ID]; ok && name != fragment.Name {
+				t.Errorf("fragment ID %d names both %s and %s", fragment.ID, name, fragment.Name)
+			}
+			seen[fragment.ID] = fragment.Name
+			if fragment.Language == "" {
+				t.Errorf("fragment %+v has no language", fragment)
+			}
+		}
+	}
+	for i, group := range report.Clones.Groups {
+		if group.ID != i {
+			t.Errorf("group %d has ID %d", i, group.ID)
+		}
 	}
 }

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -180,3 +180,41 @@ func TestAnalyzeMergesLanguages(t *testing.T) {
 		}
 	}
 }
+
+func TestRankOrdersGroupsLikeCore(t *testing.T) {
+	fragment := func(path string, line int) clone.Fragment { return clone.Fragment{FilePath: path, StartLine: line} }
+	report := &clone.Report{
+		Groups: []clone.Group{
+			{Similarity: 0.9, Fragments: []clone.Fragment{fragment("a.rs", 1), fragment("b.rs", 1)}},
+			{Similarity: 0.9 + 1e-12, Fragments: []clone.Fragment{fragment("z.go", 1), fragment("z.go", 50), fragment("y.go", 1)}},
+			{Similarity: 1, Fragments: []clone.Fragment{fragment("c.rs", 1), fragment("d.rs", 1)}},
+		},
+		Pairs: []clone.Pair{
+			{Similarity: 0.8, Fragment1: fragment("b.go", 1), Fragment2: fragment("c.go", 1)},
+			{Similarity: 0.8, Fragment1: fragment("a.rs", 1), Fragment2: fragment("c.rs", 1)},
+			{Similarity: 1, Fragment1: fragment("x.go", 1), Fragment2: fragment("y.go", 1)},
+		},
+	}
+	rank(report)
+
+	var groups []string
+	for _, group := range report.Groups {
+		groups = append(groups, group.Fragments[0].FilePath)
+	}
+	// Equal similarity within epsilon: the larger group comes first.
+	if want := []string{"c.rs", "z.go", "a.rs"}; strings.Join(groups, ",") != strings.Join(want, ",") {
+		t.Errorf("groups = %v, want %v", groups, want)
+	}
+	var pairs []string
+	for _, pair := range report.Pairs {
+		pairs = append(pairs, pair.Fragment1.FilePath)
+	}
+	if want := []string{"x.go", "a.rs", "b.go"}; strings.Join(pairs, ",") != strings.Join(want, ",") {
+		t.Errorf("pairs = %v, want %v", pairs, want)
+	}
+	for i, group := range report.Groups {
+		if group.ID != i {
+			t.Errorf("group %d has ID %d", i, group.ID)
+		}
+	}
+}

--- a/polyscan/internal/clone/detector.go
+++ b/polyscan/internal/clone/detector.go
@@ -111,6 +111,7 @@ type Group struct {
 type Fragment struct {
 	ID        int    `json:"id"`
 	Name      string `json:"name"`
+	Language  string `json:"language"`
 	FilePath  string `json:"file_path"`
 	StartLine int    `json:"start_line"`
 	EndLine   int    `json:"end_line"`

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -8,6 +8,7 @@ package engine
 import (
 	"context"
 	"fmt"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -42,11 +43,13 @@ type Language struct {
 	Decisions string
 	// Clone names the node types clone detection prices and compares.
 	Clone CloneSpec
-	// TestFiles are file name globs of test files, and TestCode is an
-	// optional tree-sitter query whose captures span test code inside a
-	// file, such as attribute-marked test functions or modules. Both are
-	// analyzed for complexity but excluded from clone detection, where the
-	// shared skeleton of test functions swamps the report.
+	// TestFiles names test files: a glob matches the file name, and a
+	// pattern ending in a slash names a directory anywhere on the path.
+	// TestCode is an optional tree-sitter query whose captures span test
+	// code inside a file, such as attribute-marked test functions or
+	// modules. Both are analyzed for complexity but excluded from clone
+	// detection, where the shared skeleton of test functions swamps the
+	// report.
 	TestFiles []string
 	TestCode  string
 
@@ -130,6 +133,27 @@ const (
 	receiverCapture  = "receiver"
 	operatorField    = "operator"
 )
+
+// IsTestFile reports whether the path matches one of the language's
+// TestFiles patterns.
+func (l *Language) IsTestFile(path string) bool {
+	components := strings.Split(filepath.ToSlash(filepath.Clean(path)), "/")
+	base := components[len(components)-1]
+	for _, pattern := range l.TestFiles {
+		if dir, ok := strings.CutSuffix(pattern, "/"); ok {
+			for _, component := range components[:len(components)-1] {
+				if component == dir {
+					return true
+				}
+			}
+			continue
+		}
+		if matched, err := filepath.Match(pattern, base); err == nil && matched {
+			return true
+		}
+	}
+	return false
+}
 
 // Analyze parses source and returns every function the language defines,
 // with its complexity computed. Source that does not parse is an error: a

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -30,6 +30,11 @@ type Language struct {
 	// name. An optional @receiver capture holds the receiver type of a
 	// method and is prefixed to the name as "Receiver.Name".
 	Definitions string
+	// A function node that several patterns match is reported once, under
+	// the match that captured a receiver when there is one, so a grammar
+	// that uses one node type for functions and methods can name methods
+	// through their enclosing type.
+	//
 	// Decisions is a tree-sitter query in which every capture is one
 	// decision point. The point is attributed to the innermost function
 	// that contains it and counted under the capture's name, so the capture
@@ -37,15 +42,19 @@ type Language struct {
 	Decisions string
 	// Clone names the node types clone detection prices and compares.
 	Clone CloneSpec
-	// TestFiles are file name globs of test files. Test files are analyzed
-	// for complexity but excluded from clone detection, where the shared
-	// skeleton of test functions swamps the report.
+	// TestFiles are file name globs of test files, and TestCode is an
+	// optional tree-sitter query whose captures span test code inside a
+	// file, such as attribute-marked test functions or modules. Both are
+	// analyzed for complexity but excluded from clone detection, where the
+	// shared skeleton of test functions swamps the report.
 	TestFiles []string
+	TestCode  string
 
 	compileOnce sync.Once
 	compileErr  error
 	definitions *sitter.Query
 	decisions   *sitter.Query
+	testCode    *sitter.Query
 	identifiers map[string]struct{}
 	literals    map[string]struct{}
 }
@@ -107,6 +116,9 @@ type Function struct {
 	// CodeLines counts the lines of Content that are not blank, so that
 	// comments and spacing do not change how large a function is.
 	CodeLines int
+	// IsTest reports that the function lies in a span the language's
+	// TestCode query captured.
+	IsTest bool
 
 	startByte uint32
 	endByte   uint32
@@ -146,6 +158,7 @@ func (l *Language) Analyze(source []byte) ([]Function, error) {
 
 	functions := l.extractFunctions(root, source)
 	l.countDecisions(root, source, functions)
+	l.markTests(root, source, functions)
 	for i := range functions {
 		functions[i].Complexity = 1
 		for _, count := range functions[i].Decisions {
@@ -170,6 +183,14 @@ func (l *Language) compile() error {
 			l.compileErr = fmt.Errorf("%s decisions query: %w", l.Name, err)
 			return
 		}
+		if l.TestCode != "" {
+			testCode, err := sitter.NewQuery([]byte(l.TestCode), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s test code query: %w", l.Name, err)
+				return
+			}
+			l.testCode = testCode
+		}
 		l.definitions = definitions
 		l.decisions = decisions
 		l.identifiers = set(l.Clone.Identifiers)
@@ -188,6 +209,7 @@ func set(names []string) map[string]struct{} {
 
 func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function {
 	var functions []Function
+	byStart := map[uint32]int{}
 	forEachMatch(l.definitions, root, source, func(match *sitter.QueryMatch) {
 		var fn Function
 		var node *sitter.Node
@@ -210,6 +232,14 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 		if receiver != "" {
 			fn.Name = receiver + "." + fn.Name
 		}
+		if index, seen := byStart[node.StartByte()]; seen {
+			if receiver != "" {
+				functions[index].Name = fn.Name
+				functions[index].Kind = fn.Kind
+			}
+			return
+		}
+		byStart[node.StartByte()] = len(functions)
 		fn.StartLine = int(node.StartPoint().Row) + 1
 		fn.StartColumn = int(node.StartPoint().Column) + 1
 		fn.EndLine = int(node.EndPoint().Row) + 1
@@ -310,6 +340,23 @@ func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []
 				continue
 			}
 			fn.Decisions[l.decisions.CaptureNameForId(capture.Index)]++
+		}
+	})
+}
+
+// markTests flags every function inside a span the TestCode query captures.
+func (l *Language) markTests(root *sitter.Node, source []byte, functions []Function) {
+	if l.testCode == nil {
+		return
+	}
+	forEachMatch(l.testCode, root, source, func(match *sitter.QueryMatch) {
+		for _, capture := range match.Captures {
+			start, end := capture.Node.StartByte(), capture.Node.EndByte()
+			for i := range functions {
+				if functions[i].startByte >= start && functions[i].endByte <= end {
+					functions[i].IsTest = true
+				}
+			}
 		}
 	})
 }

--- a/polyscan/internal/lang/lang.go
+++ b/polyscan/internal/lang/lang.go
@@ -7,10 +7,11 @@ import (
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/rust"
 )
 
 // All lists every supported language.
-var All = []*engine.Language{golang.Language}
+var All = []*engine.Language{golang.Language, rust.Language}
 
 // ByPath returns the language that owns the file's extension.
 func ByPath(path string) (*engine.Language, bool) {

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -22,13 +22,22 @@ var Language = &engine.Language{
 	// integration tests.
 	TestFiles: []string{"tests.rs", "*_tests.rs", "tests/"},
 	// Tests kept next to the code are found by attribute: #[test]
-	// functions and #[cfg(test)] modules, with any other attributes
-	// between the marker and the item.
+	// functions and any item under #[cfg(test)] or #[cfg(all(test, ...))],
+	// with any other attributes between the marker and the item. In the
+	// direct form the flag is a child of the argument list, so
+	// #[cfg(not(test))], whose test sits one level deeper, does not match;
+	// the nested form is restricted to all(...), because code under
+	// any(test, ...) is also built without tests.
 	TestCode: `
-((attribute_item (attribute (identifier) @attr)) . (attribute_item)* . (function_item) @test
+((attribute_item (attribute (identifier) @attr)) . (attribute_item)* .
+  (function_item) @test
   (#eq? @attr "test"))
-((attribute_item (attribute (identifier) @attr arguments: (token_tree (identifier) @flag))) . (attribute_item)* . (mod_item) @test
+((attribute_item (attribute (identifier) @attr arguments: (token_tree (identifier) @flag))) . (attribute_item)* .
+  [(function_item) (impl_item) (trait_item) (mod_item)] @test
   (#eq? @attr "cfg") (#eq? @flag "test"))
+((attribute_item (attribute (identifier) @attr arguments: (token_tree (identifier) @combinator (token_tree (identifier) @flag)))) . (attribute_item)* .
+  [(function_item) (impl_item) (trait_item) (mod_item)] @test
+  (#eq? @attr "cfg") (#eq? @combinator "all") (#eq? @flag "test"))
 `,
 	// The function pattern of tree-sitter-rust's queries/tags.scm, plus
 	// the same node inside an impl or trait body, where the implemented

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -17,9 +17,10 @@ var Language = &engine.Language{
 	Grammar:    tsrust.GetLanguage(),
 	// A test module split into its own file is declared as
 	// #[cfg(test)] mod tests; in the parent, which a single file cannot
-	// see, so the conventional names stand in for the attribute: tests.rs,
-	// and a tests directory, which also holds Cargo's integration tests.
-	TestFiles: []string{"tests.rs", "tests/"},
+	// see, so the conventional names stand in for the attribute: tests.rs and
+	// *_tests.rs, and a tests directory, which also holds Cargo's
+	// integration tests.
+	TestFiles: []string{"tests.rs", "*_tests.rs", "tests/"},
 	// Tests kept next to the code are found by attribute: #[test]
 	// functions and #[cfg(test)] modules, with any other attributes
 	// between the marker and the item.

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -17,8 +17,9 @@ var Language = &engine.Language{
 	Grammar:    tsrust.GetLanguage(),
 	// A test module split into its own file is declared as
 	// #[cfg(test)] mod tests; in the parent, which a single file cannot
-	// see, so the conventional file name stands in for the attribute.
-	TestFiles: []string{"tests.rs"},
+	// see, so the conventional names stand in for the attribute: tests.rs,
+	// and a tests directory, which also holds Cargo's integration tests.
+	TestFiles: []string{"tests.rs", "tests/"},
 	// Tests kept next to the code are found by attribute: #[test]
 	// functions and #[cfg(test)] modules, with any other attributes
 	// between the marker and the item.
@@ -42,16 +43,21 @@ var Language = &engine.Language{
   body: (declaration_list (function_item name: (identifier) @name) @definition.method))
 `,
 	// A match is exhaustive, so its last arm is the path the other arms
-	// branch away from and only arms followed by another arm count. The ?
-	// operator is an early return and counts like the exception edge
-	// core/cfg counts.
+	// branch away from and only arms followed by another arm count; an
+	// arm's guard is a further branch. let-else branches on the pattern.
+	// In a let chain the && are tokens of the chain rather than binary
+	// expressions. The ? operator is an early return and counts like the
+	// exception edge core/cfg counts.
 	Decisions: `
 (if_expression) @branch
+(match_pattern condition: (_)) @branch
+(let_declaration alternative: (_)) @branch
 (match_block (match_arm) @case . (match_arm))
 (for_expression) @loop
 (while_expression) @loop
 (loop_expression) @loop
 (binary_expression operator: ["&&" "||"]) @logical_operator
+(let_chain "&&" @logical_operator)
 (try_expression) @try_operator
 `,
 	Clone: engine.CloneSpec{

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -15,9 +15,13 @@ var Language = &engine.Language{
 	Name:       "Rust",
 	Extensions: []string{".rs"},
 	Grammar:    tsrust.GetLanguage(),
-	// Rust keeps tests next to the code, so they are found by attribute:
-	// #[test] functions and #[cfg(test)] modules, with any other
-	// attributes between the marker and the item.
+	// A test module split into its own file is declared as
+	// #[cfg(test)] mod tests; in the parent, which a single file cannot
+	// see, so the conventional file name stands in for the attribute.
+	TestFiles: []string{"tests.rs"},
+	// Tests kept next to the code are found by attribute: #[test]
+	// functions and #[cfg(test)] modules, with any other attributes
+	// between the marker and the item.
 	TestCode: `
 ((attribute_item (attribute (identifier) @attr)) . (attribute_item)* . (function_item) @test
   (#eq? @attr "test"))

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -1,0 +1,101 @@
+// Package rust defines how polyscan analyzes Rust.
+package rust
+
+import (
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	tsrust "github.com/smacker/go-tree-sitter/rust"
+)
+
+// Language is the Rust definition. Closures are not extracted on their
+// own: their decision points count toward the enclosing function, as Go's
+// function literals do. Macro invocations parse as token trees, so the
+// code inside a macro call contributes tokens but no structure, which
+// lowers clone detection recall on macro-heavy code.
+var Language = &engine.Language{
+	Name:       "Rust",
+	Extensions: []string{".rs"},
+	Grammar:    tsrust.GetLanguage(),
+	// Rust keeps tests next to the code, so they are found by attribute:
+	// #[test] functions and #[cfg(test)] modules, with any other
+	// attributes between the marker and the item.
+	TestCode: `
+((attribute_item (attribute (identifier) @attr)) . (attribute_item)* . (function_item) @test
+  (#eq? @attr "test"))
+((attribute_item (attribute (identifier) @attr arguments: (token_tree (identifier) @flag))) . (attribute_item)* . (mod_item) @test
+  (#eq? @attr "cfg") (#eq? @flag "test"))
+`,
+	// The function pattern of tree-sitter-rust's queries/tags.scm, plus
+	// the same node inside an impl or trait body, where the implemented
+	// type or the trait becomes the receiver. The engine merges the two
+	// matches of one function node and keeps the receiver.
+	Definitions: `
+(function_item name: (identifier) @name) @definition.function
+
+(impl_item type: (_) @receiver
+  body: (declaration_list (function_item name: (identifier) @name) @definition.method))
+
+(trait_item name: (type_identifier) @receiver
+  body: (declaration_list (function_item name: (identifier) @name) @definition.method))
+`,
+	// A match is exhaustive, so its last arm is the path the other arms
+	// branch away from and only arms followed by another arm count. The ?
+	// operator is an early return and counts like the exception edge
+	// core/cfg counts.
+	Decisions: `
+(if_expression) @branch
+(match_block (match_arm) @case . (match_arm))
+(for_expression) @loop
+(while_expression) @loop
+(loop_expression) @loop
+(binary_expression operator: ["&&" "||"]) @logical_operator
+(try_expression) @try_operator
+`,
+	Clone: engine.CloneSpec{
+		Identifiers: []string{
+			"identifier", "field_identifier", "type_identifier", "shorthand_field_identifier",
+			"primitive_type", "lifetime", "metavariable",
+		},
+		Literals: []string{
+			"integer_literal", "float_literal", "string_literal", "raw_string_literal",
+			"char_literal", "boolean_literal", "negative_literal",
+		},
+		Patterns: []string{
+			"if_expression", "match_expression", "match_arm", "for_expression", "while_expression",
+			"loop_expression", "return_expression", "break_expression", "continue_expression",
+			"try_expression", "await_expression", "closure_expression", "call_expression",
+			"field_expression", "index_expression", "binary_expression", "unary_expression",
+			"assignment_expression", "compound_assignment_expr", "let_declaration",
+			"struct_expression", "macro_invocation", "reference_expression", "unsafe_block",
+			"async_block", "range_expression", "tuple_expression", "array_expression",
+			"type_cast_expression",
+		},
+		Structural: []string{
+			"source_file", "function_item", "closure_expression", "impl_item", "trait_item",
+			"struct_item", "enum_item", "union_item", "mod_item", "type_item",
+		},
+		ControlFlow: []string{
+			"if_expression", "else_clause", "let_condition", "let_chain",
+			"match_expression", "match_block", "match_arm",
+			"for_expression", "while_expression", "loop_expression",
+			"return_expression", "break_expression", "continue_expression", "try_expression",
+		},
+		Expressions: []string{
+			"binary_expression", "unary_expression", "call_expression", "arguments",
+			"field_expression", "index_expression", "assignment_expression",
+			"compound_assignment_expr", "reference_expression", "struct_expression",
+			"tuple_expression", "array_expression", "range_expression", "type_cast_expression",
+			"parenthesized_expression", "await_expression", "macro_invocation",
+		},
+		Related: [][2]string{
+			{"for_expression", "while_expression"},
+			{"for_expression", "loop_expression"},
+			{"while_expression", "loop_expression"},
+			{"if_expression", "match_expression"},
+			{"assignment_expression", "compound_assignment_expr"},
+			{"let_declaration", "assignment_expression"},
+			{"binary_expression", "unary_expression"},
+			{"struct_expression", "tuple_expression"},
+			{"return_expression", "try_expression"},
+		},
+	},
+}

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -160,11 +160,12 @@ func TestSyntaxErrorIsReported(t *testing.T) {
 
 func TestTestFiles(t *testing.T) {
 	for path, want := range map[string]bool{
-		"src/lib.rs":           false,
-		"src/parser/tests.rs":  true,
-		"src/tests/mod.rs":     true,
-		"tests/integration.rs": true,
-		"src/contests/x.rs":    false,
+		"src/lib.rs":                   false,
+		"src/parser/tests.rs":          true,
+		"src/bin/integration_tests.rs": true,
+		"src/tests/mod.rs":             true,
+		"tests/integration.rs":         true,
+		"src/contests/x.rs":            false,
 	} {
 		if got := Language.IsTestFile(path); got != want {
 			t.Errorf("IsTestFile(%q) = %v, want %v", path, got, want)

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -78,6 +78,9 @@ func TestComplexityCountsDecisionPoints(t *testing.T) {
 		{"logical operators", `if a && b || c { }`, 4, map[string]int{"branch": 1, "logical_operator": 2}},
 		{"bitwise operators do not count", `n & 1 | 2`, 1, map[string]int{}},
 		{"question mark", `let v = r?; v`, 2, map[string]int{"try_operator": 1}},
+		{"match guard", `match o { Some(v) if v > 0 => v, _ => 0 }`, 3, map[string]int{"case": 1, "branch": 1}},
+		{"let else", `let Some(v) = o else { return 0 }; v`, 2, map[string]int{"branch": 1}},
+		{"let chain", `if let Some(v) = o && v > 0 && a { v } else { 0 }`, 4, map[string]int{"branch": 1, "logical_operator": 2}},
 		{"closure counts toward its enclosing function", `let f = |x| if x { 1 } else { 2 }; f(a)`, 2, map[string]int{"branch": 1}},
 	}
 	for _, tc := range cases {
@@ -152,5 +155,19 @@ func TestSyntaxErrorIsReported(t *testing.T) {
 	_, err := Language.Analyze([]byte("fn f() {\n\tif {\n"))
 	if err == nil || !strings.Contains(err.Error(), "syntax error") {
 		t.Fatalf("err = %v, want a syntax error", err)
+	}
+}
+
+func TestTestFiles(t *testing.T) {
+	for path, want := range map[string]bool{
+		"src/lib.rs":           false,
+		"src/parser/tests.rs":  true,
+		"src/tests/mod.rs":     true,
+		"tests/integration.rs": true,
+		"src/contests/x.rs":    false,
+	} {
+		if got := Language.IsTestFile(path); got != want {
+			t.Errorf("IsTestFile(%q) = %v, want %v", path, got, want)
+		}
 	}
 }

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -130,10 +130,30 @@ fn cfg_then_test() {}
 #[allow(dead_code)]
 #[cfg(test)]
 mod more_tests { fn helper2() {} }
+
+#[cfg(test)]
+fn test_helper() {}
+
+#[cfg(test)]
+impl S { fn fixture(&self) {} }
+
+#[cfg(test)]
+trait TestOnly { fn provided(&self) {} }
+
+#[cfg(all(test, unix))]
+mod unix_tests { fn helper3() {} }
+
+#[cfg(not(test))]
+fn real() {}
+
+#[cfg(any(test, feature = "x"))]
+fn maybe() {}
 `)
 	for name, want := range map[string]bool{
 		"production": false, "unit": true, "helper": true, "in_module": true, "gated": false,
 		"test_then_cfg": true, "cfg_then_test": true, "helper2": true,
+		"test_helper": true, "S.fixture": true, "TestOnly.provided": true, "helper3": true,
+		"real": false, "maybe": false,
 	} {
 		if got := functions[name].IsTest; got != want {
 			t.Errorf("%s: IsTest = %v, want %v", name, got, want)

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -1,0 +1,156 @@
+package rust
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+func analyze(t *testing.T, source string) map[string]engine.Function {
+	t.Helper()
+	functions, err := Language.Analyze([]byte(source))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	byName := map[string]engine.Function{}
+	for _, fn := range functions {
+		byName[fn.Name] = fn
+	}
+	return byName
+}
+
+func TestExtractsFunctionsAndMethods(t *testing.T) {
+	functions := analyze(t, `
+fn free() {}
+struct S;
+struct G<T>(T);
+impl S { fn method(&self) {} }
+impl<T> G<T> { fn generic(&self) {} }
+impl fmt::Display for S { fn fmt(&self) {} }
+trait Tr { fn provided(&self) {} fn required(&self); }
+mod m { fn inner() { fn nested() {} } }
+fn with_closure() { let f = |x| x; f(1); }
+`)
+
+	want := map[string]string{
+		"free":         "function",
+		"S.method":     "method",
+		"G<T>.generic": "method",
+		"S.fmt":        "method",
+		"Tr.provided":  "method",
+		"inner":        "function",
+		"nested":       "function",
+		"with_closure": "function",
+	}
+	if len(functions) != len(want) {
+		t.Fatalf("got %d functions, want %d: %v", len(functions), len(want), functions)
+	}
+	for name, kind := range want {
+		fn, ok := functions[name]
+		if !ok {
+			t.Errorf("missing function %q", name)
+			continue
+		}
+		if fn.Kind != kind {
+			t.Errorf("%s: kind = %q, want %q", name, fn.Kind, kind)
+		}
+	}
+}
+
+func TestComplexityCountsDecisionPoints(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		want      int
+		decisions map[string]int
+	}{
+		{"none", `a`, 1, map[string]int{}},
+		{"if", `if a { 1 } else { 2 }`, 2, map[string]int{"branch": 1}},
+		{"else if chain", `if a { 1 } else if b { 2 } else { 3 }`, 3, map[string]int{"branch": 2}},
+		{"if let", `if let Some(x) = o { x } else { 0 }`, 2, map[string]int{"branch": 1}},
+		{"match arms except the last", `match n { 1 => 1, 2 | 3 => 2, _ => 0 }`, 3, map[string]int{"case": 2}},
+		{"single arm match", `match n { _ => 0 }`, 1, map[string]int{}},
+		{"for", `for i in 0..3 { }`, 2, map[string]int{"loop": 1}},
+		{"while", `while a { }`, 2, map[string]int{"loop": 1}},
+		{"while let", `while let Some(x) = o { }`, 2, map[string]int{"loop": 1}},
+		{"loop", `loop { break; }`, 2, map[string]int{"loop": 1}},
+		{"logical operators", `if a && b || c { }`, 4, map[string]int{"branch": 1, "logical_operator": 2}},
+		{"bitwise operators do not count", `n & 1 | 2`, 1, map[string]int{}},
+		{"question mark", `let v = r?; v`, 2, map[string]int{"try_operator": 1}},
+		{"closure counts toward its enclosing function", `let f = |x| if x { 1 } else { 2 }; f(a)`, 2, map[string]int{"branch": 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := analyze(t, "fn f(a: bool, b: bool, c: bool, n: i32, o: Option<i32>, r: Result<i32, ()>) -> i32 {\n\t"+tc.body+"\n}\n")["f"]
+			if fn.Complexity != tc.want {
+				t.Errorf("complexity = %d, want %d", fn.Complexity, tc.want)
+			}
+			if len(fn.Decisions) != len(tc.decisions) {
+				t.Errorf("decisions = %v, want %v", fn.Decisions, tc.decisions)
+			}
+			for kind, count := range tc.decisions {
+				if fn.Decisions[kind] != count {
+					t.Errorf("decisions[%q] = %d, want %d", kind, fn.Decisions[kind], count)
+				}
+			}
+		})
+	}
+}
+
+func TestTestCodeIsMarked(t *testing.T) {
+	functions := analyze(t, `
+fn production() {}
+
+#[test]
+fn unit() {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    fn helper() {}
+    #[test]
+    fn in_module() {}
+}
+
+#[cfg(feature = "x")]
+mod feature { fn gated() {} }
+
+#[test]
+#[cfg(feature = "alloc")]
+fn test_then_cfg() {}
+
+#[cfg(feature = "alloc")]
+#[test]
+fn cfg_then_test() {}
+
+#[allow(dead_code)]
+#[cfg(test)]
+mod more_tests { fn helper2() {} }
+`)
+	for name, want := range map[string]bool{
+		"production": false, "unit": true, "helper": true, "in_module": true, "gated": false,
+		"test_then_cfg": true, "cfg_then_test": true, "helper2": true,
+	} {
+		if got := functions[name].IsTest; got != want {
+			t.Errorf("%s: IsTest = %v, want %v", name, got, want)
+		}
+	}
+}
+
+func TestContentDropsComments(t *testing.T) {
+	fn := analyze(t, "/// Doc.\nfn f() -> i32 {\n\t// line\n\t1 /* block */\n}\n")["f"]
+	if strings.Contains(fn.Content, "line") || strings.Contains(fn.Content, "block") || strings.Contains(fn.Content, "Doc") {
+		t.Errorf("content keeps comments: %q", fn.Content)
+	}
+	if fn.CodeLines != 3 {
+		t.Errorf("code lines = %d, want 3", fn.CodeLines)
+	}
+}
+
+func TestSyntaxErrorIsReported(t *testing.T) {
+	_, err := Language.Analyze([]byte("fn f() {\n\tif {\n"))
+	if err == nil || !strings.Contains(err.Error(), "syntax error") {
+		t.Fatalf("err = %v, want a syntax error", err)
+	}
+}

--- a/polyscan/npm/README.md
+++ b/polyscan/npm/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-Multi-language code quality analyzer. It currently measures cyclomatic complexity for Go.
+Multi-language code quality analyzer. It measures cyclomatic complexity and detects code clones for Go and Rust.
 
 ## Installation
 

--- a/polyscan/npm/package.json
+++ b/polyscan/npm/package.json
@@ -5,6 +5,7 @@
   "keywords": [
     "go",
     "golang",
+    "rust",
     "code-quality",
     "static-analysis",
     "analyzer",

--- a/polyscan/testdata/rust/sample.rs
+++ b/polyscan/testdata/rust/sample.rs
@@ -1,0 +1,73 @@
+/// Adds the positive values and reports how many there were.
+pub fn sum_positive(values: &[i32]) -> (i32, usize) {
+    let mut total = 0;
+    let mut count = 0;
+    for value in values {
+        if *value > 0 {
+            total += value;
+            count += 1;
+        }
+    }
+    println!("{} positive values", count);
+    (total, count)
+}
+
+/// sum_positive with the names and the comparison changed.
+pub fn sum_negative(numbers: &[i32]) -> (i32, usize) {
+    let mut sum = 0;
+    let mut seen = 0;
+    for number in numbers {
+        if *number < 0 {
+            sum += number;
+            seen += 1;
+        }
+    }
+    println!("{} negative values", seen);
+    (sum, seen)
+}
+
+pub struct Server;
+
+impl Server {
+    /// Two loops, a match with three arms, an if with && and a ? make 8.
+    pub fn handle(&self, items: &[i32], n: i32, r: Result<i32, ()>) -> Result<i32, ()> {
+        let mut acc = 0;
+        for i in 0..10 {
+            acc += i;
+        }
+        while acc > 100 {
+            acc -= 1;
+        }
+        let bonus = match n {
+            1 => 10,
+            2 | 3 => 20,
+            _ => 0,
+        };
+        if acc > 5 && n > 0 {
+            acc += bonus;
+        }
+        let v = r?;
+        Ok(acc + v + items.len() as i32)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Another copy of sum_positive, which test code excludes from clones.
+    #[test]
+    fn sums_positive_values() {
+        let values = [1, -2, 3];
+        let mut total = 0;
+        let mut count = 0;
+        for value in values.iter() {
+            if *value > 0 {
+                total += value;
+                count += 1;
+            }
+        }
+        assert_eq!((total, count), (4, 2));
+        assert_eq!(sum_positive(&values), (4, 2));
+    }
+}

--- a/polyscan/testdata/rust/tests.rs
+++ b/polyscan/testdata/rust/tests.rs
@@ -1,0 +1,16 @@
+//! A test module split into its own file, declared as `#[cfg(test)] mod
+//! tests;` by its parent. The file name alone marks it as test code.
+
+/// Another copy of sum_positive that must not be reported as a clone.
+fn roundtrip(values: &[i32]) -> (i32, usize) {
+    let mut total = 0;
+    let mut count = 0;
+    for value in values {
+        if *value > 0 {
+            total += value;
+            count += 1;
+        }
+    }
+    println!("{} positive values", count);
+    (total, count)
+}

--- a/polyscan/testdata/rust/tests/integration.rs
+++ b/polyscan/testdata/rust/tests/integration.rs
@@ -1,0 +1,15 @@
+//! A Cargo integration test. The tests directory marks it as test code.
+
+/// Another copy of sum_positive that must not be reported as a clone.
+fn roundtrip_again(values: &[i32]) -> (i32, usize) {
+    let mut total = 0;
+    let mut count = 0;
+    for value in values {
+        if *value > 0 {
+            total += value;
+            count += 1;
+        }
+    }
+    println!("{} positive values", count);
+    (total, count)
+}


### PR DESCRIPTION
Part of #69, closes #72.

Rust is the first language defined purely through declarative mappings, and the engine needed two additions to make that work: matches of one function node are merged with the receiver kept (Rust uses `function_item` inside and outside `impl`), and a `TestCode` query marks in-file test code.

- Definitions from tree-sitter-rust's `tags.scm`; `impl` and `trait` bodies supply the receiver, so methods report as `Type.method`
- Decisions: `if`/`if let`, `match` arms except the last plus arm guards, `let ... else`, `for`/`while`/`loop`, `&&`/`||` including let chains, and `?` (the exception edge `core/cfg` counts). Closures count toward the enclosing function, like Go's function literals
- Clone spec (identifiers, literals, patterns, cost tiers, related types) and test exclusion: `#[test]` functions, `#[cfg(test)]` modules, `tests.rs`, `*_tests.rs` and `tests/` directories; `TestFiles` patterns ending in a slash now name a directory
- Mixed-language runs rank pairs and groups across languages and keep fragment IDs unique, with the language on each fragment
- Known limitations, documented: macro invocations are token trees, and the bundled grammar predates Rust 2024 syntax such as `unsafe extern`, which skipped 72 of 9,528 files (0.75%) in the sample below

Sample: the local cargo registry, 369 crates, 9,456 files, 109,654 functions in 68s; 21,845 fragments → 9,956 pairs (Type-1 2,208, Type-2 7,266, Type-3 482), 2,047 groups, none in test paths. Type-1 pairs are mostly the same function across crate versions; Type-2 samples such as `Month::succ`/`Month::pred` and `FilterMap::next`/`next_back` are genuine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)