### PR TITLE
fix(engine): compute nesting depth for Go, Rust and C++

### DIFF
--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -35,8 +35,11 @@ type Function struct {
 	Complexity int `json:"complexity"`
 	// Decisions breaks the decision points down by kind. The kinds are
 	// defined per language.
-	Decisions map[string]int   `json:"decisions"`
-	RiskLevel domain.RiskLevel `json:"risk_level"`
+	Decisions map[string]int `json:"decisions"`
+	// NestingDepth is the deepest chain of nested control structures, with
+	// the function body at 0.
+	NestingDepth int              `json:"nesting_depth"`
+	RiskLevel    domain.RiskLevel `json:"risk_level"`
 }
 
 // ComplexitySummary aggregates every analyzed function. Report filters only
@@ -194,15 +197,16 @@ func countLines(content []byte) int {
 
 func newFunction(fn engine.Function, language *engine.Language, display string) Function {
 	return Function{
-		Name:        fn.Name,
-		FilePath:    display,
-		Language:    language.Name,
-		StartLine:   fn.StartLine,
-		StartColumn: fn.StartColumn,
-		EndLine:     fn.EndLine,
-		Complexity:  fn.Complexity,
-		Decisions:   fn.Decisions,
-		RiskLevel:   RiskLevel(fn.Complexity),
+		Name:         fn.Name,
+		FilePath:     display,
+		Language:     language.Name,
+		StartLine:    fn.StartLine,
+		StartColumn:  fn.StartColumn,
+		EndLine:      fn.EndLine,
+		Complexity:   fn.Complexity,
+		Decisions:    fn.Decisions,
+		NestingDepth: fn.NestingDepth,
+		RiskLevel:    RiskLevel(fn.Complexity),
 	}
 }
 

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -68,6 +68,14 @@ func TestAnalyzeComplexity(t *testing.T) {
 	if first.Language != "Go" || filepath.Base(first.FilePath) != "sample.go" {
 		t.Errorf("first function language=%q path=%q", first.Language, first.FilePath)
 	}
+	if first.NestingDepth != 1 {
+		t.Errorf("Server.Handle nesting depth = %d, want 1", first.NestingDepth)
+	}
+	for _, fn := range functions {
+		if fn.Name == "Closure" && fn.NestingDepth != 2 {
+			t.Errorf("Closure nesting depth = %d, want 2 (the literal's for and if count toward it)", fn.NestingDepth)
+		}
+	}
 	for i := 1; i < len(functions); i++ {
 		if functions[i].Complexity > functions[i-1].Complexity {
 			t.Errorf("functions are not sorted by descending complexity at %d", i)

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -47,6 +47,16 @@ type Language struct {
 	// that contains it and counted under the capture's name, so the capture
 	// names double as the breakdown reported next to the complexity.
 	Decisions string
+	// Nesting is a tree-sitter query whose captures are the constructs that
+	// open a nesting level: branches, loops, switches and try blocks. A
+	// capture named @continuation marks a construct that continues the
+	// level its parent opened rather than deepening it, as an if in the
+	// else arm of another if does. A function's nesting depth is the
+	// longest chain of these constructs inside it, with the function body
+	// at depth 0. Code inside a function that is extracted on its own
+	// belongs to that function; code inside a closure that is not counts
+	// toward the enclosing function, as its decision points do.
+	Nesting string
 	// Clone names the node types clone detection prices and compares.
 	Clone CloneSpec
 	// TestFiles names test files: a glob matches the file name, and a
@@ -63,6 +73,7 @@ type Language struct {
 	compileErr  error
 	definitions *sitter.Query
 	decisions   *sitter.Query
+	nesting     *sitter.Query
 	scopes      *sitter.Query
 	testCode    *sitter.Query
 	identifiers map[string]struct{}
@@ -117,6 +128,10 @@ type Function struct {
 	// Decisions breaks the decision points down by the name of the capture
 	// that produced them.
 	Decisions map[string]int
+	// NestingDepth is the deepest chain of nested control structures inside
+	// the function, per the language's Nesting query. It is 0 for a
+	// language without one.
+	NestingDepth int
 	// Tree is the function's syntax tree in the form the tree edit distance
 	// consumes: named nodes only, comments dropped, labeled per CloneSpec.
 	Tree *apted.TreeNode
@@ -136,11 +151,12 @@ type Function struct {
 }
 
 const (
-	definitionPrefix = "definition."
-	nameCapture      = "name"
-	receiverCapture  = "receiver"
-	scopeCapture     = "scope"
-	operatorField    = "operator"
+	definitionPrefix    = "definition."
+	nameCapture         = "name"
+	receiverCapture     = "receiver"
+	scopeCapture        = "scope"
+	continuationCapture = "continuation"
+	operatorField       = "operator"
 )
 
 func (l *Language) separator() string {
@@ -208,6 +224,7 @@ func (l *Language) Analyze(source []byte) (*Result, error) {
 	functions := l.extractFunctions(root, source)
 	l.applyScopes(root, source, functions)
 	l.countDecisions(root, source, functions)
+	l.measureNesting(root, source, functions)
 	l.markTests(root, source, functions)
 	for i := range functions {
 		functions[i].Complexity = 1
@@ -237,6 +254,14 @@ func (l *Language) compile() error {
 		if err != nil {
 			l.compileErr = fmt.Errorf("%s decisions query: %w", l.Name, err)
 			return
+		}
+		if l.Nesting != "" {
+			nesting, err := sitter.NewQuery([]byte(l.Nesting), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s nesting query: %w", l.Name, err)
+				return
+			}
+			l.nesting = nesting
 		}
 		if l.Scopes != "" {
 			scopes, err := sitter.NewQuery([]byte(l.Scopes), l.Grammar)
@@ -395,6 +420,46 @@ func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []
 				continue
 			}
 			fn.Decisions[l.decisions.CaptureNameForId(capture.Index)]++
+		}
+	})
+}
+
+// measureNesting sets each function's NestingDepth to the deepest chain of
+// nesting constructs inside it. Every construct the Nesting query captures
+// is attributed to the innermost function that contains it, and its depth
+// is the number of level-opening constructs on the path from it up to that
+// function, itself included. A construct in a nested function belongs to
+// the nested function alone, because that function is the innermost one
+// containing it.
+func (l *Language) measureNesting(root *sitter.Node, source []byte, functions []Function) {
+	if l.nesting == nil {
+		return
+	}
+	// levels maps each captured node to the levels it opens: one, or zero
+	// for a continuation.
+	levels := map[uintptr]int{}
+	forEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
+		for _, capture := range match.Captures {
+			id := capture.Node.ID()
+			if l.nesting.CaptureNameForId(capture.Index) == continuationCapture {
+				levels[id] = 0
+			} else if _, seen := levels[id]; !seen {
+				levels[id] = 1
+			}
+		}
+	})
+	forEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
+		for _, capture := range match.Captures {
+			node := capture.Node
+			fn := innermost(functions, node.StartByte(), node.EndByte())
+			if fn == nil {
+				continue
+			}
+			depth := 0
+			for n := node; n != nil && (n.StartByte() != fn.startByte || n.EndByte() != fn.endByte); n = n.Parent() {
+				depth += levels[n.ID()]
+			}
+			fn.NestingDepth = max(fn.NestingDepth, depth)
 		}
 	})
 }

--- a/polyscan/internal/lang/cpp/cpp.go
+++ b/polyscan/internal/lang/cpp/cpp.go
@@ -66,6 +66,18 @@ var Language = &engine.Language{
 (catch_clause) @exception
 (binary_expression operator: ["&&" "||"]) @logical_operator
 `,
+	// An if in the else arm of another if continues that if's chain. A
+	// catch clause is part of the try statement that already opened a level.
+	Nesting: `
+(if_statement) @nesting
+(if_statement alternative: (else_clause (if_statement) @continuation))
+(switch_statement) @nesting
+(for_statement) @nesting
+(for_range_loop) @nesting
+(while_statement) @nesting
+(do_statement) @nesting
+(try_statement) @nesting
+`,
 	Clone: engine.CloneSpec{
 		Identifiers: []string{
 			"identifier", "field_identifier", "type_identifier", "namespace_identifier",

--- a/polyscan/internal/lang/cpp/cpp.go
+++ b/polyscan/internal/lang/cpp/cpp.go
@@ -66,11 +66,16 @@ var Language = &engine.Language{
 (catch_clause) @exception
 (binary_expression operator: ["&&" "||"]) @logical_operator
 `,
-	// An if in the else arm of another if continues that if's chain. A
-	// catch clause is part of the try statement that already opened a level.
+	// An if in the else arm of another if continues that if's chain, also
+	// when an attribute such as [[likely]] wraps it in an
+	// attributed_statement. A catch clause is part of the try statement
+	// that already opened a level.
 	Nesting: `
 (if_statement) @nesting
-(if_statement alternative: (else_clause (if_statement) @continuation))
+(if_statement alternative: (else_clause [
+  (if_statement) @continuation
+  (attributed_statement (if_statement) @continuation)
+]))
 (switch_statement) @nesting
 (for_statement) @nesting
 (for_range_loop) @nesting

--- a/polyscan/internal/lang/cpp/cpp_test.go
+++ b/polyscan/internal/lang/cpp/cpp_test.go
@@ -176,3 +176,52 @@ int broken(int a) { if ( return a; }
 		t.Error("a function containing the error must not be analyzed")
 	}
 }
+
+func TestNestingDepth(t *testing.T) {
+	functions := analyze(t, `
+void flat(bool a) {
+    if (a) {}
+    while (a) {}
+}
+
+void else_if_continues_the_chain(bool a, bool b) {
+    if (a) {
+    } else if (b) {
+        for (;;) {}
+    } else {
+        if (a) { if (b) {} }
+    }
+}
+
+void deep(bool a, int xs[]) {
+    if (a) {
+        for (int x : xs) {
+            switch (x) {
+            case 1:
+                try { } catch (...) { do {} while (a); }
+            }
+        }
+    }
+}
+
+void lambda(bool a, bool b) {
+    auto l = [&] { if (a) { if (b) {} } };
+}
+`)
+	want := map[string]int{
+		"flat":                        1,
+		"else_if_continues_the_chain": 3,
+		"deep":                        5,
+		"lambda":                      2,
+	}
+	for name, depth := range want {
+		fn, ok := functions[name]
+		if !ok {
+			t.Errorf("missing function %q", name)
+			continue
+		}
+		if fn.NestingDepth != depth {
+			t.Errorf("%s: nesting depth = %d, want %d", name, fn.NestingDepth, depth)
+		}
+	}
+}

--- a/polyscan/internal/lang/cpp/cpp_test.go
+++ b/polyscan/internal/lang/cpp/cpp_test.go
@@ -193,6 +193,13 @@ void else_if_continues_the_chain(bool a, bool b) {
     }
 }
 
+void attributed_else_if_continues_the_chain(bool a, bool b) {
+    if (a) {
+    } else [[likely]] if (b) {
+        while (b) {}
+    }
+}
+
 void deep(bool a, int xs[]) {
     if (a) {
         for (int x : xs) {
@@ -209,10 +216,11 @@ void lambda(bool a, bool b) {
 }
 `)
 	want := map[string]int{
-		"flat":                        1,
-		"else_if_continues_the_chain": 3,
-		"deep":                        5,
-		"lambda":                      2,
+		"flat":                                   1,
+		"else_if_continues_the_chain":            3,
+		"attributed_else_if_continues_the_chain": 2,
+		"deep":                                   5,
+		"lambda":                                 2,
 	}
 	for name, depth := range want {
 		fn, ok := functions[name]

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -50,6 +50,15 @@ var Language = &engine.Language{
 (communication_case) @case
 (binary_expression operator: ["&&" "||"]) @logical_operator
 `,
+	// An if in the else arm of another if continues that if's chain.
+	Nesting: `
+(if_statement) @nesting
+(if_statement alternative: (if_statement) @continuation)
+(for_statement) @nesting
+(expression_switch_statement) @nesting
+(type_switch_statement) @nesting
+(select_statement) @nesting
+`,
 	Clone: engine.CloneSpec{
 		Identifiers: []string{"identifier", "field_identifier", "type_identifier", "package_identifier", "label_name"},
 		Literals: []string{

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -152,3 +152,63 @@ func TestContentDropsCommentsButKeepsTokensApart(t *testing.T) {
 		t.Errorf("code lines = %d, want 3", fn.CodeLines)
 	}
 }
+
+func TestNestingDepth(t *testing.T) {
+	functions := analyze(t, `package p
+
+func Flat(a bool) {
+	if a {
+	}
+	for {
+	}
+}
+
+func ElseIfContinuesTheChain(a, b bool) {
+	if a {
+	} else if b {
+		for {
+		}
+	} else {
+		if a {
+			if b {
+			}
+		}
+	}
+}
+
+func Deep(a bool, xs []int) {
+	if a {
+		for _, x := range xs {
+			switch x {
+			case 1:
+				select {
+				default:
+				}
+			}
+		}
+	}
+}
+
+func Closure(a, b bool) func() {
+	return func() {
+		for {
+			if a {
+				if b {
+				}
+			}
+		}
+	}
+}
+`)
+	want := map[string]int{
+		"Flat":                    1,
+		"ElseIfContinuesTheChain": 3,
+		"Deep":                    4,
+		"Closure":                 3,
+	}
+	for name, depth := range want {
+		if got := functions[name].NestingDepth; got != depth {
+			t.Errorf("%s: nesting depth = %d, want %d", name, got, depth)
+		}
+	}
+}

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -67,10 +67,12 @@ var Language = &engine.Language{
 (let_chain "&&" @logical_operator)
 (try_expression) @try_operator
 `,
-	// An if in the else arm of another if continues that if's chain.
+	// An if in the else arm of another if continues that if's chain. The
+	// else block of a let-else is one level deep, as it branches.
 	Nesting: `
 (if_expression) @nesting
 (if_expression alternative: (else_clause (if_expression) @continuation))
+(let_declaration alternative: (_)) @nesting
 (match_expression) @nesting
 (for_expression) @nesting
 (while_expression) @nesting

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -67,6 +67,15 @@ var Language = &engine.Language{
 (let_chain "&&" @logical_operator)
 (try_expression) @try_operator
 `,
+	// An if in the else arm of another if continues that if's chain.
+	Nesting: `
+(if_expression) @nesting
+(if_expression alternative: (else_clause (if_expression) @continuation))
+(match_expression) @nesting
+(for_expression) @nesting
+(while_expression) @nesting
+(loop_expression) @nesting
+`,
 	Clone: engine.CloneSpec{
 		Identifiers: []string{
 			"identifier", "field_identifier", "type_identifier", "shorthand_field_identifier",

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -226,6 +226,13 @@ fn deep(a: bool, xs: Vec<i32>) {
     }
 }
 
+fn let_else(value: Option<i32>, retry: bool) {
+    let Some(_value) = value else {
+        if retry {}
+        return;
+    };
+}
+
 fn outer(a: bool) {
     fn inner(a: bool) {
         if a { if a { if a {} } }
@@ -237,6 +244,7 @@ fn outer(a: bool) {
 		"flat":                        1,
 		"else_if_continues_the_chain": 3,
 		"deep":                        4,
+		"let_else":                    2,
 		"outer":                       2,
 		"inner":                       3,
 	}

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -198,3 +198,56 @@ func TestTestFiles(t *testing.T) {
 		}
 	}
 }
+
+func TestNestingDepth(t *testing.T) {
+	functions := analyze(t, `
+fn flat(a: bool) {
+    if a {}
+    loop { break; }
+}
+
+fn else_if_continues_the_chain(a: bool, b: bool) {
+    if a {
+    } else if b {
+        while b {}
+    } else {
+        if a { if b {} }
+    }
+}
+
+fn deep(a: bool, xs: Vec<i32>) {
+    if a {
+        for x in xs {
+            match x {
+                1 => { if let Some(_) = Some(x) {} }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn outer(a: bool) {
+    fn inner(a: bool) {
+        if a { if a { if a {} } }
+    }
+    let closure = || { if a { if a {} } };
+}
+`)
+	want := map[string]int{
+		"flat":                        1,
+		"else_if_continues_the_chain": 3,
+		"deep":                        4,
+		"outer":                       2,
+		"inner":                       3,
+	}
+	for name, depth := range want {
+		fn, ok := functions[name]
+		if !ok {
+			t.Errorf("missing function %q", name)
+			continue
+		}
+		if fn.NestingDepth != depth {
+			t.Errorf("%s: nesting depth = %d, want %d", name, fn.NestingDepth, depth)
+		}
+	}
+}

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -69,7 +69,7 @@ func genericComplexity(report *analysis.Report) (*domain.ComplexityResponse, err
 			StartLine:   fn.StartLine,
 			StartColumn: fn.StartColumn,
 			EndLine:     fn.EndLine,
-			Metrics:     domain.ComplexityMetrics{Complexity: fn.Complexity},
+			Metrics:     domain.ComplexityMetrics{Complexity: fn.Complexity, NestingDepth: fn.NestingDepth},
 			RiskLevel:   domain.RiskLevel(fn.RiskLevel),
 		})
 		distribution[fn.Complexity]++

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -18,7 +18,7 @@ func genericReport() *analysis.Report {
 		Files: analysis.Files{Total: 3, Analyzed: 2, Skipped: 1},
 		Complexity: &analysis.Complexity{
 			Functions: []analysis.Function{
-				{Name: "Sum", FilePath: "a.go", Language: "Go", StartLine: 1, EndLine: 10, Complexity: 12, RiskLevel: coredomain.RiskLevelMedium},
+				{Name: "Sum", FilePath: "a.go", Language: "Go", StartLine: 1, EndLine: 10, Complexity: 12, NestingDepth: 3, RiskLevel: coredomain.RiskLevelMedium},
 				{Name: "Add", FilePath: "b.go", Language: "Go", StartLine: 5, EndLine: 14, Complexity: 2, RiskLevel: coredomain.RiskLevelLow},
 			},
 			Summary: analysis.ComplexitySummary{
@@ -64,7 +64,7 @@ func TestCombineGenericOnly(t *testing.T) {
 		t.Fatalf("functions = %+v", complexity.Functions)
 	}
 	first := complexity.Functions[0]
-	if first.Language != "Go" || first.Metrics.Complexity != 12 || first.RiskLevel != domain.RiskLevelMedium {
+	if first.Language != "Go" || first.Metrics.Complexity != 12 || first.Metrics.NestingDepth != 3 || first.RiskLevel != domain.RiskLevelMedium {
 		t.Errorf("converted function = %+v", first)
 	}
 	summary := complexity.Summary

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -134,7 +134,7 @@ Each entry in `functions` looks like this:
     "complexity": 4,
     "nodes": 0,
     "edges": 0,
-    "nesting_depth": 0,
+    "nesting_depth": 2,
     "if_statements": 0,
     "loop_statements": 0,
     "exception_handlers": 0,
@@ -146,7 +146,7 @@ Each entry in `functions` looks like this:
 
 `language` names the language the function was analyzed as: `JavaScript`, `TypeScript`, `Go`, `Rust`, or `C++`.
 
-For JavaScript/TypeScript functions, `nodes` and `edges` describe the control flow graph the complexity was derived from, and `nesting_depth` is the deepest chain of nested control structures in the function: an `else if` continues the chain its `if` opened rather than starting a deeper one, a `catch` clause stays at the level of its `try`, and nested functions are measured separately. For the other languages the graph and statement-breakdown fields are `0`, because their complexity is counted from decision points rather than a control flow graph. `risk_level` is `low`, `medium`, or `high`.
+`nesting_depth` is the deepest chain of nested control structures in the function, in every language: the function body is depth 0, an `else if` continues the chain its `if` opened rather than starting a deeper one, a `catch` clause stays at the level of its `try`, and a nested function is measured separately. A Go function literal, a Rust closure or a C++ lambda is not a separate function, so the control structures inside it count toward the function that contains it. For JavaScript/TypeScript functions, `nodes` and `edges` describe the control flow graph the complexity was derived from. For the other languages the graph and statement-breakdown fields are `0`, because their complexity is counted from decision points rather than a control flow graph. `risk_level` is `low`, `medium`, or `high`.
 
 File paths for JavaScript/TypeScript are reported exactly as polyscan resolved them, which means they are absolute when you passed an absolute path and relative when you passed a relative one. Go, Rust and C++ paths are shortened to be relative to the working directory when the file lies under it.
 


### PR DESCRIPTION
Closes #94.

The generic engine never computed nesting depth, so the directory complexity rows for Go, Rust and C++ always printed `Nesting: avg 0.00, max 0`.

Each language now declares a `Nesting` tree-sitter query, and the engine measures a function's depth with the JS analyzer's definition: the function body is depth 0, an `else if` continues the chain its outer `if` opened, and code inside a function that is extracted on its own belongs to that function. Code inside a closure that is not extracted counts toward the enclosing function, as its decision points already do.

The depth is threaded through `analysis.Function` (`nesting_depth` in JSON) into the report's per-function metrics, so the directory rollups and the HTML deepest-nesting stat pick it up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYjVvccgT4VkYkwhpuU93