### PR TITLE
fix(analyze): charge parse errors to the health score whichever analyses ran

### DIFF
--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -95,22 +95,20 @@ Examples:
 			if generic == nil && javascript == nil {
 				return analysis.ErrNoFiles
 			}
-			responses, err := report.Combine(generic, javascript)
+			results, err := report.Combine(generic, javascript)
 			if err != nil {
 				return err
 			}
-			filterFunctions(responses.Complexity, minComplexity)
+			filterFunctions(results.Complexity, minComplexity)
 			duration := time.Since(start)
 
 			formatter := service.NewOutputFormatter()
 			write := func(w io.Writer, format jsdomain.OutputFormat) error {
-				return formatter.WriteAnalyze(responses.Complexity, responses.DeadCode,
-					responses.Clone, responses.CBO, responses.Deps, format, w, duration)
+				return formatter.WriteAnalyze(results, format, w, duration)
 			}
 			summarize := func(w io.Writer) {
-				summary := service.BuildAnalyzeSummary(responses.Complexity, responses.DeadCode,
-					responses.Clone, responses.CBO, responses.Deps)
-				fmt.Fprint(w, service.FormatCLISummary(summary, duration, unanalyzedFiles(responses.Complexity)))
+				summary := service.BuildAnalyzeSummary(results)
+				fmt.Fprint(w, service.FormatCLISummary(summary, duration, results.Files.Errors))
 			}
 
 			switch outputFormat {
@@ -221,17 +219,6 @@ func filterFunctions(complexity *jsdomain.ComplexityResponse, minComplexity int)
 		}
 	}
 	complexity.Functions = listed
-}
-
-// unanalyzedFiles returns the per-file failures the complexity analysis
-// collected: it is the only analysis that reports the files it dropped, and
-// it runs over the same file set as the others, so its list identifies what
-// every score is missing.
-func unanalyzedFiles(complexity *jsdomain.ComplexityResponse) []string {
-	if complexity == nil {
-		return nil
-	}
-	return complexity.Errors
 }
 
 // fileURL turns an absolute path into a file URL, escaping characters such

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -47,6 +47,8 @@ type analyzeJSON struct {
 	Summary *struct {
 		HealthScore       int    `json:"health_score"`
 		Grade             string `json:"grade"`
+		TotalFiles        int    `json:"total_files"`
+		SkippedFiles      int    `json:"skipped_files"`
 		ComplexityEnabled bool   `json:"complexity_enabled"`
 		DeadCodeEnabled   bool   `json:"dead_code_enabled"`
 		CloneEnabled      bool   `json:"clone_enabled"`
@@ -263,6 +265,38 @@ func TestFileURL(t *testing.T) {
 	} {
 		if got := fileURL(path); got != want {
 			t.Errorf("fileURL(%q) = %q, want %q", path, got, want)
+		}
+	}
+}
+
+// TestAnalyzeChargesParseErrorsWithoutComplexity covers #92: a run that
+// leaves complexity out still reports and charges the files it could not
+// parse.
+func TestAnalyzeChargesParseErrorsWithoutComplexity(t *testing.T) {
+	dir := t.TempDir()
+	for name, content := range map[string]string{
+		"ok.js":     "export function ok(a) { return a; }\n",
+		"broken.js": "function broken( {\n",
+	} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := run(t, "analyze", "--format", "json", "--select", "deadcode", dir)
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.Summary == nil || doc.Summary.TotalFiles != 2 || doc.Summary.SkippedFiles != 1 {
+		t.Fatalf("summary = %+v, want 2 files with 1 skipped", doc.Summary)
+	}
+	if doc.Summary.HealthScore >= 100 {
+		t.Errorf("health score = %d, want the parse-error penalty applied", doc.Summary.HealthScore)
+	}
+	for _, want := range []string{"1 of 2 files skipped (parse errors)", "broken.js: syntax error"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output lacks %q:\n%s", want, out)
 		}
 	}
 }

--- a/polyscan/internal/js/domain/analyze.go
+++ b/polyscan/internal/js/domain/analyze.go
@@ -108,6 +108,40 @@ type AnalyzeResponse struct {
 	Version     string    `json:"version" yaml:"version"`
 }
 
