### PR TITLE
feat(polyscan): add C++ support

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ uvx pyscn@latest analyze .
 
 See: [**pyscn**](https://github.com/ludo-technologies/pyscn)
 
-### Go / Rust
+### Go / Rust / C++
 ```
 npx polyscan analyze .
 ```
@@ -38,7 +38,7 @@ npx polyscan analyze .
 See: [**polyscan**](polyscan/)
 
 ### Others
-We are also planning to support other languages (C++ and more).
+We are also planning to support more languages.
 
 ## What You Get
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-A multi-language code quality analyzer. It detects the language of each file by its extension and measures cyclomatic complexity and detects code clones for Go and Rust.
+A multi-language code quality analyzer. It detects the language of each file by its extension and measures cyclomatic complexity and detects code clones for Go, Rust and C++.
 
 ## Installation
 
@@ -34,7 +34,7 @@ polyscan analyze --select clone .
 polyscan analyze --min-complexity 10 .
 ```
 
-Files that fail to parse are skipped, counted in `files_skipped`, and listed under `Errors`.
+A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
 ## Complexity
 
@@ -56,7 +56,16 @@ Cyclomatic complexity is one plus the number of decision points in a function, c
 | `&&`, `\|\|`, including `&&` in a let chain | 1 each |
 | `?` | 1, the early return that `core/cfg` counts as an exception edge |
 
-Function literals and closures are not reported on their own. Their decision points count toward the enclosing function, so the Go numbers match gocyclo.
+| C++ construct | Decision points |
+| --- | --- |
+| `if`, `else if` | 1 each |
+| `?:` | 1 |
+| `for`, range `for`, `while`, `do` | 1 each |
+| `switch` | 1 per `case`, `default` excluded |
+| `catch` | 1, the exception edge `core/cfg` counts |
+| `&&`, `\|\|` | 1 each |
+
+Function literals, closures and lambdas are not reported on their own. Their decision points count toward the enclosing function, so the Go numbers match gocyclo.
 
 Risk levels use the thresholds shared by every polyscan analyzer: low up to 9, medium up to 19, high from 20.
 
@@ -70,9 +79,11 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.75 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.70 |
 
-Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for Rust it is `#[test]` functions, items under `#[cfg(test)]` or `#[cfg(all(test, ...))]`, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
+Pairs below 0.70 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for C++ it is `*_test.*`, `*_tests.*`, `test_*.*` and `*Test.*` source files and any `test` or `tests` directory; for Rust it is `#[test]` functions, items under `#[cfg(test)]` or `#[cfg(all(test, ...))]`, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
 
-Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as a syntax error and skipped, which affected 0.75% of the files in a sample of 369 crates.
+C++ files are parsed one at a time without the preprocessor. Every branch of an `#if` is analyzed, macros are not expanded, and code whose syntax only makes sense after expansion is a syntax error: the file is reported as partial and the functions containing the error are left out. Heavily templated code is parsed on a best-effort basis. Header files, `.h` included, are analyzed as C++.
+
+Rust macro invocations parse as token trees, so the code inside a macro call contributes tokens but no structure. Clone detection recall is lower on macro-heavy code. The bundled tree-sitter-rust grammar predates Rust 2024 edition syntax such as `unsafe extern` blocks; a file that uses it is reported as partial, which affected 0.75% of the files in a sample of 369 crates.
 
 Pairs are merged into groups by connected components, and the groups are deduplicated by the shared `core/clone` passes. When there are more than 10,000 candidate pairs, only pairs that share a MinHash band are compared, and within a band each function is compared with at most 1,024 of the functions that follow it. Neighbours in a band are always compared, so a large set of near-identical functions still ends up in one group.
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -93,6 +93,7 @@ A language is declarative: a tree-sitter grammar and two queries. See `internal/
 
 - The definitions query matches each function once. `@definition.<kind>` spans the function, `@name` its name, and an optional `@receiver` is prefixed to the name. The bundled `queries/tags.scm` of a grammar is the starting point.
 - In the decisions query every capture is one decision point, attributed to the innermost function that contains it and reported under the capture's name.
+- The optional scopes query names the scopes that enclose functions, such as classes, impl blocks and namespaces, so members read `Type::method`; a `@receiver` capture in the definitions query names a receiver declared on the function itself, as Go methods have.
 - The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names test files by file name glob or, with a trailing slash, by directory, and `TestCode` is a query capturing test code inside a file; both are excluded from clone detection.
 
 ## Development

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -37,7 +37,7 @@ func analyzeCmd() *cobra.Command {
 		Short: "Analyze source files",
 		Long: `Analyze source files for cyclomatic complexity and code clones.
 
-The language of each file is detected from its extension. Supported: Go, Rust.
+The language of each file is detected from its extension. Supported: Go, Rust, C++.
 
 By default, generates an HTML report and opens it in your browser.
 

--- a/polyscan/cmd/polyscan/main.go
+++ b/polyscan/cmd/polyscan/main.go
@@ -24,7 +24,7 @@ func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "polyscan",
 		Short:   "polyscan - multi-language static analyzer",
-		Long:    "polyscan is a static analyzer that measures code quality across languages.\nIt currently analyzes cyclomatic complexity and code clones for Go and Rust.",
+		Long:    "polyscan is a static analyzer that measures code quality across languages.\nIt currently analyzes cyclomatic complexity and code clones for Go, Rust and C++.",
 		Version: version.Version,
 	}
 	cmd.AddCommand(analyzeCmd())

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -58,12 +58,14 @@ type Complexity struct {
 	Summary   ComplexitySummary `json:"summary"`
 }
 
-// Files counts the files a run covered. Skipped files could not be read or
-// parsed and are absent from every metric, so a consumer must read this
-// before trusting the aggregates.
+// Files counts the files a run covered. Skipped files could not be read
+// and are absent from every metric; partial files had a syntax error, and
+// the functions containing it are absent. A consumer must read this before
+// trusting the aggregates.
 type Files struct {
 	Total    int `json:"total"`
 	Analyzed int `json:"analyzed"`
+	Partial  int `json:"partial"`
 	Skipped  int `json:"skipped"`
 }
 
@@ -72,13 +74,17 @@ type Report struct {
 	Files      Files         `json:"files"`
 	Complexity *Complexity   `json:"complexity,omitempty"`
 	Clones     *clone.Report `json:"clone,omitempty"`
+	// Warnings lists, per partial file, its syntax error.
+	Warnings []string `json:"warnings,omitempty"`
 	// Errors lists, per skipped file, why it was skipped.
 	Errors []string `json:"errors,omitempty"`
 }
 
 // Analyze collects every supported source file under paths and runs the
