### PR TITLE
fix(npm): drop the ./ prefix from the bin paths

### DIFF
--- a/jscan/npm/package.json
+++ b/jscan/npm/package.json
@@ -28,7 +28,7 @@
     "package.json"
   ],
   "bin": {
-    "jscan": "./bin/jscan"
+    "jscan": "bin/jscan"
   },
   "engines": {
     "node": ">=14"

--- a/polyscan/npm/package.json
+++ b/polyscan/npm/package.json
@@ -29,7 +29,7 @@
     "package.json"
   ],
   "bin": {
-    "polyscan": "./bin/polyscan"
+    "polyscan": "bin/polyscan"
   },
   "engines": {
     "node": ">=14"


### PR DESCRIPTION
npm 11.17.0 (released 2026-08-26) warns `"bin[jscan]" script name bin/jscan was invalid and removed` on `npm publish` for the `./bin/x` form and drops the entry from the manifest it sends, which would leave `npx jscan` and `npx polyscan` without a command once a runner picks that npm up. `bin/x` publishes without the warning; the packed tarball is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)