+// FileAccounting counts the files a run covered, kept apart from any one
+// analysis: every analysis silently excludes the files it cannot parse, so the
+// health score charges them separately whichever dimensions ran.
+type FileAccounting struct {
+	// Total is the number of files the run covered.
+	Total int
+	// Skipped is the number of files no analysis could use because they could
+	// not be read or parsed.
+	Skipped int
+	// Errors says, per skipped file, why it was skipped.
+	Errors []string
+}
+
+// Add folds another run's accounting into this one, as when the generic
+// engine and the JavaScript pipeline each cover part of a tree.
+func (a *FileAccounting) Add(other FileAccounting) {
+	a.Total += other.Total
+	a.Skipped += other.Skipped
+	a.Errors = append(a.Errors, other.Errors...)
+}
+
+// AnalysisResults is one run's output: the file set it covered and the
+// response of each analysis that ran. An analysis that did not run, or found
+// nothing to analyze, leaves its response nil, and the health score leaves
+// that dimension out instead of scoring it as clean.
+type AnalysisResults struct {
+	Files      FileAccounting
+	Complexity *ComplexityResponse
+	DeadCode   *DeadCodeResponse
+	Clone      *CloneResponse
+	CBO        *CBOResponse
+	Deps       *DependencyGraphResponse
+}
+
 // AnalyzeSummary provides an overall summary of all analyses
 type AnalyzeSummary struct {
 	// File statistics

--- a/polyscan/internal/js/domain/analyze.go
+++ b/polyscan/internal/js/domain/analyze.go
@@ -175,6 +175,11 @@ type AnalyzeSummary struct {
 	HighComplexityCount   int     `json:"high_complexity_count" yaml:"high_complexity_count"`
 	MediumComplexityCount int     `json:"medium_complexity_count" yaml:"medium_complexity_count"`
 
+	// DeadCodeFiles is the number of files the dead code analysis covered. It
+	// is the divisor of the dead code penalty rather than TotalFiles, which
+	// counts every language in the run while dead code detection covers
+	// JavaScript/TypeScript only.
+	DeadCodeFiles    int `json:"dead_code_files" yaml:"dead_code_files"`
 	DeadCodeCount    int `json:"dead_code_count" yaml:"dead_code_count"`
 	CriticalDeadCode int `json:"critical_dead_code" yaml:"critical_dead_code"`
 	WarningDeadCode  int `json:"warning_dead_code" yaml:"warning_dead_code"`
@@ -293,7 +298,7 @@ func (s *AnalyzeSummary) calculateComplexityPenalty() int {
 // calculateDeadCodePenalty calculates the penalty for dead code (max 20)
 // Uses per-file rate of weighted findings so that large repos are not unfairly penalized.
 // Weights: Critical=1.0, Warning=0.5, Info=0.2
-// The rate (weightedFindings / totalFiles) is mapped linearly to 0–20,
+// The rate (weightedFindings / DeadCodeFiles) is mapped linearly to 0–20,
 // reaching the maximum penalty at a rate of 3.0 findings per file.
 func (s *AnalyzeSummary) calculateDeadCodePenalty() int {
 	weightedDeadCode := float64(s.CriticalDeadCode)*1.0 +
@@ -304,7 +309,7 @@ func (s *AnalyzeSummary) calculateDeadCodePenalty() int {
 		return 0
 	}
 
-	files := s.TotalFiles
+	files := s.DeadCodeFiles
 	if files < 1 {
 		files = 1
 	}

--- a/polyscan/internal/js/js.go
+++ b/polyscan/internal/js/js.go
@@ -46,8 +46,11 @@ func (s Selection) count() int {
 
 // Result holds each analysis response next to its error. An analysis that
 // was not selected leaves both nil; one that failed leaves the response nil
-// and the error set, and the others still stand.
+// and the error set, and the others still stand. Files is the run's own
+// accounting of the files it covered and could not use, kept apart from the
+// analyses so it is complete whichever of them ran.
 type Result struct {
+	Files         domain.FileAccounting
 	Complexity    *domain.ComplexityResponse
 	ComplexityErr error
 	DeadCode      *domain.DeadCodeResponse
@@ -120,13 +123,16 @@ func CollectFiles(paths []string, cfg *config.Config) ([]string, error) {
 // goroutines below finish, so the shared trees become collectable as soon as
 // the analyses are done with them — clone detection drops its per-fragment
 // AST references itself once fragments are converted for APTED. A single
-// selected analysis has nobody to share with and skips the snapshot: the
-// services' own entry points then release each file as they go, which holds
-// far fewer parse trees at once.
+// selected analysis has nobody to share with and gets a snapshot that loads
+// each file inside its fan-out and releases it right after, which holds far
+// fewer parse trees at once. Dependency analysis is the exception: graph
+// construction needs every module's tree at once.
 func Run(ctx context.Context, files []string, cfg *config.Config, selected Selection) *Result {
 	var snapshot *service.ProjectSnapshot
-	if selected.count() > 1 {
+	if selected.count() > 1 || selected.Deps {
 		snapshot = service.BuildProjectSnapshot(ctx, files)
+	} else {
+		snapshot = service.NewProjectSnapshot(files)
 	}
 
 	result := &Result{}
@@ -189,11 +195,11 @@ func Run(ctx context.Context, files []string, cfg *config.Config, selected Selec
 	}
 
 	wg.Wait()
+	result.Files = snapshot.Accounting()
 	return result
 }
 
-// runComplexity runs complexity analysis without progress tracking, over the
-// shared snapshot when one exists.
+// runComplexity runs complexity analysis over the snapshot.
 func runComplexity(ctx context.Context, snapshot *service.ProjectSnapshot, files []string, cfg *config.Config) (*domain.ComplexityResponse, error) {
 	svc := service.NewComplexityService(&cfg.Complexity)
 
@@ -205,19 +211,12 @@ func runComplexity(ctx context.Context, snapshot *service.ProjectSnapshot, files
 		SortBy:          domain.SortCriteria(cfg.Output.SortBy),
 	}
 
-	if snapshot != nil {
-		return svc.AnalyzeSnapshot(ctx, snapshot, req)
-	}
-	return svc.Analyze(ctx, req)
+	return svc.AnalyzeSnapshot(ctx, snapshot, req)
 }
 
-// runDeadCode runs dead code analysis without progress tracking, over the
-// shared snapshot when one exists.
+// runDeadCode runs dead code analysis over the snapshot.
 func runDeadCode(ctx context.Context, snapshot *service.ProjectSnapshot, files []string, cfg *config.Config) (*domain.DeadCodeResponse, error) {
-	if snapshot != nil {
-		return service.AnalyzeDeadCodeSnapshot(ctx, snapshot, DeadCodeRequest(files, cfg))
-	}
-	return service.AnalyzeDeadCode(ctx, DeadCodeRequest(files, cfg))
+	return service.AnalyzeDeadCodeSnapshot(ctx, snapshot, DeadCodeRequest(files, cfg))
 }
 
 // DeadCodeRequest builds the dead code request.
@@ -229,22 +228,17 @@ func DeadCodeRequest(files []string, cfg *config.Config) domain.DeadCodeRequest 
 	}
 }
 
-// runClones runs clone detection without progress tracking, over the shared
-// snapshot when one exists.
+// runClones runs clone detection over the snapshot.
 func runClones(ctx context.Context, snapshot *service.ProjectSnapshot, files []string) (*domain.CloneResponse, error) {
 	svc := service.NewCloneServiceWithDefaults()
 
 	req := domain.DefaultCloneRequest()
 	req.Paths = files
 
-	if snapshot != nil {
-		return svc.DetectClonesInSnapshot(ctx, snapshot, req)
-	}
-	return svc.DetectClones(ctx, req)
+	return svc.DetectClonesInSnapshot(ctx, snapshot, req)
 }
 
-// runCBO runs CBO analysis without progress tracking, over the shared
-// snapshot when one exists.
+// runCBO runs CBO analysis over the snapshot.
 func runCBO(ctx context.Context, snapshot *service.ProjectSnapshot, files []string) (*domain.CBOResponse, error) {
 	svc := service.NewCBOServiceWithDefaults()
 
@@ -252,14 +246,10 @@ func runCBO(ctx context.Context, snapshot *service.ProjectSnapshot, files []stri
 		Paths: files,
 	}
 
-	if snapshot != nil {
-		return svc.AnalyzeSnapshot(ctx, snapshot, req)
-	}
-	return svc.Analyze(ctx, req)
+	return svc.AnalyzeSnapshot(ctx, snapshot, req)
 }
 
-// runDeps runs dependency analysis without progress tracking, over the
-// shared snapshot when one exists.
+// runDeps runs dependency analysis over the snapshot.
 func runDeps(ctx context.Context, snapshot *service.ProjectSnapshot, files []string) (*domain.DependencyGraphResponse, error) {
 	svc := service.NewDependencyGraphServiceWithDefaults()
 
@@ -268,8 +258,5 @@ func runDeps(ctx context.Context, snapshot *service.ProjectSnapshot, files []str
 		DetectCycles: domain.BoolPtr(true),
 	}
 
-	if snapshot != nil {
-		return svc.AnalyzeSnapshot(ctx, snapshot, req)
-	}
-	return svc.Analyze(ctx, req)
+	return svc.AnalyzeSnapshot(ctx, snapshot, req)
 }

--- a/polyscan/internal/js/run_test.go
+++ b/polyscan/internal/js/run_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 	"testing"
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/config"
@@ -140,5 +141,36 @@ func TestRunComplexityAnalysisInternal_MinComplexityFromConfig(t *testing.T) {
 	if filtered.Summary.FunctionsParsed != len(baseline.Functions) {
 		t.Errorf("FunctionsParsed should stay at the analyzed population %d, got %d",
 			len(baseline.Functions), filtered.Summary.FunctionsParsed)
+	}
+}
+
+// TestRun_AccountsForSkippedFilesWhicheverAnalysesRan covers #92: the run's
+// file accounting is independent of the complexity analysis, so a single
+// non-complexity analysis and a shared-snapshot run report the same skipped
+// file.
+func TestRun_AccountsForSkippedFilesWhicheverAnalysesRan(t *testing.T) {
+	dir := t.TempDir()
+	valid := filepath.Join(dir, "ok.js")
+	broken := filepath.Join(dir, "broken.js")
+	if err := os.WriteFile(valid, []byte(complexityFixture), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(broken, []byte("function broken( {"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	files := []string{valid, broken}
+
+	for name, selected := range map[string]Selection{
+		"deadcode only":       {DeadCode: true},
+		"deps only":           {Deps: true},
+		"deadcode and clones": {DeadCode: true, Clones: true},
+	} {
+		result := Run(context.Background(), files, config.DefaultConfig(), selected)
+		if result.Files.Total != 2 || result.Files.Skipped != 1 {
+			t.Errorf("%s: files = %+v, want 2 files with 1 skipped", name, result.Files)
+		}
+		if len(result.Files.Errors) != 1 || !strings.HasPrefix(result.Files.Errors[0], broken+": syntax error") {
+			t.Errorf("%s: errors = %v, want the broken file named", name, result.Files.Errors)
+		}
 	}
 }

--- a/polyscan/internal/js/service/cbo_service.go
+++ b/polyscan/internal/js/service/cbo_service.go
@@ -43,29 +43,22 @@ func NewCBOServiceWithDefaults() *CBOServiceImpl {
 // extracted — use AnalyzeSnapshot when several analyses should share the
 // parse trees.
 func (s *CBOServiceImpl) Analyze(ctx context.Context, req domain.CBORequest) (*domain.CBOResponse, error) {
-	config := s.effectiveConfig(req)
-	cboAnalyzer := analyzer.NewCBOAnalyzer(&config)
-
-	results := analyzeProjectFilesFromPaths(ctx, req.Paths,
-		func(file *ProjectFile) fileAnalysis[*domain.ClassCoupling] {
-			return s.analyzeProjectFile(cboAnalyzer, file)
-		})
-	return s.buildResponse(ctx, results, &config, req)
+	return s.AnalyzeSnapshot(ctx, NewProjectSnapshot(req.Paths), req)
 }
 
 // AnalyzeSnapshot performs CBO analysis on already parsed project files. The
 // snapshot defines the analyzed file set; req.Paths, when set, must name the
 // same files.
 func (s *CBOServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *ProjectSnapshot, req domain.CBORequest) (*domain.CBOResponse, error) {
-	if err := snapshot.validateRequestPaths(req.Paths); err != nil {
+	if err := snapshot.validateRequest(req.Paths); err != nil {
 		return nil, err
 	}
 
 	config := s.effectiveConfig(req)
 	cboAnalyzer := analyzer.NewCBOAnalyzer(&config)
 
-	results := analyzeFilesConcurrently(ctx, snapshot.Files,
-		func(_ context.Context, file *ProjectFile) fileAnalysis[*domain.ClassCoupling] {
+	results := analyzeSnapshotFiles(ctx, snapshot,
+		func(file *ProjectFile) fileAnalysis[*domain.ClassCoupling] {
 			return s.analyzeProjectFile(cboAnalyzer, file)
 		})
 	return s.buildResponse(ctx, results, &config, req)

--- a/polyscan/internal/js/service/clone_service.go
+++ b/polyscan/internal/js/service/clone_service.go
@@ -76,15 +76,7 @@ func extractFileFragments(detector *analyzer.CloneDetector, file *ProjectFile) f
 // proceeds — use DetectClonesInSnapshot when several analyses should share
 // the parse trees.
 func (s *CloneServiceImpl) DetectClones(ctx context.Context, req *domain.CloneRequest) (*domain.CloneResponse, error) {
-	startTime := time.Now()
-	config := s.effectiveConfig(req)
-	detector := analyzer.NewCloneDetector(&config)
-
-	results := analyzeProjectFilesFromPaths(ctx, req.Paths,
-		func(file *ProjectFile) fileAnalysis[*extractedFragments] {
-			return extractFileFragments(detector, file)
-		})
-	return s.detectFromExtraction(ctx, results, detector, &config, req, startTime)
+	return s.DetectClonesInSnapshot(ctx, NewProjectSnapshot(req.Paths), req)
 }
 
 // DetectClonesInSnapshot performs clone detection on already parsed project
@@ -94,7 +86,7 @@ func (s *CloneServiceImpl) DetectClones(ctx context.Context, req *domain.CloneRe
 // the trees' sole owner, so they stay collectable once every analysis sharing
 // the snapshot has finished.
 func (s *CloneServiceImpl) DetectClonesInSnapshot(ctx context.Context, snapshot *ProjectSnapshot, req *domain.CloneRequest) (*domain.CloneResponse, error) {
-	if err := snapshot.validateRequestPaths(req.Paths); err != nil {
+	if err := snapshot.validateRequest(req.Paths); err != nil {
 		return nil, err
 	}
 
@@ -102,8 +94,8 @@ func (s *CloneServiceImpl) DetectClonesInSnapshot(ctx context.Context, snapshot 
 	config := s.effectiveConfig(req)
 	detector := analyzer.NewCloneDetector(&config)
 
-	results := analyzeFilesConcurrently(ctx, snapshot.Files,
-		func(_ context.Context, file *ProjectFile) fileAnalysis[*extractedFragments] {
+	results := analyzeSnapshotFiles(ctx, snapshot,
+		func(file *ProjectFile) fileAnalysis[*extractedFragments] {
 			return extractFileFragments(detector, file)
 		})
 	return s.detectFromExtraction(ctx, results, detector, &config, req, startTime)

--- a/polyscan/internal/js/service/complexity_service.go
+++ b/polyscan/internal/js/service/complexity_service.go
@@ -30,22 +30,18 @@ func NewComplexityService(cfg *config.ComplexityConfig) *ComplexityServiceImpl {
 // are extracted, so peak memory holds only as many parse trees as there are
 // workers — use AnalyzeSnapshot when several analyses should share the trees.
 func (s *ComplexityServiceImpl) Analyze(ctx context.Context, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
-	results := analyzeProjectFilesFromPaths(ctx, req.Paths, s.analyzeProjectFile)
-	return s.buildResponse(ctx, results, req.Paths, req)
+	return s.AnalyzeSnapshot(ctx, NewProjectSnapshot(req.Paths), req)
 }
 
 // AnalyzeSnapshot performs complexity analysis on already parsed project files.
 // The snapshot defines the analyzed file set; req.Paths, when set, must name
 // the same files.
 func (s *ComplexityServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *ProjectSnapshot, req domain.ComplexityRequest) (*domain.ComplexityResponse, error) {
-	if err := snapshot.validateRequestPaths(req.Paths); err != nil {
+	if err := snapshot.validateRequest(req.Paths); err != nil {
 		return nil, err
 	}
 
-	results := analyzeFilesConcurrently(ctx, snapshot.Files,
-		func(_ context.Context, file *ProjectFile) fileAnalysis[fileComplexity] {
-			return s.analyzeProjectFile(file)
-		})
+	results := analyzeSnapshotFiles(ctx, snapshot, s.analyzeProjectFile)
 	return s.buildResponse(ctx, results, snapshot.Paths(), req)
 }
 

--- a/polyscan/internal/js/service/dead_code_aggregate.go
+++ b/polyscan/internal/js/service/dead_code_aggregate.go
@@ -92,12 +92,7 @@ func AnalyzeDeadCode(ctx context.Context, req domain.DeadCodeRequest) (*domain.D
 		ctx = context.Background()
 	}
 
-	moduleAnalyzer := analyzer.NewModuleAnalyzer(nil)
-	scanned := analyzeProjectFilesFromPaths(ctx, req.Paths,
-		func(file *ProjectFile) fileAnalysis[*scannedFile] {
-			return scanFileForDeadCode(moduleAnalyzer, file)
-		})
-	return aggregateDeadCodeScans(ctx, scanned, req.Paths, req)
+	return AnalyzeDeadCodeSnapshot(ctx, NewProjectSnapshot(req.Paths), req)
 }
 
 // AnalyzeDeadCodeSnapshot runs dead code analysis on already parsed project
@@ -107,13 +102,13 @@ func AnalyzeDeadCodeSnapshot(ctx context.Context, snapshot *ProjectSnapshot, req
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	if err := snapshot.validateRequestPaths(req.Paths); err != nil {
+	if err := snapshot.validateRequest(req.Paths); err != nil {
 		return nil, err
 	}
 
 	moduleAnalyzer := analyzer.NewModuleAnalyzer(nil)
-	scanned := analyzeFilesConcurrently(ctx, snapshot.Files,
-		func(_ context.Context, file *ProjectFile) fileAnalysis[*scannedFile] {
+	scanned := analyzeSnapshotFiles(ctx, snapshot,
+		func(file *ProjectFile) fileAnalysis[*scannedFile] {
 			return scanFileForDeadCode(moduleAnalyzer, file)
 		})
 	return aggregateDeadCodeScans(ctx, scanned, snapshot.Paths(), req)

--- a/polyscan/internal/js/service/dependency_graph_service.go
+++ b/polyscan/internal/js/service/dependency_graph_service.go
@@ -45,8 +45,11 @@ func (s *DependencyGraphServiceImpl) Analyze(ctx context.Context, req domain.Dep
 // files. The snapshot defines the analyzed file set; req.Paths, when set, must
 // name the same files.
 func (s *DependencyGraphServiceImpl) AnalyzeSnapshot(ctx context.Context, snapshot *ProjectSnapshot, req domain.DependencyGraphRequest) (*domain.DependencyGraphResponse, error) {
-	if err := snapshot.validateRequestPaths(req.Paths); err != nil {
+	if err := snapshot.validateRequest(req.Paths); err != nil {
 		return nil, err
+	}
+	if !snapshot.retain {
+		return nil, domain.NewInvalidInputError("dependency analysis needs a snapshot that keeps every parse tree", nil)
 	}
 
 	var warnings []string

--- a/polyscan/internal/js/service/doc.go
+++ b/polyscan/internal/js/service/doc.go
@@ -18,8 +18,10 @@
 //
 // Output is handled by OutputFormatterImpl for text, JSON, YAML, CSV, and HTML.
 //
-// BuildAnalyzeSummary combines the five responses into a domain.AnalyzeSummary
+// BuildAnalyzeSummary combines a run's results into a domain.AnalyzeSummary
 // and computes the health score. Because a nil response is treated as an
 // analysis that did not run, and a category that did not run contributes no
 // penalty, summaries built from different --select values are not comparable.
+// The file counts come from the run's ProjectSnapshot, not from any response,
+// so the parse-error penalty is charged whichever analyses ran.
 package service

--- a/polyscan/internal/js/service/html_formatter.go
+++ b/polyscan/internal/js/service/html_formatter.go
@@ -60,30 +60,24 @@ func analyzeTemplateFuncs() template.FuncMap {
 
 // WriteHTML writes the analysis result as a self-contained HTML report.
 func (f *OutputFormatterImpl) WriteHTML(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
-	if cloneResponse != nil {
-		if cloneResponse.Statistics == nil {
-			cloneResponse.Statistics = &domain.CloneStatistics{}
+	if results.Clone != nil {
+		if results.Clone.Statistics == nil {
+			results.Clone.Statistics = &domain.CloneStatistics{}
 		}
-		clonePairs := make([]*domain.ClonePair, 0, len(cloneResponse.ClonePairs))
-		for _, pair := range cloneResponse.ClonePairs {
+		clonePairs := make([]*domain.ClonePair, 0, len(results.Clone.ClonePairs))
+		for _, pair := range results.Clone.ClonePairs {
 			if pair != nil {
 				clonePairs = append(clonePairs, pair)
 			}
 		}
-		cloneResponse.ClonePairs = clonePairs
+		results.Clone.ClonePairs = clonePairs
 	}
 
-	view := buildAnalyzeReportView(
-		complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, duration,
-	)
+	view := buildAnalyzeReportView(results, duration)
 	if err := analyzeReportTemplate.Execute(writer, view); err != nil {
 		return fmt.Errorf("failed to render HTML report: %w", err)
 	}
@@ -252,17 +246,13 @@ func scoreBand(score int) string {
 }
 
 func buildAnalyzeReportView(
-	complexity *domain.ComplexityResponse,
-	deadCode *domain.DeadCodeResponse,
-	clone *domain.CloneResponse,
-	cbo *domain.CBOResponse,
-	deps *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	duration time.Duration,
 ) *analyzeReportView {
 	// Reuse the shared summary and rollup builders so the report can never
 	// disagree with the text, JSON, or CSV output about a score.
-	summary := BuildAnalyzeSummary(complexity, deadCode, clone, cbo, deps)
-	moduleQuality := BuildModuleQuality(complexity, deadCode, deps)
+	summary := BuildAnalyzeSummary(results)
+	moduleQuality := BuildModuleQuality(results.Complexity, results.DeadCode, results.Deps)
 
 	view := &analyzeReportView{
 		CSS:             analyzeReportCSS,
@@ -270,32 +260,32 @@ func buildAnalyzeReportView(
 		GeneratedAt:     time.Now(),
 		Duration:        duration.Milliseconds(),
 		Version:         version.Version,
-		Complexity:      complexity,
-		DeadCode:        deadCode,
-		Clone:           clone,
-		CBO:             cbo,
-		Deps:            deps,
+		Complexity:      results.Complexity,
+		DeadCode:        results.DeadCode,
+		Clone:           results.Clone,
+		CBO:             results.CBO,
+		Deps:            results.Deps,
 		ModuleQuality:   moduleQuality,
 		Summary:         summary,
 		ScoreBand:       scoreBand(summary.HealthScore),
 		RingOffset:      reportScoreRingCircumf * (1 - float64(clampScore(summary.HealthScore))/100),
 		ProjectScale:    FormatProjectScale(summary),
 		SkippedFiles:    summary.SkippedFiles,
-		ShowFunctions:   reportHasFunctions(summary, complexity, moduleQuality),
+		ShowFunctions:   reportHasFunctions(summary, results.Complexity, moduleQuality),
 		ShowDeadColumn:  summary.DeadCodeEnabled,
 		ShowCloneColumn: summary.CloneEnabled,
 	}
-	risk := readComplexityRisk(complexity)
-	view.ProjectName, view.ProjectPath = reportProject(moduleQuality, complexity)
-	view.Tabs = buildReportTabs(summary, complexity, moduleQuality, deps)
+	risk := readComplexityRisk(results.Complexity)
+	view.ProjectName, view.ProjectPath = reportProject(moduleQuality, results.Complexity)
+	view.Tabs = buildReportTabs(summary, results.Complexity, moduleQuality, results.Deps)
 	view.Dimensions = buildReportDimensions(summary, view.Tabs)
 	view.Verdict = buildReportVerdict(summary, view.Dimensions)
 	view.Facts = buildReportFacts(summary, moduleQuality)
-	view.Hotspots = buildReportHotspots(moduleQuality, clone, risk)
-	view.Histogram = buildReportHistogram(complexity, risk)
-	view.Duplication = buildReportDuplication(summary, clone)
-	view.Classes = buildReportClasses(summary, cbo)
-	view.Structure = buildReportStructure(deps)
+	view.Hotspots = buildReportHotspots(moduleQuality, results.Clone, risk)
+	view.Histogram = buildReportHistogram(results.Complexity, risk)
+	view.Duplication = buildReportDuplication(summary, results.Clone)
+	view.Classes = buildReportClasses(summary, results.CBO)
+	view.Structure = buildReportStructure(results.Deps)
 	return view
 }
 

--- a/polyscan/internal/js/service/html_formatter_test.go
+++ b/polyscan/internal/js/service/html_formatter_test.go
@@ -399,16 +399,14 @@ func TestCountClonesByFileCountsEachFragmentOnce(t *testing.T) {
 
 func TestWriteHTMLRendersTheOverviewFromAnalysisData(t *testing.T) {
 	complexity := reportComplexityResponse(9, 19, 1, 4, 12, 30)
-	complexity.Summary.TotalFiles = 4
-	complexity.Summary.FilesAnalyzed = 3
-	complexity.Summary.SkippedFiles = 1
 	complexity.ModuleRollups = map[string]domain.ModuleComplexityMetrics{
 		"src/a.ts": {LinesOfCode: 240, AnalyzedFunctionCount: 4, AverageComplexity: 11.75, MaxComplexity: 30, HighRiskFunctionCount: 1},
 	}
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteHTML(complexity, nil, nil, nil, nil, &buf, 1200*time.Millisecond); err != nil {
+	results := domain.AnalysisResults{Files: domain.FileAccounting{Total: 4, Skipped: 1}, Complexity: complexity}
+	if err := formatter.WriteHTML(results, &buf, 1200*time.Millisecond); err != nil {
 		t.Fatalf("WriteHTML failed: %v", err)
 	}
 
@@ -455,7 +453,7 @@ func TestWriteHTMLAnnouncesDeadCodeTruncation(t *testing.T) {
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteHTML(nil, deadCode, nil, nil, nil, &buf, time.Second); err != nil {
+	if err := formatter.WriteHTML(domain.AnalysisResults{DeadCode: deadCode}, &buf, time.Second); err != nil {
 		t.Fatalf("WriteHTML failed: %v", err)
 	}
 

--- a/polyscan/internal/js/service/module_quality_test.go
+++ b/polyscan/internal/js/service/module_quality_test.go
@@ -100,7 +100,7 @@ func TestWriteAnalyzeJSONReportsModuleQualityAndDirectories(t *testing.T) {
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteAnalyze(complexityResponse, deadCodeResponse, nil, nil, depsResponse, domain.OutputFormatJSON, &buf, time.Second); err != nil {
+	if err := formatter.WriteAnalyze(domain.AnalysisResults{Complexity: complexityResponse, DeadCode: deadCodeResponse, Deps: depsResponse}, domain.OutputFormatJSON, &buf, time.Second); err != nil {
 		t.Fatalf("WriteAnalyze failed: %v", err)
 	}
 
@@ -134,7 +134,7 @@ func TestWriteAnalyzeTextListsModuleHotspotsAndDirectories(t *testing.T) {
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteAnalyze(complexityResponse, deadCodeResponse, nil, nil, depsResponse, domain.OutputFormatText, &buf, time.Second); err != nil {
+	if err := formatter.WriteAnalyze(domain.AnalysisResults{Complexity: complexityResponse, DeadCode: deadCodeResponse, Deps: depsResponse}, domain.OutputFormatText, &buf, time.Second); err != nil {
 		t.Fatalf("WriteAnalyze failed: %v", err)
 	}
 
@@ -177,7 +177,7 @@ func TestWriteAnalyzeCSVReportsRollupRows(t *testing.T) {
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteAnalyze(complexityResponse, deadCodeResponse, nil, nil, depsResponse, domain.OutputFormatCSV, &buf, time.Second); err != nil {
+	if err := formatter.WriteAnalyze(domain.AnalysisResults{Complexity: complexityResponse, DeadCode: deadCodeResponse, Deps: depsResponse}, domain.OutputFormatCSV, &buf, time.Second); err != nil {
 		t.Fatalf("WriteAnalyze failed: %v", err)
 	}
 
@@ -200,7 +200,7 @@ func TestWriteHTMLRendersRollupTables(t *testing.T) {
 
 	var buf bytes.Buffer
 	formatter := NewOutputFormatter()
-	if err := formatter.WriteHTML(complexityResponse, deadCodeResponse, nil, nil, depsResponse, &buf, time.Second); err != nil {
+	if err := formatter.WriteHTML(domain.AnalysisResults{Complexity: complexityResponse, DeadCode: deadCodeResponse, Deps: depsResponse}, &buf, time.Second); err != nil {
 		t.Fatalf("WriteHTML failed: %v", err)
 	}
 

--- a/polyscan/internal/js/service/output_formatter.go
+++ b/polyscan/internal/js/service/output_formatter.go
@@ -280,6 +280,7 @@ func BuildAnalyzeSummary(results domain.AnalysisResults) *domain.AnalyzeSummary 
 
 	if results.DeadCode != nil {
 		summary.DeadCodeEnabled = true
+		summary.DeadCodeFiles = results.DeadCode.Summary.TotalFiles
 		summary.DeadCodeCount = results.DeadCode.Summary.TotalFindings
 		summary.CriticalDeadCode = results.DeadCode.Summary.CriticalFindings
 		summary.WarningDeadCode = results.DeadCode.Summary.WarningFindings

--- a/polyscan/internal/js/service/output_formatter.go
+++ b/polyscan/internal/js/service/output_formatter.go
@@ -130,11 +130,7 @@ func newComplexityResponseJSON(response *domain.ComplexityResponse) *ComplexityR
 // newAnalyzeResponseJSON assembles the unified payload shared by the JSON and
 // YAML outputs, including the module quality join.
 func newAnalyzeResponseJSON(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	duration time.Duration,
 	now time.Time,
 ) AnalyzeResponseJSON {
@@ -142,55 +138,55 @@ func newAnalyzeResponseJSON(
 		Version:       version.Version,
 		GeneratedAt:   now.Format(time.RFC3339),
 		DurationMs:    duration.Milliseconds(),
-		ModuleQuality: BuildModuleQuality(complexityResponse, deadCodeResponse, depsResponse),
-		Summary:       BuildAnalyzeSummary(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse),
+		ModuleQuality: BuildModuleQuality(results.Complexity, results.DeadCode, results.Deps),
+		Summary:       BuildAnalyzeSummary(results),
 	}
 
-	if complexityResponse != nil {
-		response.Complexity = newComplexityResponseJSON(complexityResponse)
+	if results.Complexity != nil {
+		response.Complexity = newComplexityResponseJSON(results.Complexity)
 	}
-	if deadCodeResponse != nil {
+	if results.DeadCode != nil {
 		response.DeadCode = &DeadCodeResponseJSON{
 			Version:     version.Version,
-			GeneratedAt: deadCodeResponse.GeneratedAt,
-			Files:       deadCodeResponse.Files,
-			Summary:     deadCodeResponse.Summary,
-			Warnings:    deadCodeResponse.Warnings,
-			Errors:      deadCodeResponse.Errors,
-			Config:      deadCodeResponse.Config,
+			GeneratedAt: results.DeadCode.GeneratedAt,
+			Files:       results.DeadCode.Files,
+			Summary:     results.DeadCode.Summary,
+			Warnings:    results.DeadCode.Warnings,
+			Errors:      results.DeadCode.Errors,
+			Config:      results.DeadCode.Config,
 		}
 	}
-	if cloneResponse != nil {
+	if results.Clone != nil {
 		response.Clone = &CloneResponseJSON{
 			Version:     version.Version,
 			GeneratedAt: now.Format(time.RFC3339),
-			DurationMs:  cloneResponse.Duration,
-			ClonePairs:  cloneResponse.ClonePairs,
-			CloneGroups: cloneResponse.CloneGroups,
-			Statistics:  cloneResponse.Statistics,
-			Success:     cloneResponse.Success,
-			Error:       cloneResponse.Error,
+			DurationMs:  results.Clone.Duration,
+			ClonePairs:  results.Clone.ClonePairs,
+			CloneGroups: results.Clone.CloneGroups,
+			Statistics:  results.Clone.Statistics,
+			Success:     results.Clone.Success,
+			Error:       results.Clone.Error,
 		}
 	}
-	if cboResponse != nil {
+	if results.CBO != nil {
 		response.CBO = &CBOResponseJSON{
 			Version:     version.Version,
-			GeneratedAt: cboResponse.GeneratedAt,
-			Classes:     cboResponse.Classes,
-			Summary:     cboResponse.Summary,
-			Warnings:    cboResponse.Warnings,
-			Errors:      cboResponse.Errors,
-			Config:      cboResponse.Config,
+			GeneratedAt: results.CBO.GeneratedAt,
+			Classes:     results.CBO.Classes,
+			Summary:     results.CBO.Summary,
+			Warnings:    results.CBO.Warnings,
+			Errors:      results.CBO.Errors,
+			Config:      results.CBO.Config,
 		}
 	}
-	if depsResponse != nil {
+	if results.Deps != nil {
 		response.Deps = &DepsResponseJSON{
 			Version:     version.Version,
-			GeneratedAt: depsResponse.GeneratedAt,
-			Graph:       depsResponse.Graph,
-			Analysis:    depsResponse.Analysis,
-			Warnings:    depsResponse.Warnings,
-			Errors:      depsResponse.Errors,
+			GeneratedAt: results.Deps.GeneratedAt,
+			Graph:       results.Deps.Graph,
+			Analysis:    results.Deps.Analysis,
+			Warnings:    results.Deps.Warnings,
+			Errors:      results.Deps.Errors,
 		}
 	}
 
@@ -223,26 +219,22 @@ func (f *OutputFormatterImpl) WriteDeadCode(response *domain.DeadCodeResponse, f
 
 // WriteAnalyze writes the unified analysis response in the specified format
 func (f *OutputFormatterImpl) WriteAnalyze(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	format domain.OutputFormat,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
 	switch format {
 	case domain.OutputFormatJSON:
-		return f.writeAnalyzeJSON(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, writer, duration)
+		return f.writeAnalyzeJSON(results, writer, duration)
 	case domain.OutputFormatText:
-		return f.writeAnalyzeText(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, writer, duration)
+		return f.writeAnalyzeText(results, writer, duration)
 	case domain.OutputFormatHTML:
-		return f.WriteHTML(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, writer, duration)
+		return f.WriteHTML(results, writer, duration)
 	case domain.OutputFormatYAML:
-		return f.writeAnalyzeYAML(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, writer, duration)
+		return f.writeAnalyzeYAML(results, writer, duration)
 	case domain.OutputFormatCSV:
-		return f.writeAnalyzeCSV(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, writer, duration)
+		return f.writeAnalyzeCSV(results, writer, duration)
 	default:
 		return fmt.Errorf("unsupported output format: %s", format)
 	}
@@ -267,73 +259,64 @@ func (f *OutputFormatterImpl) writeDeadCodeJSON(response *domain.DeadCodeRespons
 	return WriteJSON(writer, jsonResponse)
 }
 
-// BuildAnalyzeSummary builds an AnalyzeSummary from analysis responses
-func BuildAnalyzeSummary(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
-) *domain.AnalyzeSummary {
-	summary := &domain.AnalyzeSummary{}
+// BuildAnalyzeSummary builds an AnalyzeSummary from a run's results. The file
+// counts come from the run's own accounting rather than from any one analysis,
+// so the parse-error penalty charges unparsable files whichever analyses ran.
+func BuildAnalyzeSummary(results domain.AnalysisResults) *domain.AnalyzeSummary {
+	summary := &domain.AnalyzeSummary{
+		TotalFiles:    results.Files.Total,
+		AnalyzedFiles: results.Files.Total - results.Files.Skipped,
+		SkippedFiles:  results.Files.Skipped,
+	}
 
-	if complexityResponse != nil {
+	if results.Complexity != nil {
 		summary.ComplexityEnabled = true
-		summary.TotalFunctions = complexityResponse.Summary.TotalFunctions
-		summary.FunctionsParsed = complexityResponse.Summary.FunctionsParsed
-		summary.AverageComplexity = complexityResponse.Summary.AverageComplexity
-		summary.HighComplexityCount = complexityResponse.Summary.HighRiskFunctions
-		summary.MediumComplexityCount = complexityResponse.Summary.MediumRiskFunctions
-		summary.AnalyzedFiles = complexityResponse.Summary.FilesAnalyzed
-		// TotalFiles must count the files that failed to parse too, otherwise
-		// the shortfall is invisible and the health score is computed as if the
-		// unanalyzable part of the project did not exist.
-		summary.TotalFiles = complexityResponse.Summary.TotalFiles
-		summary.SkippedFiles = complexityResponse.Summary.SkippedFiles
+		summary.TotalFunctions = results.Complexity.Summary.TotalFunctions
+		summary.FunctionsParsed = results.Complexity.Summary.FunctionsParsed
+		summary.AverageComplexity = results.Complexity.Summary.AverageComplexity
+		summary.HighComplexityCount = results.Complexity.Summary.HighRiskFunctions
+		summary.MediumComplexityCount = results.Complexity.Summary.MediumRiskFunctions
 	}
 
-	if deadCodeResponse != nil {
+	if results.DeadCode != nil {
 		summary.DeadCodeEnabled = true
-		summary.DeadCodeCount = deadCodeResponse.Summary.TotalFindings
-		summary.CriticalDeadCode = deadCodeResponse.Summary.CriticalFindings
-		summary.WarningDeadCode = deadCodeResponse.Summary.WarningFindings
-		summary.InfoDeadCode = deadCodeResponse.Summary.InfoFindings
-		if deadCodeResponse.Summary.TotalFiles > summary.TotalFiles {
-			summary.TotalFiles = deadCodeResponse.Summary.TotalFiles
-		}
+		summary.DeadCodeCount = results.DeadCode.Summary.TotalFindings
+		summary.CriticalDeadCode = results.DeadCode.Summary.CriticalFindings
+		summary.WarningDeadCode = results.DeadCode.Summary.WarningFindings
+		summary.InfoDeadCode = results.DeadCode.Summary.InfoFindings
 	}
 
-	if cloneResponse != nil {
+	if results.Clone != nil {
 		summary.CloneEnabled = true
-		if cloneResponse.Statistics != nil {
-			summary.TotalClones = cloneResponse.Statistics.TotalClones
-			summary.ClonePairs = cloneResponse.Statistics.TotalClonePairs
-			summary.CloneGroups = cloneResponse.Statistics.TotalCloneGroups
-			summary.CodeDuplication = calculateDuplicationPercentage(cloneResponse)
-			summary.TotalLOC = cloneResponse.Statistics.LinesAnalyzed
+		if results.Clone.Statistics != nil {
+			summary.TotalClones = results.Clone.Statistics.TotalClones
+			summary.ClonePairs = results.Clone.Statistics.TotalClonePairs
+			summary.CloneGroups = results.Clone.Statistics.TotalCloneGroups
+			summary.CodeDuplication = calculateDuplicationPercentage(results.Clone)
+			summary.TotalLOC = results.Clone.Statistics.LinesAnalyzed
 		}
 	}
 
-	if cboResponse != nil {
+	if results.CBO != nil {
 		summary.CBOEnabled = true
-		summary.CBOClasses = cboResponse.Summary.TotalClasses
-		summary.HighCouplingClasses = cboResponse.Summary.HighRiskClasses
-		summary.MediumCouplingClasses = cboResponse.Summary.MediumRiskClasses
-		summary.AverageCoupling = cboResponse.Summary.AverageCBO
+		summary.CBOClasses = results.CBO.Summary.TotalClasses
+		summary.HighCouplingClasses = results.CBO.Summary.HighRiskClasses
+		summary.MediumCouplingClasses = results.CBO.Summary.MediumRiskClasses
+		summary.AverageCoupling = results.CBO.Summary.AverageCBO
 	}
 
-	if depsResponse != nil {
+	if results.Deps != nil {
 		summary.DepsEnabled = true
-		if depsResponse.Graph != nil {
-			summary.DepsTotalModules = depsResponse.Graph.NodeCount()
+		if results.Deps.Graph != nil {
+			summary.DepsTotalModules = results.Deps.Graph.NodeCount()
 		}
-		if depsResponse.Analysis != nil {
-			if depsResponse.Analysis.CircularDependencies != nil {
-				summary.DepsModulesInCycles = depsResponse.Analysis.CircularDependencies.TotalModulesInCycles
+		if results.Deps.Analysis != nil {
+			if results.Deps.Analysis.CircularDependencies != nil {
+				summary.DepsModulesInCycles = results.Deps.Analysis.CircularDependencies.TotalModulesInCycles
 			}
-			summary.DepsMaxDepth = depsResponse.Analysis.MaxDepth
-			if depsResponse.Analysis.CouplingAnalysis != nil {
-				summary.DepsMainSequenceDeviation = depsResponse.Analysis.CouplingAnalysis.MainSequenceDeviation
+			summary.DepsMaxDepth = results.Deps.Analysis.MaxDepth
+			if results.Deps.Analysis.CouplingAnalysis != nil {
+				summary.DepsMainSequenceDeviation = results.Deps.Analysis.CouplingAnalysis.MainSequenceDeviation
 			}
 		}
 	}
@@ -422,15 +405,11 @@ func scoreIndicator(score int) string {
 
 // writeAnalyzeJSON writes unified analysis response as JSON
 func (f *OutputFormatterImpl) writeAnalyzeJSON(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
-	response := newAnalyzeResponseJSON(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, duration, time.Now())
+	response := newAnalyzeResponseJSON(results, duration, time.Now())
 	return WriteJSON(writer, response)
 }
 
@@ -617,11 +596,7 @@ func (f *OutputFormatterImpl) writeDeadCodeText(response *domain.DeadCodeRespons
 
 // writeAnalyzeText writes unified analysis response as plain text
 func (f *OutputFormatterImpl) writeAnalyzeText(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
@@ -631,43 +606,43 @@ func (f *OutputFormatterImpl) writeAnalyzeText(
 	fmt.Fprintf(writer, "Version: %s\n\n", version.Version)
 
 	// Complexity results
-	if complexityResponse != nil {
-		if err := f.writeComplexityText(complexityResponse, writer); err != nil {
+	if results.Complexity != nil {
+		if err := f.writeComplexityText(results.Complexity, writer); err != nil {
 			return err
 		}
 	}
 
 	// Dead code results
-	if deadCodeResponse != nil {
-		if err := f.writeDeadCodeText(deadCodeResponse, writer); err != nil {
+	if results.DeadCode != nil {
+		if err := f.writeDeadCodeText(results.DeadCode, writer); err != nil {
 			return err
 		}
 	}
 
 	// Clone detection results
-	if cloneResponse != nil {
-		if err := f.writeCloneText(cloneResponse, writer); err != nil {
+	if results.Clone != nil {
+		if err := f.writeCloneText(results.Clone, writer); err != nil {
 			return err
 		}
 	}
 
 	// CBO analysis results
-	if cboResponse != nil {
-		if err := f.writeCBOText(cboResponse, writer); err != nil {
+	if results.CBO != nil {
+		if err := f.writeCBOText(results.CBO, writer); err != nil {
 			return err
 		}
 	}
 
 	// Dependency analysis results
-	if depsResponse != nil {
-		if err := f.writeDepsText(depsResponse, writer); err != nil {
+	if results.Deps != nil {
+		if err := f.writeDepsText(results.Deps, writer); err != nil {
 			return err
 		}
 	}
 
-	writeModuleQualityText(writer, BuildModuleQuality(complexityResponse, deadCodeResponse, depsResponse))
+	writeModuleQualityText(writer, BuildModuleQuality(results.Complexity, results.DeadCode, results.Deps))
 
-	summary := BuildAnalyzeSummary(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse)
+	summary := BuildAnalyzeSummary(results)
 
 	// Write Health Score section
 	fmt.Fprintf(writer, "\n=== Health Score ===\n\n")
@@ -849,15 +824,11 @@ func (f *OutputFormatterImpl) writeCBOText(response *domain.CBOResponse, writer 
 
 // writeAnalyzeYAML writes unified analysis response as YAML
 func (f *OutputFormatterImpl) writeAnalyzeYAML(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
-	response := newAnalyzeResponseJSON(complexityResponse, deadCodeResponse, cloneResponse, cboResponse, depsResponse, duration, time.Now())
+	response := newAnalyzeResponseJSON(results, duration, time.Now())
 
 	// Write YAML
 	encoder := yaml.NewEncoder(writer)
@@ -867,11 +838,7 @@ func (f *OutputFormatterImpl) writeAnalyzeYAML(
 
 // writeAnalyzeCSV writes unified analysis response as CSV
 func (f *OutputFormatterImpl) writeAnalyzeCSV(
-	complexityResponse *domain.ComplexityResponse,
-	deadCodeResponse *domain.DeadCodeResponse,
-	cloneResponse *domain.CloneResponse,
-	cboResponse *domain.CBOResponse,
-	depsResponse *domain.DependencyGraphResponse,
+	results domain.AnalysisResults,
 	writer io.Writer,
 	duration time.Duration,
 ) error {
@@ -881,7 +848,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 	needsSeparator := false
 
 	// Write complexity results
-	if complexityResponse != nil {
+	if results.Complexity != nil {
 		// Write header
 		if err := csvWriter.Write([]string{
 			"type", "file", "function", "start_line", "end_line",
@@ -891,7 +858,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 		}
 
 		// Write function data
-		for _, fn := range complexityResponse.Functions {
+		for _, fn := range results.Complexity.Functions {
 			record := []string{
 				"complexity",
 				fn.FilePath,
@@ -909,7 +876,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 		}
 		needsSeparator = true
 
-		if len(complexityResponse.ByDirectory) > 0 {
+		if len(results.Complexity.ByDirectory) > 0 {
 			if err := csvWriter.Write([]string{}); err != nil {
 				return err
 			}
@@ -920,7 +887,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 				return err
 			}
 
-			for _, directory := range complexityResponse.ByDirectory {
+			for _, directory := range results.Complexity.ByDirectory {
 				record := []string{
 					"directory_complexity",
 					directory.DirectoryPath,
@@ -939,7 +906,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 	}
 
 	// Write dead code results
-	if deadCodeResponse != nil {
+	if results.DeadCode != nil {
 		if needsSeparator {
 			if err := csvWriter.Write([]string{}); err != nil {
 				return err
@@ -953,7 +920,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 		}
 
 		// Write dead code findings
-		for _, file := range deadCodeResponse.Files {
+		for _, file := range results.DeadCode.Files {
 			// File-level findings (unused imports/exports)
 			for _, finding := range file.FileLevelFindings {
 				record := []string{
@@ -993,7 +960,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 	}
 
 	// Write clone results
-	if cloneResponse != nil && len(cloneResponse.ClonePairs) > 0 {
+	if results.Clone != nil && len(results.Clone.ClonePairs) > 0 {
 		if needsSeparator {
 			if err := csvWriter.Write([]string{}); err != nil {
 				return err
@@ -1007,7 +974,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 			return err
 		}
 
-		for _, pair := range cloneResponse.ClonePairs {
+		for _, pair := range results.Clone.ClonePairs {
 			file1, start1, end1 := "", "0", "0"
 			file2, start2, end2 := "", "0", "0"
 			if pair.Clone1 != nil && pair.Clone1.Location != nil {
@@ -1035,7 +1002,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 	}
 
 	// Write CBO results
-	if cboResponse != nil && len(cboResponse.Classes) > 0 {
+	if results.CBO != nil && len(results.CBO.Classes) > 0 {
 		if needsSeparator {
 			if err := csvWriter.Write([]string{}); err != nil {
 				return err
@@ -1047,7 +1014,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 			return err
 		}
 
-		for _, class := range cboResponse.Classes {
+		for _, class := range results.CBO.Classes {
 			record := []string{
 				"cbo",
 				class.Name,
@@ -1063,7 +1030,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 	}
 
 	// Write dependency graph results
-	if depsResponse != nil && depsResponse.Graph != nil {
+	if results.Deps != nil && results.Deps.Graph != nil {
 		if needsSeparator {
 			if err := csvWriter.Write([]string{}); err != nil {
 				return err
@@ -1075,14 +1042,14 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 			return err
 		}
 
-		fromIDs := make([]string, 0, len(depsResponse.Graph.Edges))
-		for from := range depsResponse.Graph.Edges {
+		fromIDs := make([]string, 0, len(results.Deps.Graph.Edges))
+		for from := range results.Deps.Graph.Edges {
 			fromIDs = append(fromIDs, from)
 		}
 		sort.Strings(fromIDs)
 
 		for _, from := range fromIDs {
-			edges := append([]*domain.DependencyEdge(nil), depsResponse.Graph.Edges[from]...)
+			edges := append([]*domain.DependencyEdge(nil), results.Deps.Graph.Edges[from]...)
 			sort.Slice(edges, func(i, j int) bool {
 				if edges[i].To == edges[j].To {
 					return edges[i].EdgeType < edges[j].EdgeType
@@ -1108,7 +1075,7 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 
 	// Write the per-module join last: it restates the analyses above, so a
 	// reader who only wants raw findings can stop before it.
-	modules := BuildModuleQuality(complexityResponse, deadCodeResponse, depsResponse)
+	modules := BuildModuleQuality(results.Complexity, results.DeadCode, results.Deps)
 	if len(modules) > 0 {
 		if needsSeparator {
 			if err := csvWriter.Write([]string{}); err != nil {

--- a/polyscan/internal/js/service/output_formatter_test.go
+++ b/polyscan/internal/js/service/output_formatter_test.go
@@ -45,7 +45,7 @@ func TestCalculateDuplicationPercentageReportsUncappedRatio(t *testing.T) {
 		t.Fatalf("expected actual 50%% fragment ratio, got %.1f%%", got)
 	}
 
-	summary := BuildAnalyzeSummary(nil, nil, response, nil, nil)
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{Clone: response})
 	if summary.CodeDuplication != 50 {
 		t.Fatalf("expected summary to retain actual ratio, got %.1f%%", summary.CodeDuplication)
 	}
@@ -56,16 +56,17 @@ func TestCalculateDuplicationPercentageReportsUncappedRatio(t *testing.T) {
 
 func TestBuildAnalyzeSummary_WiresProjectScale(t *testing.T) {
 	complexityResponse := &domain.ComplexityResponse{
-		Summary: domain.ComplexitySummary{
-			TotalFunctions: 240,
-			FilesAnalyzed:  123,
-		},
+		Summary: domain.ComplexitySummary{TotalFunctions: 240},
 	}
 	cloneResponse := &domain.CloneResponse{Statistics: &domain.CloneStatistics{
 		LinesAnalyzed: 7890,
 	}}
 
-	summary := BuildAnalyzeSummary(complexityResponse, nil, cloneResponse, nil, nil)
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{
+		Files:      domain.FileAccounting{Total: 123},
+		Complexity: complexityResponse,
+		Clone:      cloneResponse,
+	})
 
 	if summary.ProjectScale != domain.ScaleMedium {
 		t.Errorf("ProjectScale = %q, want %q", summary.ProjectScale, domain.ScaleMedium)
@@ -86,12 +87,10 @@ func TestBuildAnalyzeSummary_WiresProjectScale(t *testing.T) {
 func TestFormatProjectScale_OmitsLOCWhenUnavailable(t *testing.T) {
 	// Clone analysis is what supplies the line count, so a run without it
 	// reports files and functions only.
-	summary := BuildAnalyzeSummary(&domain.ComplexityResponse{
-		Summary: domain.ComplexitySummary{
-			TotalFunctions: 6,
-			FilesAnalyzed:  4,
-		},
-	}, nil, nil, nil, nil)
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{
+		Files:      domain.FileAccounting{Total: 4},
+		Complexity: &domain.ComplexityResponse{Summary: domain.ComplexitySummary{TotalFunctions: 6}},
+	})
 
 	want := "Micro (4 files, 6 functions)"
 	if got := FormatProjectScale(summary); got != want {
@@ -282,7 +281,7 @@ func TestOutputFormatterWriteAnalyzeJSON(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := formatter.WriteAnalyze(complexityResponse, nil, nil, nil, nil, domain.OutputFormatJSON, &buf, 100*time.Millisecond)
+	err := formatter.WriteAnalyze(domain.AnalysisResults{Complexity: complexityResponse}, domain.OutputFormatJSON, &buf, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WriteAnalyze failed: %v", err)
 	}
@@ -317,7 +316,7 @@ func TestOutputFormatterWriteAnalyzeJSON_CloneErrorIncluded(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := formatter.WriteAnalyze(nil, nil, cloneResponse, nil, nil, domain.OutputFormatJSON, &buf, 100*time.Millisecond)
+	err := formatter.WriteAnalyze(domain.AnalysisResults{Clone: cloneResponse}, domain.OutputFormatJSON, &buf, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WriteAnalyze failed: %v", err)
 	}
@@ -373,7 +372,7 @@ func TestOutputFormatterWriteHTML(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := formatter.WriteAnalyze(complexityResponse, deadCodeResponse, nil, nil, nil, domain.OutputFormatHTML, &buf, 100*time.Millisecond)
+	err := formatter.WriteAnalyze(domain.AnalysisResults{Complexity: complexityResponse, DeadCode: deadCodeResponse}, domain.OutputFormatHTML, &buf, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WriteAnalyze with HTML failed: %v", err)
 	}
@@ -405,7 +404,7 @@ func TestOutputFormatterWriteHTML_CloneNilSafe(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := formatter.WriteAnalyze(nil, nil, cloneResponse, nil, nil, domain.OutputFormatHTML, &buf, 100*time.Millisecond)
+	err := formatter.WriteAnalyze(domain.AnalysisResults{Clone: cloneResponse}, domain.OutputFormatHTML, &buf, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WriteAnalyze with HTML failed: %v", err)
 	}
@@ -441,7 +440,7 @@ func TestOutputFormatterWriteAnalyzeCSV_WithDeps(t *testing.T) {
 	}
 
 	var buf bytes.Buffer
-	err := formatter.WriteAnalyze(nil, nil, nil, nil, depsResponse, domain.OutputFormatCSV, &buf, 100*time.Millisecond)
+	err := formatter.WriteAnalyze(domain.AnalysisResults{Deps: depsResponse}, domain.OutputFormatCSV, &buf, 100*time.Millisecond)
 	if err != nil {
 		t.Fatalf("WriteAnalyze with CSV failed: %v", err)
 	}
@@ -483,7 +482,7 @@ func TestBuildAnalyzeSummary_WiresMSD(t *testing.T) {
 		},
 	}
 
-	summary := BuildAnalyzeSummary(nil, nil, nil, nil, depsResponse)
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{Deps: depsResponse})
 
 	if summary.DepsMainSequenceDeviation != 0.42 {
 		t.Errorf("DepsMainSequenceDeviation = %f, want 0.42", summary.DepsMainSequenceDeviation)
@@ -509,7 +508,7 @@ func TestBuildAnalyzeSummary_WiresCycles(t *testing.T) {
 		},
 	}
 
-	summary := BuildAnalyzeSummary(nil, nil, nil, nil, depsResponse)
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{Deps: depsResponse})
 
 	if summary.DepsModulesInCycles != 10 {
 		t.Errorf("DepsModulesInCycles = %d, want 10", summary.DepsModulesInCycles)
@@ -561,5 +560,35 @@ func TestComplexityFunctionsHeading(t *testing.T) {
 				t.Errorf("heading = %q, expected %q", heading, tc.expected)
 			}
 		})
+	}
+}
+
+// TestBuildAnalyzeSummary_ChargesSkippedFilesWithoutComplexity pins the fix
+// for #92: the parse-error penalty and the file counts come from the run's
+// accounting, so a run that left complexity out still reports and charges the
+// files it could not parse.
+func TestBuildAnalyzeSummary_ChargesSkippedFilesWithoutComplexity(t *testing.T) {
+	files := domain.FileAccounting{Total: 2, Skipped: 1, Errors: []string{"broken.js: syntax error at line 1"}}
+	deadCode := &domain.DeadCodeResponse{Summary: domain.DeadCodeSummary{TotalFiles: 2}}
+
+	summary := BuildAnalyzeSummary(domain.AnalysisResults{Files: files, DeadCode: deadCode})
+
+	if summary.TotalFiles != 2 || summary.AnalyzedFiles != 1 || summary.SkippedFiles != 1 {
+		t.Fatalf("file counts = %d/%d/%d, want total 2, analyzed 1, skipped 1",
+			summary.TotalFiles, summary.AnalyzedFiles, summary.SkippedFiles)
+	}
+	if summary.HealthScore >= 100 {
+		t.Errorf("HealthScore = %d, want the parse-error penalty applied", summary.HealthScore)
+	}
+	clean := BuildAnalyzeSummary(domain.AnalysisResults{Files: domain.FileAccounting{Total: 2}, DeadCode: deadCode})
+	if clean.HealthScore != 100 {
+		t.Errorf("clean HealthScore = %d, want 100", clean.HealthScore)
+	}
+
+	cli := FormatCLISummary(summary, time.Second, files.Errors)
+	for _, want := range []string{"1 of 2 files skipped (parse errors)", "broken.js: syntax error at line 1"} {
+		if !strings.Contains(cli, want) {
+			t.Errorf("CLI summary lacks %q:\n%s", want, cli)
+		}
 	}
 }

--- a/polyscan/internal/js/service/output_formatter_test.go
+++ b/polyscan/internal/js/service/output_formatter_test.go
@@ -592,3 +592,26 @@ func TestBuildAnalyzeSummary_ChargesSkippedFilesWithoutComplexity(t *testing.T) 
 		}
 	}
 }
+
+// TestBuildAnalyzeSummary_DeadCodeRateUsesDeadCodeFiles pins the divisor of
+// the dead code penalty: the files that analysis covered, not the whole run,
+// so files of other languages do not dilute a JavaScript finding rate.
+func TestBuildAnalyzeSummary_DeadCodeRateUsesDeadCodeFiles(t *testing.T) {
+	deadCode := &domain.DeadCodeResponse{Summary: domain.DeadCodeSummary{
+		TotalFiles: 1, TotalFindings: 1, CriticalFindings: 1,
+	}}
+	alone := BuildAnalyzeSummary(domain.AnalysisResults{Files: domain.FileAccounting{Total: 1}, DeadCode: deadCode})
+	mixed := BuildAnalyzeSummary(domain.AnalysisResults{
+		Files:    domain.FileAccounting{Total: 100},
+		DeadCode: deadCode,
+		Clone:    &domain.CloneResponse{Statistics: &domain.CloneStatistics{}},
+	})
+
+	if alone.DeadCodeFiles != 1 || mixed.DeadCodeFiles != 1 {
+		t.Fatalf("DeadCodeFiles = %d and %d, want 1 for both", alone.DeadCodeFiles, mixed.DeadCodeFiles)
+	}
+	if mixed.DeadCodeScore != alone.DeadCodeScore || mixed.DeadCodeScore == 100 {
+		t.Errorf("DeadCodeScore = %d alone, %d in a mixed tree; want equal and penalized",
+			alone.DeadCodeScore, mixed.DeadCodeScore)
+	}
+}

--- a/polyscan/internal/js/service/project_snapshot.go
+++ b/polyscan/internal/js/service/project_snapshot.go
@@ -11,14 +11,29 @@ import (
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/parser"
 )
 
-// ProjectSnapshot holds every analyzed file read and parsed exactly once, so
-// the analyses that used to parse the project independently can share one set
-// of parse trees. The snapshot is the parse trees' owner: analyses must not
-// mutate the shared AST, and clone detection keeps dropping its per-fragment
-// AST references after APTED conversion, so the trees become collectable as
-// soon as the last snapshot reference is gone.
+// ProjectSnapshot is the file set of one run. It is the parse trees' owner:
+// analyses must not mutate the shared AST, and clone detection keeps dropping
+// its per-fragment AST references after APTED conversion, so the trees become
+// collectable as soon as the last snapshot reference is gone.
+//
+// A snapshot built with BuildProjectSnapshot reads and parses every file up
+// front and keeps the trees, so several analyses can share one set of parse
+// trees. One created with NewProjectSnapshot is for a single analysis: each
+// file is loaded inside that analysis's fan-out and released as soon as the
+// analysis has extracted its results, so peak memory holds only as many parse
+// trees as there are workers.
+//
+// Either way the snapshot records, per file, whether it could be read and
+// parsed. That is the run's file accounting, and it is kept here rather than
+// in any one analysis so the health score can charge unparsable files
+// whichever analyses ran.
 type ProjectSnapshot struct {
 	Files []*ProjectFile
+
+	// retain keeps each file's parse tree after an analysis pass so the next
+	// analysis can share it. A single-analysis snapshot releases each tree
+	// instead.
+	retain bool
 }
 
 // ProjectFile is one file after read and parse, plus the lazily built CFGs the
@@ -30,51 +45,71 @@ type ProjectFile struct {
 	ReadErr  error
 	ParseErr error
 
+	loaded   bool
+	released bool
+
 	cfgOnce sync.Once
 	cfgs    map[string]*analyzer.CFG
 	cfgErr  error
 }
 
-// BuildProjectSnapshot reads and parses each file once, in parallel. Files come
+// NewProjectSnapshot names the files of a single-analysis run without reading
+// them. The analysis loads each file as its fan-out reaches it and releases the
+// parse tree right after, so the snapshot never holds the whole project at
+// once. The entry points reject a second analysis over the same snapshot: the
+// trees it would need are gone.
+func NewProjectSnapshot(paths []string) *ProjectSnapshot {
+	files := make([]*ProjectFile, len(paths))
+	for index, path := range paths {
+		files[index] = &ProjectFile{Path: path}
+	}
+	return &ProjectSnapshot{Files: files}
+}
+
+// BuildProjectSnapshot reads and parses each file once, in parallel, and keeps
+// the parse trees for every analysis that runs over the snapshot. Files come
 // out in path order regardless of scheduling, so downstream reports stay
 // deterministic. Read and parse failures are recorded per file rather than
 // aborting the build: each analysis reports them in its own format.
 func BuildProjectSnapshot(ctx context.Context, paths []string) *ProjectSnapshot {
-	results := analyzeFilesConcurrently(ctx, paths,
-		func(_ context.Context, path string) fileAnalysis[*ProjectFile] {
-			return fileAnalysis[*ProjectFile]{value: buildProjectFile(path)}
+	snapshot := NewProjectSnapshot(paths)
+	snapshot.retain = true
+	// Loading is the whole job here, so the pass analyzes nothing.
+	analyzeSnapshotFiles(ctx, snapshot, func(*ProjectFile) fileAnalysis[struct{}] {
+		return fileAnalysis[struct{}]{}
+	})
+	return snapshot
+}
+
+// analyzeSnapshotFiles applies analyze to every file of the snapshot across
+// worker goroutines and returns the results in file order. Each file is loaded
+// before analyze sees it, so analyze can read Content, AST, ReadErr and
+// ParseErr directly, and a single-analysis snapshot releases the file right
+// after. Files a cancelled pass never reached record the cancellation as their
+// read error, so the accounting stays complete.
+func analyzeSnapshotFiles[T any](
+	ctx context.Context,
+	snapshot *ProjectSnapshot,
+	analyze func(*ProjectFile) fileAnalysis[T],
+) []fileAnalysis[T] {
+	results := analyzeFilesConcurrently(ctx, snapshot.Files,
+		func(_ context.Context, file *ProjectFile) fileAnalysis[T] {
+			file.load()
+			result := analyze(file)
+			if !snapshot.retain {
+				file.release()
+			}
+			return result
 		})
 
-	files := make([]*ProjectFile, len(paths))
-	for index, result := range results {
-		if result.value != nil {
-			files[index] = result.value
-			continue
-		}
-		// The worker never reached this slot: the context was cancelled.
-		files[index] = &ProjectFile{
-			Path:    paths[index],
-			ReadErr: fmt.Errorf("analysis cancelled: %w", context.Cause(ctx)),
+	for _, file := range snapshot.Files {
+		if !file.loaded {
+			file.loaded = true
+			file.ReadErr = fmt.Errorf("analysis cancelled: %w", context.Cause(ctx))
 		}
 	}
 
-	return &ProjectSnapshot{Files: files}
-}
-
-// analyzeProjectFilesFromPaths reads, parses, and analyzes each path inside the
-// fan-out, so every analysis sees the same *ProjectFile shape as the snapshot
-// path while each file's parse tree is released as soon as analyze returns.
-// This is the memory-lean pipeline for a single analysis; a run that shares
-// files across several analyses builds a ProjectSnapshot instead.
-func analyzeProjectFilesFromPaths[T any](
-	ctx context.Context,
-	paths []string,
-	analyze func(*ProjectFile) fileAnalysis[T],
-) []fileAnalysis[T] {
-	return analyzeFilesConcurrently(ctx, paths,
-		func(_ context.Context, path string) fileAnalysis[T] {
-			return analyze(buildProjectFile(path))
-		})
+	return results
 }
 
 // Paths returns the snapshot's file paths in analysis order.
@@ -86,14 +121,44 @@ func (s *ProjectSnapshot) Paths() []string {
 	return paths
 }
 
-// validateRequestPaths guards the AnalyzeSnapshot entry points: the snapshot
+// Accounting reports the run's file set the way the health score charges it:
+// every file the run covered, and those no analysis could use. It reads what
+// the analyses learned about each file, so it must be called once they have
+// finished; calling it earlier is a programming error and panics.
+func (s *ProjectSnapshot) Accounting() domain.FileAccounting {
+	accounting := domain.FileAccounting{Total: len(s.Files)}
+	for _, file := range s.Files {
+		if !file.loaded {
+			panic(fmt.Sprintf("file accounting requested before %s was analyzed", file.Path))
+		}
+		err := file.ReadErr
+		if err == nil {
+			err = file.ParseErr
+		}
+		if err == nil {
+			continue
+		}
+		accounting.Skipped++
+		accounting.Errors = append(accounting.Errors, fmt.Sprintf("%s: %v", file.Path, err))
+	}
+	return accounting
+}
+
+// validateRequest guards the AnalyzeSnapshot entry points. The snapshot
 // defines the analyzed file set, so a request that names paths must name the
 // snapshot's files — anything else means the caller built the snapshot from a
 // different selection than it thinks it is analyzing. An empty path list
-// defers to the snapshot entirely.
-func (s *ProjectSnapshot) validateRequestPaths(paths []string) error {
+// defers to the snapshot entirely. A single-analysis snapshot has released its
+// parse trees after its one pass, so it cannot be analyzed again.
+func (s *ProjectSnapshot) validateRequest(paths []string) error {
 	if s == nil {
 		return domain.NewInvalidInputError("project snapshot cannot be nil", nil)
+	}
+	for _, file := range s.Files {
+		if file.released {
+			return domain.NewInvalidInputError(
+				fmt.Sprintf("file %s was released after its single analysis and cannot be analyzed again", file.Path), nil)
+		}
 	}
 	if len(paths) == 0 {
 		return nil
@@ -116,24 +181,38 @@ func (s *ProjectSnapshot) validateRequestPaths(paths []string) error {
 	return nil
 }
 
-func buildProjectFile(path string) *ProjectFile {
-	file := &ProjectFile{Path: path}
-
-	content, err := os.ReadFile(path)
-	if err != nil {
-		file.ReadErr = err
-		return file
+// load reads and parses the file once. Only the fan-out calls it, one call per
+// file per pass, so it needs no lock: a retained file is simply already loaded
+// on the next pass.
+func (f *ProjectFile) load() {
+	if f.loaded {
+		return
 	}
-	file.Content = content
+	f.loaded = true
 
-	ast, err := parser.ParseForLanguage(path, content)
+	content, err := os.ReadFile(f.Path)
 	if err != nil {
-		file.ParseErr = err
-		return file
+		f.ReadErr = err
+		return
 	}
-	file.AST = ast
+	f.Content = content
 
-	return file
+	ast, err := parser.ParseForLanguage(f.Path, content)
+	if err != nil {
+		f.ParseErr = err
+		return
+	}
+	f.AST = ast
+}
+
+// release drops the file's contents, parse tree and CFGs once its single
+// analysis is done with them, keeping only the path and the errors the
+// accounting reads.
+func (f *ProjectFile) release() {
+	f.released = true
+	f.Content = nil
+	f.AST = nil
+	f.cfgs = nil
 }
 
 // Parsed reports whether the file has a valid parse tree to analyze.

--- a/polyscan/internal/js/service/project_snapshot_test.go
+++ b/polyscan/internal/js/service/project_snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"sync"
 	"testing"
 
@@ -213,5 +214,75 @@ func TestAnalyzeSnapshot_NilSnapshot(t *testing.T) {
 	}
 	if _, err := NewCloneServiceWithDefaults().DetectClonesInSnapshot(context.Background(), nil, domain.DefaultCloneRequest()); err == nil {
 		t.Error("nil snapshot should be rejected")
+	}
+}
+
+const brokenSnapshotFixture = `function broken( {`
+
+func TestNewProjectSnapshot_AccountsForFilesWhileReleasingThem(t *testing.T) {
+	valid := writeSnapshotFixture(t, "a.js", `function a() { return 1; }`)
+	broken := writeSnapshotFixture(t, "b.js", brokenSnapshotFixture)
+	missing := filepath.Join(t.TempDir(), "missing.js")
+	snapshot := NewProjectSnapshot([]string{valid, broken, missing})
+
+	response, err := NewComplexityService(complexityTestConfig()).AnalyzeSnapshot(context.Background(), snapshot, domain.ComplexityRequest{})
+	if err != nil {
+		t.Fatalf("analysis failed: %v", err)
+	}
+	if response.Summary.FilesAnalyzed != 1 || response.Summary.SkippedFiles != 2 {
+		t.Errorf("summary = %+v, want 1 analyzed and 2 skipped", response.Summary)
+	}
+
+	accounting := snapshot.Accounting()
+	if accounting.Total != 3 || accounting.Skipped != 2 || len(accounting.Errors) != 2 {
+		t.Fatalf("accounting = %+v, want 3 files with 2 skipped", accounting)
+	}
+	if !strings.HasPrefix(accounting.Errors[0], broken+": syntax error") {
+		t.Errorf("parse failure not reported per file: %q", accounting.Errors[0])
+	}
+	if !strings.HasPrefix(accounting.Errors[1], missing+": ") {
+		t.Errorf("read failure not reported per file: %q", accounting.Errors[1])
+	}
+	for _, file := range snapshot.Files {
+		if file.AST != nil || file.Content != nil {
+			t.Errorf("%s still holds its parse tree after its single analysis", file.Path)
+		}
+	}
+}
+
+func TestNewProjectSnapshot_RejectsASecondAnalysis(t *testing.T) {
+	path := writeSnapshotFixture(t, "a.js", `function a() { return 1; }`)
+	snapshot := NewProjectSnapshot([]string{path})
+	svc := NewComplexityService(complexityTestConfig())
+	if _, err := svc.AnalyzeSnapshot(context.Background(), snapshot, domain.ComplexityRequest{}); err != nil {
+		t.Fatalf("first analysis failed: %v", err)
+	}
+
+	if _, err := svc.AnalyzeSnapshot(context.Background(), snapshot, domain.ComplexityRequest{}); err == nil {
+		t.Error("a second analysis over a released snapshot must be rejected")
+	}
+	if _, err := NewDependencyGraphServiceWithDefaults().AnalyzeSnapshot(context.Background(), NewProjectSnapshot([]string{path}), domain.DependencyGraphRequest{}); err == nil {
+		t.Error("dependency analysis over a single-analysis snapshot must be rejected")
+	}
+}
+
+func TestProjectSnapshot_AccountingBeforeAnalysisPanics(t *testing.T) {
+	snapshot := NewProjectSnapshot([]string{"unloaded.js"})
+	defer func() {
+		if recover() == nil {
+			t.Error("accounting before the analysis loaded the files must panic")
+		}
+	}()
+	snapshot.Accounting()
+}
+
+func TestBuildProjectSnapshot_AccountingIsAvailableAfterBuild(t *testing.T) {
+	valid := writeSnapshotFixture(t, "a.js", `function a() { return 1; }`)
+	broken := writeSnapshotFixture(t, "b.js", brokenSnapshotFixture)
+
+	accounting := BuildProjectSnapshot(context.Background(), []string{valid, broken}).Accounting()
+
+	if accounting.Total != 2 || accounting.Skipped != 1 {
+		t.Errorf("accounting = %+v, want 2 files with 1 skipped", accounting)
 	}
 }

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -17,40 +17,37 @@ import (
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/version"
 )
 
-// Responses is the unified analysis in the shape the output formatter
-// renders. An analysis that did not run, or found nothing to analyze,
-// leaves its response nil, and the health score leaves those dimensions
-// out instead of scoring them as clean.
-type Responses struct {
-	Complexity *domain.ComplexityResponse
-	DeadCode   *domain.DeadCodeResponse
-	Clone      *domain.CloneResponse
-	CBO        *domain.CBOResponse
-	Deps       *domain.DependencyGraphResponse
-}
-
 // Combine merges the generic-engine report with the JavaScript/TypeScript
-// result. Complexity and clone results merge across languages; dead code,
-// coupling and dependencies exist only for JavaScript/TypeScript and pass
-// through. Either input may be nil when its side found no files.
-func Combine(generic *analysis.Report, javascript *js.Result) (Responses, error) {
-	responses := Responses{}
+// result into the shape the output formatter renders. Complexity and clone
+// results merge across languages; dead code, coupling and dependencies exist
+// only for JavaScript/TypeScript and pass through. The file accounting adds
+// up across both sides, so the health score charges every unparsable file
+// whichever analyses ran. Either input may be nil when its side found no
+// files.
+func Combine(generic *analysis.Report, javascript *js.Result) (domain.AnalysisResults, error) {
+	results := domain.AnalysisResults{}
 	if javascript != nil {
-		responses.Complexity = javascript.Complexity
-		responses.DeadCode = javascript.DeadCode
-		responses.Clone = javascript.Clones
-		responses.CBO = javascript.CBO
-		responses.Deps = javascript.Deps
+		results.Files = javascript.Files
+		results.Complexity = javascript.Complexity
+		results.DeadCode = javascript.DeadCode
+		results.Clone = javascript.Clones
+		results.CBO = javascript.CBO
+		results.Deps = javascript.Deps
 	}
 	if generic != nil {
 		complexity, err := genericComplexity(generic)
 		if err != nil {
-			return Responses{}, err
+			return domain.AnalysisResults{}, err
 		}
-		responses.Complexity = mergeComplexity(complexity, responses.Complexity)
-		responses.Clone = mergeClones(genericClones(generic), responses.Clone)
+		results.Files.Add(domain.FileAccounting{
+			Total:   generic.Files.Total,
+			Skipped: generic.Files.Skipped,
+			Errors:  generic.Errors,
+		})
+		results.Complexity = mergeComplexity(complexity, results.Complexity)
+		results.Clone = mergeClones(genericClones(generic), results.Clone)
 	}
-	return responses, nil
+	return results, nil
 }
 
 // genericComplexity converts the generic engine's complexity analysis into

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -1,6 +1,7 @@
 package report
 
 import (
+	"reflect"
 	"testing"
 
 	coredomain "github.com/ludo-technologies/polyscan/core/domain"
@@ -103,6 +104,9 @@ func TestCombineGenericOnly(t *testing.T) {
 	if responses.DeadCode != nil || responses.CBO != nil || responses.Deps != nil {
 		t.Error("the generic engine has no dead code, CBO or dependency analysis")
 	}
+	if !reflect.DeepEqual(responses.Files, domain.FileAccounting{Total: 3, Skipped: 1, Errors: []string{"c.go: read error"}}) {
+		t.Errorf("files = %+v", responses.Files)
+	}
 }
 
 func javascriptResult() *js.Result {
@@ -115,6 +119,7 @@ func javascriptResult() *js.Result {
 		Location: &domain.CloneLocation{FilePath: "app.js", StartLine: 20, EndLine: 31},
 	}
 	return &js.Result{
+		Files: domain.FileAccounting{Total: 1},
 		Complexity: &domain.ComplexityResponse{
 			Functions: []domain.FunctionComplexity{{
 				Name: "handler", FilePath: "app.js", Language: "JavaScript", StartLine: 1, EndLine: 30,
@@ -164,6 +169,9 @@ func TestCombineMergesLanguages(t *testing.T) {
 	summary := complexity.Summary
 	if summary.TotalFunctions != 3 || summary.TotalFiles != 4 || summary.FilesAnalyzed != 3 || summary.SkippedFiles != 1 {
 		t.Errorf("summary = %+v", summary)
+	}
+	if responses.Files.Total != 4 || responses.Files.Skipped != 1 {
+		t.Errorf("files = %+v, want both languages' files counted", responses.Files)
 	}
 	if want := (7.0*2 + 5.0) / 3; summary.AverageComplexity != want {
 		t.Errorf("AverageComplexity = %v, want %v", summary.AverageComplexity, want)
@@ -234,5 +242,24 @@ func TestCombineSelectionWithoutComplexity(t *testing.T) {
 	}
 	if responses.Clone == nil {
 		t.Error("the clone response must survive without complexity")
+	}
+	if responses.Files.Skipped != 1 {
+		t.Errorf("files = %+v, want the skipped file charged without complexity", responses.Files)
+	}
+}
+
+// TestCombineJavaScriptSkippedFilesWithoutComplexity covers #92 on the
+// JavaScript side: a dead-code-only run still carries its unparsable files.
+func TestCombineJavaScriptSkippedFilesWithoutComplexity(t *testing.T) {
+	javascript := &js.Result{
+		Files:    domain.FileAccounting{Total: 2, Skipped: 1, Errors: []string{"broken.js: syntax error at line 1"}},
+		DeadCode: &domain.DeadCodeResponse{},
+	}
+	responses, err := Combine(nil, javascript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(responses.Files, javascript.Files) {
+		t.Errorf("files = %+v, want %+v", responses.Files, javascript.Files)
 	}
 }

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -89,11 +89,11 @@ Which functions count as high or medium risk depends on the thresholds, so for J
 
 ```text
 weighted = 1.0 × critical + 0.5 × warning + 0.2 × info
-rate     = weighted ÷ total files
+rate     = weighted ÷ dead_code_files
 penalty  = 20 × rate ÷ 3.0, capped at 20
 ```
 
-This is a per-file rate rather than a raw count, so a large codebase is not penalized simply for being large. The penalty maxes out at three weighted findings per file. The divisor is the file count the dead code analysis covered, which is the JavaScript/TypeScript files.
+This is a per-file rate rather than a raw count, so a large codebase is not penalized simply for being large. The penalty maxes out at three weighted findings per file. The divisor is the file count the dead code analysis covered, which is the JavaScript/TypeScript files, reported as `dead_code_files` in the summary. The whole run's `total_files` is not used here, so Go, Rust and C++ files in a mixed tree do not dilute the rate.
 
 ### Duplication
 

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -100,6 +100,8 @@ The `*_enabled` flags say which dimensions actually ran and therefore which the 
 
 `grade` is one of `A`, `B`, `C`, `D`, `F`, or `N/A`. The last appears only when the summary failed validation, in which case `health_score` is 0 as well.
 
+`total_files`, `analyzed_files` and `skipped_files` describe the whole run, whichever analyses were selected: a file that could not be read or parsed is counted as skipped and charged the parse-error penalty even when complexity analysis did not run. The complexity object below carries its own file counts, which cover only the files that analysis saw.
+
 `project_scale` is a size label derived from `analyzed_files`. See [Project scale](health-score.md#project-scale) for the thresholds. `total_loc` is the number of lines the clone analysis read, so it is `0` when clone analysis is turned off.
 
 ## `complexity`

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -63,6 +63,7 @@ This is the object most scripts want. It carries the health score, the per-categ
   "average_complexity": 4.5,
   "high_complexity_count": 0,
   "medium_complexity_count": 0,
+  "dead_code_files": 2,
   "dead_code_count": 3,
   "critical_dead_code": 1,
   "warning_dead_code": 2,
@@ -100,7 +101,7 @@ The `*_enabled` flags say which dimensions actually ran and therefore which the 
 
 `grade` is one of `A`, `B`, `C`, `D`, `F`, or `N/A`. The last appears only when the summary failed validation, in which case `health_score` is 0 as well.
 
-`total_files`, `analyzed_files` and `skipped_files` describe the whole run, whichever analyses were selected: a file that could not be read or parsed is counted as skipped and charged the parse-error penalty even when complexity analysis did not run. The complexity object below carries its own file counts, which cover only the files that analysis saw.
+`total_files`, `analyzed_files` and `skipped_files` describe the whole run, whichever analyses were selected: a file that could not be read or parsed is counted as skipped and charged the parse-error penalty even when complexity analysis did not run. The complexity object below carries its own file counts, which cover only the files that analysis saw, and `dead_code_files` counts the JavaScript/TypeScript files the dead code analysis covered, which is the divisor of the dead code penalty.
 
 `project_scale` is a size label derived from `analyzed_files`. See [Project scale](health-score.md#project-scale) for the thresholds. `total_loc` is the number of lines the clone analysis read, so it is `0` when clone analysis is turned off.
 


### PR DESCRIPTION
Closes #92.

`summary.skipped_files` and the parse-error penalty were populated only by the complexity analysis, so `polyscan analyze --select deadcode` on a tree with an unparsable file scored 100/100 with no warning while `--select complexity,deadcode` scored it 72/100.

- The JavaScript run keeps its file accounting on the project snapshot (`ProjectSnapshot.Accounting`), independent of which analyses ran, and `js.Result` carries it as `Files`.
- `report.Combine` returns `domain.AnalysisResults`, which bundles the responses with the file accounting summed across the generic engine and the JavaScript run. The formatter and `BuildAnalyzeSummary` take that struct instead of five positional responses.
- A single-analysis run still releases each parse tree after use: `NewProjectSnapshot` loads files inside the analysis fan-out, so the services' plain entry points become wrappers over it and `analyzeProjectFilesFromPaths` is gone.
- The CLI lists the skipped files from the run accounting rather than from the complexity errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYjVvccgT4VkYkwhpuU93