-// selected analyses on it. A file that cannot be read or parsed is skipped
-// and reported in Errors; finding no supported file at all is an error.
+// selected analyses on it. A file that cannot be read is skipped and
+// reported in Errors, a file with a syntax error is analyzed without the
+// functions that contain it and reported in Warnings, and finding no
+// supported file at all is an error.
 func Analyze(paths []string, options Options) (*Report, error) {
 	files, err := source.CollectFiles(paths, source.FileFilter{
 		IncludePatterns: lang.IncludePatterns(),
@@ -104,13 +110,18 @@ func Analyze(paths []string, options Options) (*Report, error) {
 			panic(fmt.Sprintf("no language for %s", file))
 		}
 		display := displayPath(file)
-		functions, err := analyzeFile(language, file)
+		result, err := analyzeFile(language, file)
 		if err != nil {
 			report.Files.Skipped++
 			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", display, err))
 			continue
 		}
 		report.Files.Analyzed++
+		if result.SyntaxError != nil {
+			report.Files.Partial++
+			report.Warnings = append(report.Warnings, fmt.Sprintf("%s: %v; functions containing it were not analyzed", display, result.SyntaxError))
+		}
+		functions := result.Functions
 
 		if options.Complexity {
 			for _, fn := range functions {
@@ -141,7 +152,7 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	return report, nil
 }
 
-func analyzeFile(language *engine.Language, path string) ([]engine.Function, error) {
+func analyzeFile(language *engine.Language, path string) (*engine.Result, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
 		return nil, err

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -11,8 +11,9 @@ import (
 )
 
 // fixtures copies the Go fixtures into a temporary directory and adds a
-// file that does not parse. The broken file is generated here rather than
-// committed so that gofmt and go vet never trip over it.
+// file that does not parse and one that cannot be read. The broken file is
+// generated here rather than committed so that gofmt and go vet never trip
+// over it.
 func fixtures(t *testing.T) string {
 	t.Helper()
 	dir := t.TempDir()
@@ -23,7 +24,10 @@ func fixtures(t *testing.T) string {
 	if err := os.WriteFile(filepath.Join(dir, "sample.go"), sample, 0o644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(dir, "broken.go"), []byte("package broken\n\nfunc Unclosed() {\n\tif true {\n"), 0o644); err != nil {
+	if err := os.WriteFile(filepath.Join(dir, "broken.go"), []byte("package broken\n\nfunc Broken() {\n\tif {\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "unreadable.go"), []byte("package p\n"), 0o000); err != nil {
 		t.Fatal(err)
 	}
 	return dir
@@ -35,11 +39,14 @@ func TestAnalyzeComplexity(t *testing.T) {
 		t.Fatalf("Analyze: %v", err)
 	}
 
-	if report.Files != (Files{Total: 2, Analyzed: 1, Skipped: 1}) {
-		t.Errorf("files = %+v, want 2/1/1", report.Files)
+	if report.Files != (Files{Total: 3, Analyzed: 2, Partial: 1, Skipped: 1}) {
+		t.Errorf("files = %+v, want total 3, analyzed 2, partial 1, skipped 1", report.Files)
 	}
-	if len(report.Errors) != 1 || !strings.Contains(report.Errors[0], "broken.go: syntax error") {
-		t.Errorf("errors = %v, want the broken file's syntax error", report.Errors)
+	if len(report.Warnings) != 1 || !strings.Contains(report.Warnings[0], "broken.go: syntax error at line 4") {
+		t.Errorf("warnings = %v, want the broken file's syntax error", report.Warnings)
+	}
+	if len(report.Errors) != 1 || !strings.Contains(report.Errors[0], "unreadable.go") {
+		t.Errorf("errors = %v, want the unreadable file", report.Errors)
 	}
 	if report.Clones != nil {
 		t.Error("clones were not selected but are present")
@@ -127,8 +134,8 @@ func TestAnalyzeRust(t *testing.T) {
 	for _, fn := range report.Complexity.Functions {
 		byName[fn.Name] = fn
 	}
-	if fn := byName["Server.handle"]; fn.Complexity != 8 || fn.Language != "Rust" {
-		t.Errorf("Server.handle = %+v, want complexity 8 in Rust", fn)
+	if fn := byName["Server::handle"]; fn.Complexity != 8 || fn.Language != "Rust" {
+		t.Errorf("Server::handle = %+v, want complexity 8 in Rust", fn)
 	}
 	if _, ok := byName["sums_positive_values"]; !ok {
 		t.Error("test functions must still be analyzed for complexity")
@@ -216,5 +223,27 @@ func TestRankOrdersGroupsLikeCore(t *testing.T) {
 		if group.ID != i {
 			t.Errorf("group %d has ID %d", i, group.ID)
 		}
+	}
+}
+
+func TestAnalyzeCpp(t *testing.T) {
+	report, err := Analyze([]string{"../../testdata/cpp"}, Options{Complexity: true, Clones: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	byName := map[string]Function{}
+	for _, fn := range report.Complexity.Functions {
+		byName[fn.Name] = fn
+	}
+	if fn := byName["Server::handle"]; fn.Complexity != 9 || fn.Language != "C++" {
+		t.Errorf("Server::handle = %+v, want complexity 9 in C++", fn)
+	}
+	if _, ok := byName["sumPositiveAgain"]; !ok {
+		t.Error("functions in test files must still be analyzed for complexity")
+	}
+	// sumPositiveAgain is a copy of sumPositive but lies in sample_test.cpp.
+	stats := report.Clones.Statistics
+	if stats.TotalFragments != 3 || stats.TotalClonePairs != 1 || stats.ClonesByType["Type-2"] != 1 {
+		t.Errorf("statistics = %+v, want one Type-2 pair among three fragments", stats)
 	}
 }

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -137,7 +137,7 @@ func TestAnalyzeRust(t *testing.T) {
 	if fn := byName["Server::handle"]; fn.Complexity != 8 || fn.Language != "Rust" {
 		t.Errorf("Server::handle = %+v, want complexity 8 in Rust", fn)
 	}
-	if _, ok := byName["sums_positive_values"]; !ok {
+	if _, ok := byName["tests::sums_positive_values"]; !ok {
 		t.Error("test functions must still be analyzed for complexity")
 	}
 

--- a/polyscan/internal/clone/detector_test.go
+++ b/polyscan/internal/clone/detector_test.go
@@ -75,11 +75,14 @@ func detectWith(t *testing.T, config Config, sources ...string) *Report {
 	t.Helper()
 	detector := NewDetector(golang.Language.Clone, config)
 	for i, source := range sources {
-		functions, err := golang.Language.Analyze([]byte("package p\n\nimport \"fmt\"\n\n" + source))
+		result, err := golang.Language.Analyze([]byte("package p\n\nimport \"fmt\"\n\n" + source))
 		if err != nil {
 			t.Fatal(err)
 		}
-		for _, fn := range functions {
+		if result.SyntaxError != nil {
+			t.Fatal(result.SyntaxError)
+		}
+		for _, fn := range result.Functions {
 			detector.Add(fn, "file"+string(rune('a'+i))+".go")
 		}
 	}

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -28,19 +28,16 @@ type Language struct {
 	Grammar *sitter.Language
 	// Definitions is a tree-sitter query that matches every function once.
 	// Its @definition.<kind> capture spans the whole function and @name its
-	// name. An optional @receiver capture holds the receiver type of a
-	// method and is prefixed to the name with the ScopeSeparator.
-	//
-	// A function node that several patterns match is reported once, under
-	// the match that captured a receiver when there is one, so a grammar
-	// that uses one node type for functions and methods can name methods
-	// through their enclosing type.
+	// name. An optional @receiver capture holds a receiver type declared on
+	// the function itself, as Go methods do, and is prefixed to the name
+	// with the ScopeSeparator.
 	Definitions string
-	// Scopes is an optional tree-sitter query for named scopes such as
-	// classes and namespaces: @scope spans the scope and @receiver holds
-	// its name. A function inside scopes is named after them, outermost
-	// first, so a member defined inside its class and one defined outside
-	// it with a qualified name read the same.
+	// Scopes is an optional tree-sitter query for the named scopes that
+	// enclose functions, such as classes, impl blocks and namespaces:
+	// @scope spans the scope and @receiver holds its name. A function is
+	// named after the scopes that contain it, outermost first, so a member
+	// defined inside its class and one defined outside it with a qualified
+	// name read the same.
 	Scopes string
 	// ScopeSeparator joins scope and receiver names to function names;
 	// empty means ".".
@@ -275,7 +272,6 @@ func set(names []string) map[string]struct{} {
 
 func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function {
 	var functions []Function
-	byStart := map[uint32]int{}
 	forEachMatch(l.definitions, root, source, func(match *sitter.QueryMatch) {
 		var fn Function
 		var node *sitter.Node
@@ -298,14 +294,6 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 		if receiver != "" {
 			fn.Name = receiver + l.separator() + fn.Name
 		}
-		if index, seen := byStart[node.StartByte()]; seen {
-			if receiver != "" {
-				functions[index].Name = fn.Name
-				functions[index].Kind = fn.Kind
-			}
-			return
-		}
-		byStart[node.StartByte()] = len(functions)
 		fn.StartLine = int(node.StartPoint().Row) + 1
 		fn.StartColumn = int(node.StartPoint().Column) + 1
 		fn.EndLine = int(node.EndPoint().Row) + 1
@@ -418,7 +406,8 @@ type scope struct {
 }
 
 // applyScopes prefixes each function with the names of the scopes that
-// contain it, outermost first.
+// contain it, outermost first. Functions and scopes are both in start
+// order, so one sweep with a stack of the open scopes covers them.
 func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Function) {
 	if l.scopes == nil {
 		return
@@ -440,13 +429,19 @@ func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Fun
 	})
 	sort.Slice(scopes, func(i, j int) bool { return scopes[i].start < scopes[j].start })
 
+	var open []scope
+	next := 0
 	for i := range functions {
 		fn := &functions[i]
+		for next < len(scopes) && scopes[next].start <= fn.startByte {
+			open = append(open, scopes[next])
+			next++
+		}
+		for len(open) > 0 && open[len(open)-1].end < fn.startByte {
+			open = open[:len(open)-1]
+		}
 		var names []string
-		for _, s := range scopes {
-			if s.start > fn.startByte {
-				break
-			}
+		for _, s := range open {
 			if s.end >= fn.endByte {
 				names = append(names, s.name)
 			}

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -29,13 +29,22 @@ type Language struct {
 	// Definitions is a tree-sitter query that matches every function once.
 	// Its @definition.<kind> capture spans the whole function and @name its
 	// name. An optional @receiver capture holds the receiver type of a
-	// method and is prefixed to the name as "Receiver.Name".
-	Definitions string
+	// method and is prefixed to the name with the ScopeSeparator.
+	//
 	// A function node that several patterns match is reported once, under
 	// the match that captured a receiver when there is one, so a grammar
 	// that uses one node type for functions and methods can name methods
 	// through their enclosing type.
-	//
+	Definitions string
+	// Scopes is an optional tree-sitter query for named scopes such as
+	// classes and namespaces: @scope spans the scope and @receiver holds
+	// its name. A function inside scopes is named after them, outermost
+	// first, so a member defined inside its class and one defined outside
+	// it with a qualified name read the same.
+	Scopes string
+	// ScopeSeparator joins scope and receiver names to function names;
+	// empty means ".".
+	ScopeSeparator string
 	// Decisions is a tree-sitter query in which every capture is one
 	// decision point. The point is attributed to the innermost function
 	// that contains it and counted under the capture's name, so the capture
@@ -57,6 +66,7 @@ type Language struct {
 	compileErr  error
 	definitions *sitter.Query
 	decisions   *sitter.Query
+	scopes      *sitter.Query
 	testCode    *sitter.Query
 	identifiers map[string]struct{}
 	literals    map[string]struct{}
@@ -125,14 +135,23 @@ type Function struct {
 
 	startByte uint32
 	endByte   uint32
+	hasError  bool
 }
 
 const (
 	definitionPrefix = "definition."
 	nameCapture      = "name"
 	receiverCapture  = "receiver"
+	scopeCapture     = "scope"
 	operatorField    = "operator"
 )
+
+func (l *Language) separator() string {
+	if l.ScopeSeparator == "" {
+		return "."
+	}
+	return l.ScopeSeparator
+}
 
 // IsTestFile reports whether the path matches one of the language's
 // TestFiles patterns.
@@ -155,12 +174,23 @@ func (l *Language) IsTestFile(path string) bool {
 	return false
 }
 
+// Result is the analysis of one file.
+type Result struct {
+	Functions []Function
+	// SyntaxError is the first syntax error in the file, or nil when the
+	// file parsed cleanly. A tree-sitter parse always yields a tree and
+	// recovers around what it cannot parse, so the functions that contain
+	// no error are still reported; the ones that do are left out, because
+	// their metrics would describe only the fragments the grammar managed
+	// to salvage. This matters most for C++, where a macro that opens a
+	// namespace or declares an attribute is a syntax error to a parser
+	// that does not run the preprocessor.
+	SyntaxError error
+}
+
 // Analyze parses source and returns every function the language defines,
-// with its complexity computed. Source that does not parse is an error: a
-// tree-sitter parse always yields a tree, so the syntax check is what keeps
-// a broken file from being reported as if its salvageable fragments were
-// the whole program.
-func (l *Language) Analyze(source []byte) ([]Function, error) {
+// with its complexity computed.
+func (l *Language) Analyze(source []byte) (*Result, error) {
 	if err := l.compile(); err != nil {
 		return nil, err
 	}
@@ -176,11 +206,10 @@ func (l *Language) Analyze(source []byte) ([]Function, error) {
 	defer tree.Close()
 
 	root := tree.RootNode()
-	if err := checkSyntax(root); err != nil {
-		return nil, err
-	}
+	result := &Result{SyntaxError: checkSyntax(root)}
 
 	functions := l.extractFunctions(root, source)
+	l.applyScopes(root, source, functions)
 	l.countDecisions(root, source, functions)
 	l.markTests(root, source, functions)
 	for i := range functions {
@@ -189,7 +218,12 @@ func (l *Language) Analyze(source []byte) ([]Function, error) {
 			functions[i].Complexity += count
 		}
 	}
-	return functions, nil
+	for _, fn := range functions {
+		if !fn.hasError {
+			result.Functions = append(result.Functions, fn)
+		}
+	}
+	return result, nil
 }
 
 // compile builds the queries once. A query that does not compile against
@@ -206,6 +240,14 @@ func (l *Language) compile() error {
 		if err != nil {
 			l.compileErr = fmt.Errorf("%s decisions query: %w", l.Name, err)
 			return
+		}
+		if l.Scopes != "" {
+			scopes, err := sitter.NewQuery([]byte(l.Scopes), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s scopes query: %w", l.Name, err)
+				return
+			}
+			l.scopes = scopes
 		}
 		if l.TestCode != "" {
 			testCode, err := sitter.NewQuery([]byte(l.TestCode), l.Grammar)
@@ -254,7 +296,7 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 			return
 		}
 		if receiver != "" {
-			fn.Name = receiver + "." + fn.Name
+			fn.Name = receiver + l.separator() + fn.Name
 		}
 		if index, seen := byStart[node.StartByte()]; seen {
 			if receiver != "" {
@@ -270,6 +312,7 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 		fn.EndColumn = int(node.EndPoint().Column) + 1
 		fn.startByte = node.StartByte()
 		fn.endByte = node.EndByte()
+		fn.hasError = node.HasError()
 		fn.Decisions = map[string]int{}
 
 		converter := treeConverter{language: l, source: source}
@@ -366,6 +409,52 @@ func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []
 			fn.Decisions[l.decisions.CaptureNameForId(capture.Index)]++
 		}
 	})
+}
+
+// scope is a named span from the Scopes query.
+type scope struct {
+	start, end uint32
+	name       string
+}
+
+// applyScopes prefixes each function with the names of the scopes that
+// contain it, outermost first.
+func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Function) {
+	if l.scopes == nil {
+		return
+	}
+	var scopes []scope
+	forEachMatch(l.scopes, root, source, func(match *sitter.QueryMatch) {
+		var s scope
+		for _, capture := range match.Captures {
+			switch l.scopes.CaptureNameForId(capture.Index) {
+			case scopeCapture:
+				s.start, s.end = capture.Node.StartByte(), capture.Node.EndByte()
+			case receiverCapture:
+				s.name = capture.Node.Content(source)
+			}
+		}
+		if s.name != "" && s.end > s.start {
+			scopes = append(scopes, s)
+		}
+	})
+	sort.Slice(scopes, func(i, j int) bool { return scopes[i].start < scopes[j].start })
+
+	for i := range functions {
+		fn := &functions[i]
+		var names []string
+		for _, s := range scopes {
+			if s.start > fn.startByte {
+				break
+			}
+			if s.end >= fn.endByte {
+				names = append(names, s.name)
+			}
+		}
+		if len(names) > 0 {
+			fn.Name = strings.Join(names, l.separator()) + l.separator() + fn.Name
+		}
+	}
 }
 
 // markTests flags every function inside a span the TestCode query captures.

--- a/polyscan/internal/lang/cpp/cpp.go
+++ b/polyscan/internal/lang/cpp/cpp.go
@@ -38,7 +38,8 @@ var Language = &engine.Language{
 	// the code or in a test directory.
 	TestFiles: []string{
 		"*_test.cc", "*_test.cpp", "*_test.cxx", "*_tests.cc", "*_tests.cpp", "*_tests.cxx",
-		"test_*.cc", "test_*.cpp", "test_*.cxx", "*Test.cc", "*Test.cpp", "*Tests.cc", "*Tests.cpp",
+		"test_*.cc", "test_*.cpp", "test_*.cxx",
+		"*Test.cc", "*Test.cpp", "*Test.cxx", "*Tests.cc", "*Tests.cpp", "*Tests.cxx",
 		"test/", "tests/",
 	},
 	// The function pattern of tree-sitter-cpp's queries/tags.scm, widened

--- a/polyscan/internal/lang/cpp/cpp.go
+++ b/polyscan/internal/lang/cpp/cpp.go
@@ -1,0 +1,118 @@
+// Package cpp defines how polyscan analyzes C++.
+package cpp
+
+import (
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	tscpp "github.com/smacker/go-tree-sitter/cpp"
+)
+
+// declarators matches a function's declarator: the function_declarator
+// itself, or one wrapped in the pointer and reference declarators of a
+// pointer, pointer-to-pointer, reference or reference-to-pointer return
+// type.
+const declarators = `[
+  (function_declarator declarator: ` + names + `)
+  (pointer_declarator declarator: (function_declarator declarator: ` + names + `))
+  (pointer_declarator declarator: (pointer_declarator declarator: (function_declarator declarator: ` + names + `)))
+  (reference_declarator (function_declarator declarator: ` + names + `))
+  (pointer_declarator declarator: (reference_declarator (function_declarator declarator: ` + names + `)))
+]`
+
+// names are the nodes that name a function: a plain or member name, a
+// destructor, an operator, or a qualified name such as ns::Type::method.
+const names = `[(identifier) (field_identifier) (destructor_name) (operator_name) (qualified_identifier)] @name`
+
+// Language is the C++ definition. Files are parsed one at a time without
+// the preprocessor, so every branch of a conditional inclusion is
+// analyzed and a file whose syntax only makes sense after macro expansion
+// is reported as a syntax error. Headers are analyzed as C++; C code
+// parses under the C++ grammar with few differences. Lambdas are not
+// extracted on their own: their decision points count toward the
+// enclosing function, as Go's function literals do.
+var Language = &engine.Language{
+	Name:           "C++",
+	Extensions:     []string{".cpp", ".cc", ".cxx", ".hpp", ".hh", ".hxx", ".h", ".ipp", ".inl"},
+	Grammar:        tscpp.GetLanguage(),
+	ScopeSeparator: "::",
+	// The conventions of GoogleTest, Catch2 and doctest: test files next to
+	// the code or in a test directory.
+	TestFiles: []string{
+		"*_test.cc", "*_test.cpp", "*_test.cxx", "*_tests.cc", "*_tests.cpp", "*_tests.cxx",
+		"test_*.cc", "test_*.cpp", "test_*.cxx", "*Test.cc", "*Test.cpp", "*Tests.cc", "*Tests.cpp",
+		"test/", "tests/",
+	},
+	// The function pattern of tree-sitter-cpp's queries/tags.scm, widened
+	// to pointer and reference return types. Members defined inside their
+	// class carry a plain name that the scopes query qualifies.
+	Definitions: `(function_definition declarator: ` + declarators + `) @definition.function`,
+	Scopes: `
+(class_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
+(struct_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
+(union_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
+(namespace_definition name: (namespace_identifier) @receiver body: (declaration_list) @scope)
+`,
+	// A case without a value is the default, the path the other cases
+	// branch away from. A catch clause is the exception edge core/cfg
+	// counts.
+	Decisions: `
+(if_statement) @branch
+(conditional_expression) @ternary
+(for_statement) @loop
+(for_range_loop) @loop
+(while_statement) @loop
+(do_statement) @loop
+(case_statement value: (_)) @case
+(catch_clause) @exception
+(binary_expression operator: ["&&" "||"]) @logical_operator
+`,
+	Clone: engine.CloneSpec{
+		Identifiers: []string{
+			"identifier", "field_identifier", "type_identifier", "namespace_identifier",
+			"statement_identifier", "primitive_type", "this", "auto",
+		},
+		Literals: []string{
+			"number_literal", "string_literal", "char_literal", "raw_string_literal",
+			"user_defined_literal", "true", "false", "null",
+		},
+		Patterns: []string{
+			"if_statement", "for_statement", "for_range_loop", "while_statement", "do_statement",
+			"switch_statement", "case_statement", "try_statement", "catch_clause", "throw_statement",
+			"return_statement", "break_statement", "continue_statement", "goto_statement",
+			"call_expression", "field_expression", "subscript_expression", "binary_expression",
+			"unary_expression", "update_expression", "assignment_expression", "conditional_expression",
+			"cast_expression", "new_expression", "delete_expression", "lambda_expression",
+			"declaration", "init_declarator", "initializer_list", "pointer_expression",
+			"sizeof_expression", "co_await_expression", "template_function",
+		},
+		Structural: []string{
+			"translation_unit", "function_definition", "lambda_expression",
+			"class_specifier", "struct_specifier", "union_specifier", "enum_specifier",
+			"namespace_definition", "template_declaration",
+		},
+		ControlFlow: []string{
+			"if_statement", "else_clause", "condition_clause",
+			"for_statement", "for_range_loop", "while_statement", "do_statement",
+			"switch_statement", "case_statement", "try_statement", "catch_clause", "throw_statement",
+			"return_statement", "break_statement", "continue_statement", "goto_statement",
+			"labeled_statement", "co_return_statement",
+		},
+		Expressions: []string{
+			"binary_expression", "unary_expression", "update_expression", "assignment_expression",
+			"conditional_expression", "call_expression", "argument_list", "field_expression",
+			"subscript_expression", "cast_expression", "pointer_expression", "new_expression",
+			"delete_expression", "sizeof_expression", "parenthesized_expression", "comma_expression",
+			"initializer_list", "compound_literal_expression", "co_await_expression",
+		},
+		Related: [][2]string{
+			{"for_statement", "for_range_loop"},
+			{"for_statement", "while_statement"},
+			{"for_range_loop", "while_statement"},
+			{"while_statement", "do_statement"},
+			{"if_statement", "conditional_expression"},
+			{"if_statement", "switch_statement"},
+			{"binary_expression", "unary_expression"},
+			{"assignment_expression", "update_expression"},
+			{"class_specifier", "struct_specifier"},
+		},
+	},
+}

--- a/polyscan/internal/lang/cpp/cpp_test.go
+++ b/polyscan/internal/lang/cpp/cpp_test.go
@@ -1,0 +1,177 @@
+package cpp
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+func analyze(t *testing.T, source string) map[string]engine.Function {
+	t.Helper()
+	result, err := Language.Analyze([]byte(source))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if result.SyntaxError != nil {
+		t.Fatalf("syntax error: %v", result.SyntaxError)
+	}
+	byName := map[string]engine.Function{}
+	for _, fn := range result.Functions {
+		byName[fn.Name] = fn
+	}
+	return byName
+}
+
+func TestExtractsFunctionsAndMembers(t *testing.T) {
+	functions := analyze(t, `
+int free(int a) { return a; }
+int* pointer() { return 0; }
+const char** pointers() { return 0; }
+int& reference(int& x) { return x; }
+int*& both(int*& x) { return x; }
+namespace ns { namespace in {
+class Foo {
+ public:
+  Foo() {}
+  ~Foo() {}
+  int method(int x) const { return x; }
+  int* member_pointer() { return 0; }
+  bool operator==(const Foo&) const { return true; }
+  class Inner { void deep() {} };
+};
+int ns_free() { return 1; }
+} }
+int ns::in::Foo::outside(int y) { return y; }
+template <typename T> T tmpl(T t) { auto l = [&](int z) { return z; }; return l(t); }
+struct S { void m() {} };
+`)
+
+	want := []string{
+		"free", "pointer", "pointers", "reference", "both",
+		"ns::in::Foo::Foo", "ns::in::Foo::~Foo", "ns::in::Foo::method", "ns::in::Foo::member_pointer",
+		"ns::in::Foo::operator==", "ns::in::Foo::Inner::deep", "ns::in::ns_free",
+		"ns::in::Foo::outside", "tmpl", "S::m",
+	}
+	if len(functions) != len(want) {
+		t.Errorf("got %d functions, want %d: %v", len(functions), len(want), functions)
+	}
+	for _, name := range want {
+		if _, ok := functions[name]; !ok {
+			t.Errorf("missing function %q", name)
+		}
+	}
+}
+
+func TestComplexityCountsDecisionPoints(t *testing.T) {
+	cases := []struct {
+		name      string
+		body      string
+		want      int
+		decisions map[string]int
+	}{
+		{"none", `return a;`, 1, map[string]int{}},
+		{"if", `if (a) return 1; return 0;`, 2, map[string]int{"branch": 1}},
+		{"if else", `if (a) { return 1; } else { return 0; }`, 2, map[string]int{"branch": 1}},
+		{"else if chain", `if (a) { } else if (b) { } else { } return 0;`, 3, map[string]int{"branch": 2}},
+		{"ternary", `return a ? 1 : 0;`, 2, map[string]int{"ternary": 1}},
+		{"for", `for (int i = 0; i < 3; i++) { } return 0;`, 2, map[string]int{"loop": 1}},
+		{"range for", `for (auto v : xs) { } return 0;`, 2, map[string]int{"loop": 1}},
+		{"while", `while (a) { } return 0;`, 2, map[string]int{"loop": 1}},
+		{"do while", `do { } while (a); return 0;`, 2, map[string]int{"loop": 1}},
+		{"switch cases without default", `switch (n) { case 1: return 1; case 2: case 3: return 2; default: return 0; }`, 4, map[string]int{"case": 3}},
+		{"try catch", `try { return 1; } catch (const E& e) { return 2; } catch (...) { return 3; }`, 3, map[string]int{"exception": 2}},
+		{"logical operators", `if (a && b || c) { } return 0;`, 4, map[string]int{"branch": 1, "logical_operator": 2}},
+		{"bitwise operators do not count", `return n & 1 | 2;`, 1, map[string]int{}},
+		{"lambda counts toward its enclosing function", `auto f = [&](int z) { if (z) return z; return 0; }; return f(n);`, 2, map[string]int{"branch": 1}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fn := analyze(t, "int f(bool a, bool b, bool c, int n, int xs[3]) {\n\t"+tc.body+"\n}\n")["f"]
+			if fn.Complexity != tc.want {
+				t.Errorf("complexity = %d, want %d", fn.Complexity, tc.want)
+			}
+			if len(fn.Decisions) != len(tc.decisions) {
+				t.Errorf("decisions = %v, want %v", fn.Decisions, tc.decisions)
+			}
+			for kind, count := range tc.decisions {
+				if fn.Decisions[kind] != count {
+					t.Errorf("decisions[%q] = %d, want %d", kind, fn.Decisions[kind], count)
+				}
+			}
+		})
+	}
+}
+
+func TestPreprocessorBranchesAreBothAnalyzed(t *testing.T) {
+	functions := analyze(t, "#ifdef X\nint cond() { if (1) return 1; return 0; }\n#else\nint other() { return 2; }\n#endif\n")
+	if functions["cond"].Complexity != 2 || functions["other"].Complexity != 1 {
+		t.Errorf("functions = %v, want both branches", functions)
+	}
+}
+
+func TestContentDropsComments(t *testing.T) {
+	fn := analyze(t, "// Doc.\nint f() {\n\t// line\n\treturn/* block */1;\n}\n")["f"]
+	if strings.Contains(fn.Content, "line") || strings.Contains(fn.Content, "block") {
+		t.Errorf("content keeps comments: %q", fn.Content)
+	}
+	if !strings.Contains(fn.Content, "return 1") || fn.CodeLines != 3 {
+		t.Errorf("content = %q, code lines = %d", fn.Content, fn.CodeLines)
+	}
+}
+
+func TestTestFiles(t *testing.T) {
+	for path, want := range map[string]bool{
+		"src/foo.cc":           false,
+		"src/foo_test.cc":      true,
+		"src/foo_tests.cpp":    true,
+		"src/test_foo.cpp":     true,
+		"src/FooTest.cpp":      true,
+		"test/foo.cc":          true,
+		"tests/unit/foo.cpp":   true,
+		"src/latest/foo.cpp":   false,
+		"include/foo_test.hpp": false,
+	} {
+		if got := Language.IsTestFile(path); got != want {
+			t.Errorf("IsTestFile(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+// TestMacroErrorsKeepOtherFunctions parses a file the way C++ libraries
+// look without the preprocessor: a macro opens the namespace and a macro
+// declares an attribute. The functions around them still count; the
+// function that contains the error does not.
+func TestMacroErrorsKeepOtherFunctions(t *testing.T) {
+	result, err := Language.Analyze([]byte(`
+FMT_BEGIN_NAMESPACE
+namespace detail {
+int first(int a) { if (a) return 1; return 0; }
+}
+GTEST_DISABLE_MSC_WARNINGS_PUSH_(4100)
+class C { int method() { return 1; } };
+int last() { return 2; }
+int broken(int a) { if ( return a; }
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SyntaxError == nil {
+		t.Fatal("expected a syntax error")
+	}
+	complexity := map[string]int{}
+	for _, fn := range result.Functions {
+		// Recovery may lose the namespace scope, so match the bare name.
+		name := fn.Name
+		if i := strings.LastIndex(name, "::"); i >= 0 {
+			name = name[i+2:]
+		}
+		complexity[name] = fn.Complexity
+	}
+	if complexity["first"] != 2 || complexity["method"] != 1 || complexity["last"] != 1 {
+		t.Errorf("functions = %v, want first, method and last", complexity)
+	}
+	if _, ok := complexity["broken"]; ok {
+		t.Error("a function containing the error must not be analyzed")
+	}
+}

--- a/polyscan/internal/lang/cpp/cpp_test.go
+++ b/polyscan/internal/lang/cpp/cpp_test.go
@@ -127,6 +127,7 @@ func TestTestFiles(t *testing.T) {
 		"src/foo_tests.cpp":    true,
 		"src/test_foo.cpp":     true,
 		"src/FooTest.cpp":      true,
+		"src/FooTests.cxx":     true,
 		"test/foo.cc":          true,
 		"tests/unit/foo.cpp":   true,
 		"src/latest/foo.cpp":   false,

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -9,12 +9,15 @@ import (
 
 func analyze(t *testing.T, source string) map[string]engine.Function {
 	t.Helper()
-	functions, err := Language.Analyze([]byte(source))
+	result, err := Language.Analyze([]byte(source))
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
+	if result.SyntaxError != nil {
+		t.Fatalf("syntax error: %v", result.SyntaxError)
+	}
 	byName := map[string]engine.Function{}
-	for _, fn := range functions {
+	for _, fn := range result.Functions {
 		byName[fn.Name] = fn
 	}
 	return byName
@@ -122,13 +125,20 @@ func TestTopLevelDecisionsAreIgnored(t *testing.T) {
 	}
 }
 
-func TestSyntaxErrorIsReported(t *testing.T) {
-	_, err := Language.Analyze([]byte("package p\n\nfunc F() {\n\tif {\n"))
-	if err == nil {
-		t.Fatal("expected a syntax error")
+func TestSyntaxErrorKeepsCleanFunctions(t *testing.T) {
+	result, err := Language.Analyze([]byte("package p\n\nfunc Clean() {\n\tif true {\n\t}\n}\n\nfunc Broken() {\n\tif {\n}\n\nfunc AlsoClean() {}\n"))
+	if err != nil {
+		t.Fatal(err)
 	}
-	if !strings.Contains(err.Error(), "syntax error at line 3") {
-		t.Errorf("error = %q, want the first error line", err)
+	if result.SyntaxError == nil || !strings.Contains(result.SyntaxError.Error(), "syntax error at line 9") {
+		t.Errorf("syntax error = %v, want the first error line", result.SyntaxError)
+	}
+	var names []string
+	for _, fn := range result.Functions {
+		names = append(names, fn.Name)
+	}
+	if strings.Join(names, ",") != "Clean,AlsoClean" {
+		t.Errorf("functions = %v, want the ones without errors", names)
 	}
 }
 

--- a/polyscan/internal/lang/lang.go
+++ b/polyscan/internal/lang/lang.go
@@ -6,12 +6,13 @@ import (
 	"path/filepath"
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/cpp"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/rust"
 )
 
 // All lists every supported language.
-var All = []*engine.Language{golang.Language, rust.Language}
+var All = []*engine.Language{golang.Language, rust.Language, cpp.Language}
 
 // ByPath returns the language that owns the file's extension.
 func ByPath(path string) (*engine.Language, bool) {

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -12,9 +12,10 @@ import (
 // code inside a macro call contributes tokens but no structure, which
 // lowers clone detection recall on macro-heavy code.
 var Language = &engine.Language{
-	Name:       "Rust",
-	Extensions: []string{".rs"},
-	Grammar:    tsrust.GetLanguage(),
+	Name:           "Rust",
+	Extensions:     []string{".rs"},
+	Grammar:        tsrust.GetLanguage(),
+	ScopeSeparator: "::",
 	// A test module split into its own file is declared as
 	// #[cfg(test)] mod tests; in the parent, which a single file cannot
 	// see, so the conventional names stand in for the attribute: tests.rs and
@@ -41,7 +42,7 @@ var Language = &engine.Language{
 `,
 	// The function pattern of tree-sitter-rust's queries/tags.scm, plus
 	// the same node inside an impl or trait body, where the implemented
-	// type or the trait becomes the receiver. The engine merges the two
+	// type or the trait becomes the receiver, as in Type::method. The engine merges the two
 	// matches of one function node and keeps the receiver.
 	Definitions: `
 (function_item name: (identifier) @name) @definition.function

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -40,18 +40,14 @@ var Language = &engine.Language{
   [(function_item) (impl_item) (trait_item) (mod_item)] @test
   (#eq? @attr "cfg") (#eq? @combinator "all") (#eq? @flag "test"))
 `,
-	// The function pattern of tree-sitter-rust's queries/tags.scm, plus
-	// the same node inside an impl or trait body, where the implemented
-	// type or the trait becomes the receiver, as in Type::method. The engine merges the two
-	// matches of one function node and keeps the receiver.
-	Definitions: `
-(function_item name: (identifier) @name) @definition.function
-
-(impl_item type: (_) @receiver
-  body: (declaration_list (function_item name: (identifier) @name) @definition.method))
-
-(trait_item name: (type_identifier) @receiver
-  body: (declaration_list (function_item name: (identifier) @name) @definition.method))
+	// The function pattern of tree-sitter-rust's queries/tags.scm. Impl
+	// and trait bodies are scopes, so their functions read Type::method,
+	// and so are modules.
+	Definitions: `(function_item name: (identifier) @name) @definition.function`,
+	Scopes: `
+(impl_item type: (_) @receiver body: (declaration_list) @scope)
+(trait_item name: (type_identifier) @receiver body: (declaration_list) @scope)
+(mod_item name: (identifier) @receiver body: (declaration_list) @scope)
 `,
 	// A match is exhaustive, so its last arm is the path the other arms
 	// branch away from and only arms followed by another arm count; an

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -38,12 +38,12 @@ fn with_closure() { let f = |x| x; f(1); }
 
 	want := map[string]string{
 		"free":          "function",
-		"S::method":     "method",
-		"G<T>::generic": "method",
-		"S::fmt":        "method",
-		"Tr::provided":  "method",
-		"inner":         "function",
-		"nested":        "function",
+		"S::method":     "function",
+		"G<T>::generic": "function",
+		"S::fmt":        "function",
+		"Tr::provided":  "function",
+		"m::inner":      "function",
+		"m::nested":     "function",
 		"with_closure":  "function",
 	}
 	if len(functions) != len(want) {
@@ -153,9 +153,9 @@ fn real() {}
 fn maybe() {}
 `)
 	for name, want := range map[string]bool{
-		"production": false, "unit": true, "helper": true, "in_module": true, "gated": false,
-		"test_then_cfg": true, "cfg_then_test": true, "helper2": true,
-		"test_helper": true, "S::fixture": true, "TestOnly::provided": true, "helper3": true,
+		"production": false, "unit": true, "tests::helper": true, "tests::in_module": true, "feature::gated": false,
+		"test_then_cfg": true, "cfg_then_test": true, "more_tests::helper2": true,
+		"test_helper": true, "S::fixture": true, "TestOnly::provided": true, "unix_tests::helper3": true,
 		"real": false, "maybe": false,
 	} {
 		if got := functions[name].IsTest; got != want {

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -9,12 +9,15 @@ import (
 
 func analyze(t *testing.T, source string) map[string]engine.Function {
 	t.Helper()
-	functions, err := Language.Analyze([]byte(source))
+	result, err := Language.Analyze([]byte(source))
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
+	if result.SyntaxError != nil {
+		t.Fatalf("syntax error: %v", result.SyntaxError)
+	}
 	byName := map[string]engine.Function{}
-	for _, fn := range functions {
+	for _, fn := range result.Functions {
 		byName[fn.Name] = fn
 	}
 	return byName
@@ -34,14 +37,14 @@ fn with_closure() { let f = |x| x; f(1); }
 `)
 
 	want := map[string]string{
-		"free":         "function",
-		"S.method":     "method",
-		"G<T>.generic": "method",
-		"S.fmt":        "method",
-		"Tr.provided":  "method",
-		"inner":        "function",
-		"nested":       "function",
-		"with_closure": "function",
+		"free":          "function",
+		"S::method":     "method",
+		"G<T>::generic": "method",
+		"S::fmt":        "method",
+		"Tr::provided":  "method",
+		"inner":         "function",
+		"nested":        "function",
+		"with_closure":  "function",
 	}
 	if len(functions) != len(want) {
 		t.Fatalf("got %d functions, want %d: %v", len(functions), len(want), functions)
@@ -152,7 +155,7 @@ fn maybe() {}
 	for name, want := range map[string]bool{
 		"production": false, "unit": true, "helper": true, "in_module": true, "gated": false,
 		"test_then_cfg": true, "cfg_then_test": true, "helper2": true,
-		"test_helper": true, "S.fixture": true, "TestOnly.provided": true, "helper3": true,
+		"test_helper": true, "S::fixture": true, "TestOnly::provided": true, "helper3": true,
 		"real": false, "maybe": false,
 	} {
 		if got := functions[name].IsTest; got != want {
@@ -172,9 +175,12 @@ func TestContentDropsComments(t *testing.T) {
 }
 
 func TestSyntaxErrorIsReported(t *testing.T) {
-	_, err := Language.Analyze([]byte("fn f() {\n\tif {\n"))
-	if err == nil || !strings.Contains(err.Error(), "syntax error") {
-		t.Fatalf("err = %v, want a syntax error", err)
+	result, err := Language.Analyze([]byte("fn f() {\n\tif {\n"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.SyntaxError == nil || !strings.Contains(result.SyntaxError.Error(), "syntax error") {
+		t.Fatalf("syntax error = %v, want one", result.SyntaxError)
 	}
 }
 

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -62,6 +62,9 @@ func writeText(w io.Writer, doc *Document) {
 	fmt.Fprintf(w, "Generated: %s\n", doc.GeneratedAt.Format(time.RFC3339))
 	fmt.Fprintf(w, "Version: %s\n", doc.Version)
 	fmt.Fprintf(w, "Files analyzed: %d\n", doc.Files.Analyzed)
+	if doc.Files.Partial > 0 {
+		fmt.Fprintf(w, "Files with syntax errors: %d\n", doc.Files.Partial)
+	}
 	if doc.Files.Skipped > 0 {
 		fmt.Fprintf(w, "Files skipped: %d\n", doc.Files.Skipped)
 	}
@@ -73,6 +76,12 @@ func writeText(w io.Writer, doc *Document) {
 		writeCloneText(w, doc.Clones)
 	}
 
+	if len(doc.Warnings) > 0 {
+		fmt.Fprintf(w, "\nWarnings:\n")
+		for _, warning := range doc.Warnings {
+			fmt.Fprintf(w, "  - %s\n", warning)
+		}
+	}
 	if len(doc.Errors) > 0 {
 		fmt.Fprintf(w, "\nErrors:\n")
 		for _, e := range doc.Errors {

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -19,7 +19,7 @@ func document(minComplexity int) *Document {
 		Version:     "test",
 		GeneratedAt: time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC),
 		Report: &analysis.Report{
-			Files: analysis.Files{Total: 3, Analyzed: 2, Skipped: 1},
+			Files: analysis.Files{Total: 4, Analyzed: 3, Partial: 1, Skipped: 1},
 			Complexity: &analysis.Complexity{
 				Functions: []analysis.Function{
 					{Name: "Big", FilePath: "a.go", StartLine: 1, EndLine: 40, Complexity: 25, Decisions: map[string]int{"branch": 24}, RiskLevel: domain.RiskLevelHigh},
@@ -32,7 +32,8 @@ func document(minComplexity int) *Document {
 				Groups:     []clone.Group{{ID: 0, Type: domain.Type1Clone, Similarity: 1, Fragments: []clone.Fragment{a, b}}},
 				Statistics: clone.Statistics{TotalFragments: 2, TotalClones: 2, TotalClonePairs: 1, TotalCloneGroups: 1, ClonesByType: map[string]int{"Type-1": 1}, AverageSimilarity: 1},
 			},
-			Errors: []string{"d.go: syntax error at line 9"},
+			Warnings: []string{"e.go: syntax error at line 2; functions containing it were not analyzed"},
+			Errors:   []string{"d.go: open d.go: permission denied"},
 		},
 		MinComplexity: minComplexity,
 	}
@@ -45,7 +46,8 @@ func TestWriteText(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Generated: 2026-01-02T03:04:05Z",
-		"Files analyzed: 2\nFiles skipped: 1\n",
+		"Files analyzed: 3\nFiles with syntax errors: 1\nFiles skipped: 1\n",
+		"Warnings:\n  - e.go: syntax error at line 2; functions containing it were not analyzed\n",
 		"=== Complexity Analysis ===",
 		"High risk: 1",
 		"Functions:\n  Big: 25 [HIGH]\n    File: a.go:1-40\n  Small: 1\n    File: b.go:3-5\n",
@@ -54,7 +56,7 @@ func TestWriteText(t *testing.T) {
 		"Clone Types:\n  Type-1: 1\n",
 		"Group 1: Type-1, 2 fragments, 100.0% similar\n    Big (a.go:1-40)\n    Copy (c.go:10-49)\n",
 		"Top Clone Pairs:\n  Type-1: Big (a.go:1-40) <-> Copy (c.go:10-49) (100.0% similar)\n",
-		"Errors:\n  - d.go: syntax error at line 9\n",
+		"Errors:\n  - d.go: open d.go: permission denied\n",
 	} {
 		if !strings.Contains(buf.String(), want) {
 			t.Errorf("text output lacks %q:\n%s", want, buf.String())
@@ -121,13 +123,15 @@ func TestWriteHTML(t *testing.T) {
 	out := buf.String()
 	for _, want := range []string{
 		"<title>polyscan report</title>",
-		"2 of 3 files analyzed, 1 skipped",
+		"3 of 4 files analyzed, 1 skipped",
+		"1 with syntax errors",
+		"e.go: syntax error at line 2",
 		`<td class="mono">Big</td>`,
 		"complexity 10 and above",
 		"Type-1 Exact · 1 pairs",
 		"Group 1",
 		"if a &lt; b {", // the preview is escaped
-		"d.go: syntax error at line 9",
+		"d.go: open d.go: permission denied",
 		"CC 20&#43;: 1 functions", // html/template escapes the plus
 	} {
 		if !strings.Contains(out, want) {

--- a/polyscan/internal/report/templates/report.css
+++ b/polyscan/internal/report/templates/report.css
@@ -91,6 +91,7 @@ main { max-width: 1200px; margin: 0 auto; padding: 24px 24px 40px; }
 .note { margin: 12px 0 0; }
 .ok-msg { color: var(--good); font-weight: 600; margin: 8px 0 0; }
 .callout { margin-top: 14px; padding: 12px 14px; border-radius: 8px; font-size: 13px; background: var(--bad-soft); color: var(--ink); }
+.callout.warn { background: var(--warn-soft); }
 .callout ul { margin: 6px 0 0; padding-left: 20px; }
 
 /* ---------- tables ---------- */

--- a/polyscan/internal/report/templates/report.html
+++ b/polyscan/internal/report/templates/report.html
@@ -13,7 +13,7 @@
     <div class="brand">polyscan{{if .Version}} <span class="ver">{{.Version}}</span>{{end}}</div>
     <div class="meta">
       <span>{{.GeneratedAt.Format "2006-01-02 15:04"}}</span>
-      <span>{{if .Files.Skipped}}<span class="bad">{{.Files.Analyzed}} of {{.Files.Total}} files analyzed, {{.Files.Skipped}} skipped</span>{{else}}{{.Files.Total}} files{{end}} in {{.DurationMs}}ms</span>
+      <span>{{if .Files.Skipped}}<span class="bad">{{.Files.Analyzed}} of {{.Files.Total}} files analyzed, {{.Files.Skipped}} skipped</span>{{else}}{{.Files.Total}} files{{end}}{{if .Files.Partial}}, <span class="warn">{{.Files.Partial}} with syntax errors</span>{{end}} in {{.DurationMs}}ms</span>
     </div>
   </div>
 </header>
@@ -141,6 +141,10 @@
 {{else}}
 <div class="card"><p class="ok-msg">No code clones detected</p></div>
 {{end}}
+{{end}}
+
+{{if .Warnings}}
+<div class="callout warn"><b>{{len .Warnings}} {{if eq (len .Warnings) 1}}file has{{else}}files have{{end}} syntax errors; the functions containing them were not analyzed</b><ul>{{range .Warnings}}<li class="mono">{{.}}</li>{{end}}</ul></div>
 {{end}}
 
 {{if .Errors}}

--- a/polyscan/npm/README.md
+++ b/polyscan/npm/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-Multi-language code quality analyzer. It measures cyclomatic complexity and detects code clones for Go and Rust.
+Multi-language code quality analyzer. It measures cyclomatic complexity and detects code clones for Go, Rust and C++.
 
 ## Installation
 

--- a/polyscan/npm/package.json
+++ b/polyscan/npm/package.json
@@ -6,6 +6,8 @@
     "go",
     "golang",
     "rust",
+    "cpp",
+    "c++",
     "code-quality",
     "static-analysis",
     "analyzer",

--- a/polyscan/testdata/cpp/sample.cpp
+++ b/polyscan/testdata/cpp/sample.cpp
@@ -1,0 +1,64 @@
+#include <cstdio>
+#include <utility>
+
+// Adds the positive values and reports how many there were.
+std::pair<int, int> sumPositive(const int* values, int n) {
+  int total = 0;
+  int count = 0;
+  for (int i = 0; i < n; i++) {
+    if (values[i] > 0) {
+      total += values[i];
+      count++;
+    }
+  }
+  std::printf("%d positive values\n", count);
+  return {total, count};
+}
+
+// sumPositive with the names and the comparison changed.
+std::pair<int, int> sumNegative(const int* numbers, int n) {
+  int sum = 0;
+  int seen = 0;
+  for (int i = 0; i < n; i++) {
+    if (numbers[i] < 0) {
+      sum += numbers[i];
+      seen++;
+    }
+  }
+  std::printf("%d negative values\n", seen);
+  return {sum, seen};
+}
+
+class Server {
+ public:
+  // Two loops, two switch cases, an if, its &&, a ternary and a catch are
+  // eight decision points, so the complexity is 9.
+  int handle(const int* items, int n, int mode) const {
+    int acc = 0;
+    for (int i = 0; i < 10; i++) {
+      acc += i;
+    }
+    while (acc > 100) {
+      acc--;
+    }
+    switch (mode) {
+      case 1:
+        acc += 10;
+        break;
+      case 2:
+        acc += 20;
+        break;
+      default:
+        break;
+    }
+    if (acc > 5 && n > 0) {
+      acc += items[0];
+    }
+    try {
+      acc += n > 0 ? n : -n;
+    } catch (...) {
+      acc = 0;
+    }
+    return acc;
+  }
+};

--- a/polyscan/testdata/cpp/sample_test.cpp
+++ b/polyscan/testdata/cpp/sample_test.cpp
@@ -1,0 +1,16 @@
+#include <cstdio>
+#include <utility>
+
+// Another copy of sumPositive, which the test file name excludes from clones.
+std::pair<int, int> sumPositiveAgain(const int* values, int n) {
+  int total = 0;
+  int count = 0;
+  for (int i = 0; i < n; i++) {
+    if (values[i] > 0) {
+      total += values[i];
+      count++;
+    }
+  }
+  std::printf("%d positive values\n", count);
+  return {total, count};
+}


### PR DESCRIPTION
Part of #69, closes #73.

- C++ defined declaratively: function definitions including pointer and reference return types (from tree-sitter-cpp's `tags.scm`), a new `Scopes` query that qualifies members with class and namespace names so `Foo::bar` reads the same whether defined inside or outside the class, decisions (`if`, `?:`, loops, `case` without `default`, `catch` as `core/cfg`'s exception edge, `&&`/`||`), a clone spec, and the test file conventions of GoogleTest, Catch2 and doctest
- Headers, `.h` included, are analyzed as C++ by default; no language detection dependency
- **Behavior change for every language**: a file with a syntax error is analyzed without the functions that contain the error and reported as partial with a warning, instead of being skipped. Without the preprocessor, a macro that opens a namespace or declares an attribute is a syntax error, and C++ libraries do that in most files: fmt 39 of 73, googletest 68 of 157, nlohmann/json 154 of 497. Under the old rule fmt yielded 193 functions; now 4,244
- Rust methods now read `Type::method` (per-language scope separator)
- Limitations documented: no preprocessing, both `#if` branches analyzed, templates best effort

Sample: fmt 4,244 functions / 152 fragments → 3 pairs; googletest 6,453 functions / 329 fragments → 31 pairs (`AssertPredNHelper` family, `DescribeTo`/`DescribeNegationTo`); nlohmann/json 3,874 functions / 568 fragments → 890 pairs, mostly the amalgamated `single_include` header against `include/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)