### PR TITLE
chore: attempt every npm package in a release and add the polyscan badge

### DIFF
--- a/.github/workflows/jscan-release.yml
+++ b/.github/workflows/jscan-release.yml
@@ -157,11 +157,15 @@ jobs:
           (cd npm && npm version "$VERSION" --no-git-tag-version)
           node -e "const fs=require('fs');const p=require('./npm/package.json');for(const d of Object.keys(p.optionalDependencies))p.optionalDependencies[d]='$VERSION';fs.writeFileSync('npm/package.json',JSON.stringify(p,null,2)+'\n')"
 
+      # Every package is attempted so that one misconfigured trusted
+      # publisher reports on its own, instead of hiding the ones after it.
       - name: Publish platform packages
         run: |
+          failed=0
           for dir in npm/platforms/*/; do
-            (cd "$dir" && npm publish --access public --provenance)
+            (cd "$dir" && npm publish --access public --provenance) || failed=1
           done
+          exit $failed
 
       - name: Publish main package
         run: |

--- a/.github/workflows/polyscan-release.yml
+++ b/.github/workflows/polyscan-release.yml
@@ -157,11 +157,15 @@ jobs:
           (cd npm && npm version "$VERSION" --no-git-tag-version)
           node -e "const fs=require('fs');const p=require('./npm/package.json');for(const d of Object.keys(p.optionalDependencies))p.optionalDependencies[d]='$VERSION';fs.writeFileSync('npm/package.json',JSON.stringify(p,null,2)+'\n')"
 
+      # Every package is attempted so that one misconfigured trusted
+      # publisher reports on its own, instead of hiding the ones after it.
       - name: Publish platform packages
         run: |
+          failed=0
           for dir in npm/platforms/*/; do
-            (cd "$dir" && npm publish --access public --provenance)
+            (cd "$dir" && npm publish --access public --provenance) || failed=1
           done
+          exit $failed
 
       - name: Publish main package
         run: |

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Building with Cursor, Claude, or ChatGPT? polyscan performs structural analysis 
 
 [![CI](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml/badge.svg)](https://github.com/ludo-technologies/polyscan/actions/workflows/ci.yml)
 [![npm](https://img.shields.io/npm/v/jscan?style=flat-square&logo=npm&label=jscan)](https://www.npmjs.com/package/jscan)
+[![npm](https://img.shields.io/npm/v/polyscan?style=flat-square&logo=npm&label=polyscan)](https://www.npmjs.com/package/polyscan)
 [![PyPI](https://img.shields.io/pypi/v/pyscn?style=flat-square&logo=pypi&label=pyscn)](https://pypi.org/project/pyscn/)
 [![License](https://img.shields.io/github/license/ludo-technologies/polyscan?style=flat-square)](LICENSE)
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.1.0] - 2026-08-28
+## [0.1.0] - 2026-08-29
 
 The first release of the multi-language analyzer. One `polyscan` binary detects the language of each file by its extension and runs the same analyses on Go, Rust and C++.
 


### PR DESCRIPTION
Follow-ups from the polyscan 0.1.0 release: the publish loop in both release workflows now attempts every package and fails at the end, the 0.1.0 changelog entry carries the actual release date, and the root README gets the polyscan npm badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)