### PR TITLE
fix(score): saturate the complexity penalty at 30% instead of 5%

### DIFF
--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- The complexity penalty saturated once 5 percent of functions were medium or high risk, so a mostly clean codebase with a few complex functions scored 0/100 on complexity. It now saturates at 30 percent, matching the documented intent (#96)
+- The complexity penalty saturated once the weighted ratio of medium and high risk functions reached 5 percent, so a mostly clean codebase with a few complex functions scored 0/100 on complexity. It now saturates at 30 percent, matching the documented intent, and any function above the medium threshold costs at least one point so the score only reads 100 when no function is at risk (#96)
 
 ## [0.2.0] - 2026-09-03
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- The complexity penalty saturated once 5 percent of functions were medium or high risk, so a mostly clean codebase with a few complex functions scored 0/100 on complexity. It now saturates at 30 percent, matching the documented intent (#96)
+
 ## [0.2.0] - 2026-09-03
 
 ### Added

--- a/polyscan/internal/js/domain/analyze.go
+++ b/polyscan/internal/js/domain/analyze.go
@@ -33,6 +33,14 @@ const (
 	CouplingMediumWeight    = coredomain.CouplingMediumWeight
 	CouplingSaturationRatio = coredomain.CouplingSaturationRatio
 
+	// Complexity scoring curve (used by calculateComplexityPenalty)
+	// Penalty grows linearly with the weighted ratio of high and medium risk
+	// functions and saturates at ComplexitySaturationRatio. The ratio is
+	// wide enough that a few complex functions in an otherwise clean
+	// codebase cost a few points rather than the whole dimension (#96).
+	ComplexityMediumWeight    = 0.5  // Medium-risk functions count 0.5 vs High = 1.0
+	ComplexitySaturationRatio = 0.30 // weighted ratio at which the penalty maxes out
+
 	// Maximum penalties
 	MaxDeadCodePenalty = coredomain.MaxDeadCodePenalty
 	MaxCriticalPenalty = coredomain.MaxCriticalPenalty
@@ -281,18 +289,18 @@ func (s *AnalyzeSummary) calculateParseErrorPenalty() int {
 
 // calculateComplexityPenalty calculates the penalty for complexity (max 20)
 // Uses ratio of high/medium complexity functions (ESLint-aligned: high > 20, medium 10-20)
-// Weight: High = 1.0, Medium = 0.5
-// Reaches max penalty when 30% or more functions are problematic
+// Weight: High = 1.0, Medium = ComplexityMediumWeight
+// Reaches max penalty at a weighted ratio of ComplexitySaturationRatio
 func (s *AnalyzeSummary) calculateComplexityPenalty() int {
 	if s.TotalFunctions == 0 {
 		return 0
 	}
 
 	// Weighted ratio of problematic functions
-	weighted := float64(s.HighComplexityCount) + 0.5*float64(s.MediumComplexityCount)
+	weighted := float64(s.HighComplexityCount) + ComplexityMediumWeight*float64(s.MediumComplexityCount)
 	ratio := weighted / float64(s.TotalFunctions)
 
-	return coredomain.LinearPenalty(ratio, 0, 0.05)
+	return coredomain.LinearPenalty(ratio, 0, ComplexitySaturationRatio)
 }
 
 // calculateDeadCodePenalty calculates the penalty for dead code (max 20)

--- a/polyscan/internal/js/domain/analyze.go
+++ b/polyscan/internal/js/domain/analyze.go
@@ -298,9 +298,15 @@ func (s *AnalyzeSummary) calculateComplexityPenalty() int {
 
 	// Weighted ratio of problematic functions
 	weighted := float64(s.HighComplexityCount) + ComplexityMediumWeight*float64(s.MediumComplexityCount)
+	if weighted <= 0 {
+		return 0
+	}
 	ratio := weighted / float64(s.TotalFunctions)
 
-	return coredomain.LinearPenalty(ratio, 0, ComplexitySaturationRatio)
+	// LinearPenalty rounds to whole points, which would let a large codebase
+	// with a few risky functions round down to a clean 100. Any function
+	// above the medium threshold costs at least one point.
+	return max(1, coredomain.LinearPenalty(ratio, 0, ComplexitySaturationRatio))
 }
 
 // calculateDeadCodePenalty calculates the penalty for dead code (max 20)

--- a/polyscan/internal/js/domain/analyze_test.go
+++ b/polyscan/internal/js/domain/analyze_test.go
@@ -233,9 +233,9 @@ func TestCalculateHealthScore_MissingDimensionsLeftOut(t *testing.T) {
 		TotalFunctions:    100,
 		TotalFiles:        10,
 		AnalyzedFiles:     10,
-		// 3 high + 2*0.5 medium = 4% weighted ratio -> penalty 16 of 20
-		HighComplexityCount:   3,
-		MediumComplexityCount: 2,
+		// 20 high + 8*0.5 medium = 24% weighted ratio -> penalty 16 of 20
+		HighComplexityCount:   20,
+		MediumComplexityCount: 8,
 		// 15% duplication -> penalty 10 of 20
 		CodeDuplication: 15.0,
 	}
@@ -246,6 +246,42 @@ func TestCalculateHealthScore_MissingDimensionsLeftOut(t *testing.T) {
 	// missing dimensions would have given 100 - 26 = 74 instead.
 	if s.HealthScore != 35 || s.Grade != "F" {
 		t.Errorf("HealthScore = %d (%s), want 35 (F)", s.HealthScore, s.Grade)
+	}
+}
+
+// TestCalculateHealthScore_ComplexityPenaltyCurve pins the complexity curve
+// from #96: a handful of complex functions in a mostly clean codebase costs a
+// few points, and only a codebase where 30% of the functions are high risk
+// takes the full penalty.
+func TestCalculateHealthScore_ComplexityPenaltyCurve(t *testing.T) {
+	tests := []struct {
+		name           string
+		total          int
+		high, medium   int
+		wantComplexity int
+	}{
+		// ky: 128 functions, 5 high and 8 medium, a weighted ratio of 7%.
+		{name: "ky", total: 128, high: 5, medium: 8, wantComplexity: 75},
+		{name: "one high function in twenty", total: 20, high: 1, wantComplexity: 85},
+		{name: "half of the functions medium", total: 100, medium: 50, wantComplexity: 15},
+		{name: "30% high saturates", total: 100, high: 30, wantComplexity: 0},
+		{name: "beyond saturation stays at the floor", total: 100, high: 80, medium: 20, wantComplexity: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := &AnalyzeSummary{
+				ComplexityEnabled:     true,
+				TotalFunctions:        tt.total,
+				HighComplexityCount:   tt.high,
+				MediumComplexityCount: tt.medium,
+			}
+			if err := s.CalculateHealthScore(); err != nil {
+				t.Fatalf("CalculateHealthScore() error: %v", err)
+			}
+			if s.ComplexityScore != tt.wantComplexity {
+				t.Errorf("ComplexityScore = %d, want %d", s.ComplexityScore, tt.wantComplexity)
+			}
+		})
 	}
 }
 

--- a/polyscan/internal/js/domain/analyze_test.go
+++ b/polyscan/internal/js/domain/analyze_test.go
@@ -263,6 +263,10 @@ func TestCalculateHealthScore_ComplexityPenaltyCurve(t *testing.T) {
 		// ky: 128 functions, 5 high and 8 medium, a weighted ratio of 7%.
 		{name: "ky", total: 128, high: 5, medium: 8, wantComplexity: 75},
 		{name: "one high function in twenty", total: 20, high: 1, wantComplexity: 85},
+		// Below half a point the linear curve rounds to 0; one point is charged instead.
+		{name: "one high function in 134 costs a point", total: 134, high: 1, wantComplexity: 95},
+		{name: "one medium function in 1000 costs a point", total: 1000, medium: 1, wantComplexity: 95},
+		{name: "no risky functions is clean", total: 1000, wantComplexity: 100},
 		{name: "half of the functions medium", total: 100, medium: 50, wantComplexity: 15},
 		{name: "30% high saturates", total: 100, high: 30, wantComplexity: 0},
 		{name: "beyond saturation stays at the floor", total: 100, high: 80, medium: 20, wantComplexity: 0},

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -106,7 +106,7 @@ The coupling analysis produces one entry per file, named after the module. The l
 
 Grade A starts at 90 and grade B at 75. In practice, treat the category scores as more actionable than the total, because each category saturates at a different point and the total hides which one is costing you.
 
-The complexity category saturates fastest. Its penalty maxes out once the weighted ratio of problematic functions reaches 5 percent, so a handful of high complexity functions in a small codebase can max it out alone.
+Each category saturates at a different point. The complexity penalty maxes out once the weighted ratio of problematic functions reaches 30 percent, so a handful of high complexity functions cost a few points rather than the whole category. In a very small codebase the same handful is a large share of the population, so the category score moves faster there.
 
 ### Why is `architecture_score` always 0?
 

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -78,10 +78,10 @@ Four of the dimensions use the same shape. A ratio is computed, and the penalty 
 
 ```text
 ratio   = (high risk functions + 0.5 × medium risk functions) ÷ total functions
-penalty = 20 × ratio ÷ 0.05, capped at 20
+penalty = 20 × ratio ÷ 0.30, capped at 20
 ```
 
-The penalty reaches its maximum once the weighted ratio hits 5 percent. That is a demanding target: a codebase where one function in twenty is high risk already receives the full 20 point penalty. Medium risk functions count half as much as high risk ones. The population covers every analyzed function in every language.
+The penalty reaches its maximum once the weighted ratio hits 30 percent. A codebase where one function in twenty is high risk loses about 3 of the 20 points, and one where every third function is high risk loses all of them. Medium risk functions count half as much as high risk ones. The population covers every analyzed function in every language.
 
 Which functions count as high or medium risk depends on the thresholds, so for JavaScript/TypeScript raising `complexity.medium_threshold` raises the score without changing any code.
 
@@ -110,7 +110,7 @@ ratio   = (high coupling modules + 0.3 × medium coupling modules) ÷ total modu
 penalty = 20 × ratio ÷ 0.40, capped at 20
 ```
 
-Medium risk modules are weighted at 0.3 rather than 0.5, which is more forgiving than the complexity weighting. The penalty saturates when the weighted ratio reaches 40 percent.
+Medium risk modules are weighted at 0.3 rather than 0.5, which is more forgiving than the complexity weighting. The penalty saturates when the weighted ratio reaches 40 percent, slightly later than the complexity penalty.
 
 ### Dependencies
 
@@ -192,4 +192,4 @@ The dead code figure is the one worth following through. The weighted finding co
 
 Because every dimension saturates, the fastest gains come from whichever dimension is furthest from zero rather than from whichever has the most raw findings. A project with a dead code score of 65 and a complexity score of 100 should fix dead code first, even if it has far more functions than findings.
 
-The dimensions also differ in how quickly they saturate. Complexity saturates at a weighted ratio of 5 percent, which is by far the tightest of the four. A handful of high complexity functions in a small codebase can max out that penalty on its own.
+The dimensions also differ in how quickly they saturate. Complexity saturates at a weighted ratio of 30 percent and coupling at 40 percent, so a handful of complex functions costs a few points, while a single unparsable file costs at least 11.

--- a/website/docs/output/health-score.md
+++ b/website/docs/output/health-score.md
@@ -78,10 +78,10 @@ Four of the dimensions use the same shape. A ratio is computed, and the penalty 
 
 ```text
 ratio   = (high risk functions + 0.5 × medium risk functions) ÷ total functions
-penalty = 20 × ratio ÷ 0.30, capped at 20
+penalty = 20 × ratio ÷ 0.30, capped at 20, at least 1 when ratio > 0
 ```
 
-The penalty reaches its maximum once the weighted ratio hits 30 percent. A codebase where one function in twenty is high risk loses about 3 of the 20 points, and one where every third function is high risk loses all of them. Medium risk functions count half as much as high risk ones. The population covers every analyzed function in every language.
+The penalty reaches its maximum once the weighted ratio hits 30 percent. It never rounds down to 0 while any function is above the medium threshold, so a complexity score of 100 means every function is low risk. A codebase where one function in twenty is high risk loses about 3 of the 20 points, and one where every third function is high risk loses all of them. Medium risk functions count half as much as high risk ones. The population covers every analyzed function in every language.
 
 Which functions count as high or medium risk depends on the thresholds, so for JavaScript/TypeScript raising `complexity.medium_threshold` raises the score without changing any code.
 


### PR DESCRIPTION
The complexity penalty was `LinearPenalty(ratio, 0, 0.05)`, so a weighted ratio of 5% already took the full 20 points and ky, Fastify and Express scored 0 to 50 on complexity despite being mostly low risk. The saturation ratio is now a named constant at 0.30, which is what the function's own comment claimed. On the ky example from the issue the complexity score goes from 0 to 75.

Tests pin the new curve, and the health score page, FAQ and changelog describe it.

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HQYjVvccgT4VkYkwhpuU93