### PR TITLE
fix(core): report clones from similarity 0.80 and saturate duplication at 60%

### DIFF
--- a/core/domain/defaults.go
+++ b/core/domain/defaults.go
@@ -1,6 +1,17 @@
 package domain
 
 // Clone type thresholds (similarity score 0.0-1.0).
+//
+// Type-2 and Type-3 share one threshold on purpose. The detector reports pairs
+// from the Type-3 threshold, so a lower Type-2 threshold would classify pairs
+// that are then never reported. What separates the two types is the syntactic
+// gate, not the similarity: a pair at or above 0.80 whose normalized trees
+// also match is Type-2, otherwise Type-3. Pairs between 0.70 and 0.80 were
+// mostly functions that share a shape rather than code, such as two output
+// formatters' switch statements, which is why the floor moved up from 0.70.
+// The JavaScript/TypeScript analyzer keeps its own thresholds in
+// polyscan/internal/js/constants; they were tuned separately and Type-3 is
+// off by default there.
 const (
 	DefaultType1CloneThreshold = 0.85
 	DefaultType2CloneThreshold = 0.80

--- a/core/domain/defaults.go
+++ b/core/domain/defaults.go
@@ -3,8 +3,8 @@ package domain
 // Clone type thresholds (similarity score 0.0-1.0).
 const (
 	DefaultType1CloneThreshold = 0.85
-	DefaultType2CloneThreshold = 0.75
-	DefaultType3CloneThreshold = 0.70
+	DefaultType2CloneThreshold = 0.80
+	DefaultType3CloneThreshold = 0.80
 	DefaultType4CloneThreshold = 0.65
 )
 

--- a/core/domain/scoring.go
+++ b/core/domain/scoring.go
@@ -16,9 +16,13 @@ const (
 	ComplexityPenaltyLow      = 6
 
 	// Code duplication thresholds and penalties
-	// 0% = perfect, 30% = max penalty (using fragment ratio: clonedFragments/totalFragments)
-	DuplicationThresholdHigh   = 30.0
-	DuplicationThresholdMedium = 15.0
+	// 0% = perfect, 60% = max penalty (using fragment ratio: clonedFragments/totalFragments).
+	// The fragment ratio counts every function of ten or more lines that has any
+	// partner at or above the Type-3 threshold, so it runs high on languages with
+	// conventional function shapes: cobra, x/crypto and polyscan itself sit near
+	// 20%, and testify and afero near 35%.
+	DuplicationThresholdHigh   = 60.0
+	DuplicationThresholdMedium = 30.0
 	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12
@@ -91,7 +95,7 @@ func LinearPenalty(value, start, saturation float64) int {
 }
 
 // DuplicationPenalty calculates the penalty for code duplication (max 20).
-// Linear: 0% duplication = 0 penalty, DuplicationThresholdHigh (30%) = max.
+// Linear: 0% duplication = 0 penalty, DuplicationThresholdHigh (60%) = max.
 // A NaN percentage is treated as missing data and yields no penalty.
 func DuplicationPenalty(duplicationPercent float64) int {
 	if math.IsNaN(duplicationPercent) || duplicationPercent <= DuplicationThresholdLow {

--- a/core/domain/scoring.go
+++ b/core/domain/scoring.go
@@ -20,9 +20,14 @@ const (
 	// The fragment ratio counts every function of ten or more lines that has any
 	// partner at or above the Type-3 threshold, so it runs high on languages with
 	// conventional function shapes: cobra, x/crypto and polyscan itself sit near
-	// 20%, and testify and afero near 35%.
+	// 20%, and testify and afero near 35%. Real duplication still saturates:
+	// pyscn's app/ directory of near-identical use cases sits at 54% and six
+	// renamed copies of one file at 100%.
+	// DuplicationThresholdMedium and the three penalty constants are unused by
+	// DuplicationPenalty, which is linear from Low to High; they are kept only
+	// because pyscn aliases them.
 	DuplicationThresholdHigh   = 60.0
-	DuplicationThresholdMedium = 30.0
+	DuplicationThresholdMedium = 15.0
 	DuplicationThresholdLow    = 0.0
 	DuplicationPenaltyHigh     = 20
 	DuplicationPenaltyMedium   = 12

--- a/core/domain/scoring_test.go
+++ b/core/domain/scoring_test.go
@@ -36,6 +36,14 @@ func TestDuplicationPenalty(t *testing.T) {
 	if p := DuplicationPenalty(90.0); p != 20 {
 		t.Errorf("90%%: got %d, want 20 (capped)", p)
 	}
+	// Real duplication must still bottom out: a directory of near-identical
+	// use cases measures about 54% and renamed copies of one file 100%.
+	if p := DuplicationPenalty(54.0); p < 18 {
+		t.Errorf("54%%: got %d, want at least 18", p)
+	}
+	if p := DuplicationPenalty(100.0); p != 20 {
+		t.Errorf("100%%: got %d, want 20", p)
+	}
 }
 
 func TestParseErrorPenalty(t *testing.T) {

--- a/core/domain/scoring_test.go
+++ b/core/domain/scoring_test.go
@@ -27,11 +27,11 @@ func TestDuplicationPenalty(t *testing.T) {
 	if p := DuplicationPenalty(0.0); p != 0 {
 		t.Errorf("0%%: got %d, want 0", p)
 	}
-	if p := DuplicationPenalty(15.0); p != 10 {
-		t.Errorf("15%%: got %d, want 10", p)
+	if p := DuplicationPenalty(30.0); p != 10 {
+		t.Errorf("30%%: got %d, want 10", p)
 	}
-	if p := DuplicationPenalty(30.0); p != 20 {
-		t.Errorf("30%%: got %d, want 20", p)
+	if p := DuplicationPenalty(60.0); p != 20 {
+		t.Errorf("60%%: got %d, want 20", p)
 	}
 	if p := DuplicationPenalty(90.0); p != 20 {
 		t.Errorf("90%%: got %d, want 20 (capped)", p)


### PR DESCRIPTION
Stopgap for the duplication score. On Go repositories the fragment ratio saturates far too early: with the current settings cobra and polyscan score 25/100 and testify and afero 0/100 on duplication, and pyscn scores 0/100.

Two constants change in `core/domain`:

- `DefaultType2CloneThreshold` and `DefaultType3CloneThreshold` go from 0.75 / 0.70 to 0.80. Pairs between 0.70 and 0.80 were mostly functions that share a shape rather than code (two formatters' `switch` statements, two preset-returning literal functions). The two are equal on purpose: the detector reports from the Type-3 threshold, so a lower Type-2 threshold would classify pairs that are never reported; the syntactic gate is what separates the types.
- `DuplicationThresholdHigh` goes from 30 to 60 percent. `DuplicationThresholdMedium` and the penalty constants are unused by `DuplicationPenalty` and are left as they were.

The JavaScript/TypeScript analyzer keeps its own thresholds in `polyscan/internal/js/constants` (0.75 / 0.70, Type-3 off by default). They were tuned separately and no JS calibration was run here; only the saturation change reaches JS scores. Unifying the two constant sets is a separate cleanup.

Scores with polyscan 0.2.1 before and after, non-test fragments:

| repo | before | after | ratio after |
| --- | --- | --- | --- |
| pyscn | 0 | 60 | 24.3% |
| polyscan | 25 | 70 | 18.8% |
| cobra | 25 | 70 | 16.8% |
| x/crypto | 45 | 80 | 12.1% |
| testify | 0 | 50 | 30.2% |
| afero | 0 | 30 | 42.9% |

Real duplication still bottoms out with the wider scale:

| input | ratio | score |
| --- | --- | --- |
| pyscn `app/` alone (near-identical use cases) | 53.7% | 10 |
| one file copied six times with renamed identifiers | 100% | 0 |

Follow-up after merge: tag `core/v0.2.6`, then a second PR bumps `polyscan/go.mod`, updates the polyscan tests, the stale 30% comment in `polyscan/internal/js/domain/analyze.go`, README, CHANGELOG and website docs (patch already prepared), and pyscn-bot bumps `POLYSCAN_VERSION`.

Proper fixes left for later: weight the ratio by similarity, drop shape-only Type-3 matches, and check the Python fragment count in pyscn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr
