### PR TITLE
feat(polyscan): dependency analysis for Go packages

### DIFF
--- a/.claude/skills/polyscan-fp-audit/SKILL.md
+++ b/.claude/skills/polyscan-fp-audit/SKILL.md
@@ -75,12 +75,12 @@ The single `analyze.json` holds every analysis under these top-level keys:
 | `clone` | all | `.clone.clone_pairs[]` → `clone1`/`clone2` (`language`, `location.{file_path,start_line,end_line}`, `content`, `line_count`), `similarity`, `type`; `.clone.clone_groups[]` |
 | `dead_code` | JS/TS only | `.dead_code.files[].functions[].findings[]` → `location`, `reason`, `severity`, `description` |
 | `cbo` | JS/TS only | `.cbo.classes[]` → `Name`, `FilePath`, `Metrics.CouplingCount`, `RiskLevel` |
-| `deps` | JS/TS only | `.deps.analysis`, `.deps.graph` |
+| `deps` | Go, JS/TS | `.deps.analysis`, `.deps.graph` (Go nodes are packages keyed by import path) |
 | `summary` | — | `health_score`, `grade`, `total_loc`, `total_files`, `skipped_files`, per-dimension scores |
 
 To narrow scope, add `--select complexity,deadcode,clone,cbo,deps`.
 
-**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected.
+**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected. For Go `deps.analysis.CircularDependencies` is always empty (the compiler forbids import cycles), Go edges carry no `location`, and Go files outside any `go.mod`, `_test.go` files, and `vendor`/`testdata` directories are absent from the graph by design.
 
 ### 4. Cluster findings
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Every analyzer scores your codebase (0-100 with an A-F grade) and generates an H
 |---|---|:-:|:-:|:-:|:-:|:-:|---|
 | JavaScript / TypeScript | `.js` `.jsx` `.mjs` `.cjs` `.ts` `.tsx` `.mts` `.cts` | ✅ | ✅ | ✅ | ✅ | ✅ CBO | `polyscan` |
 | Python | `.py` | ✅ | ✅ | ✅ | ✅ | ✅ CBO, LCOM | `pyscn` |
-| Go | `.go` | ✅ | ✅ | — | — | — | `polyscan` |
+| Go | `.go` | ✅ | ✅ | — | ✅ | — | `polyscan` |
 | Rust | `.rs` | ✅ | ✅ | — | — | — | `polyscan` |
 | C++ | `.cpp` `.cc` `.cxx` `.hpp` `.hh` `.hxx` `.h` `.ipp` `.inl` | ✅ | ✅ | — | — | — | `polyscan` |
 
-Complexity and duplicate code cover every language. Dead code, dependencies and class design need the import graph and class model that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
+Complexity and duplicate code cover every language. Dependencies cover Go, JavaScript/TypeScript and Python: for Go the nodes are packages, resolved through `go.mod`. Dead code and class design need the class model and the file-level import graph that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
 
 ## Polyscan for GitHub
 

--- a/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze JavaScript/TypeScript module architecture using polyscan - 
 
 # Architecture Review with polyscan
 
-Run the polyscan CLI to understand module structure and coupling. Coupling (CBO) and dependency analysis exist for JavaScript/TypeScript; other languages get complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
+Run the polyscan CLI to understand module structure and coupling. Dependency analysis exists for Go (package graph) and JavaScript/TypeScript (module graph); coupling (CBO) for JavaScript/TypeScript; Rust and C++ get complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
 
 ## Commands
 

--- a/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
@@ -24,7 +24,7 @@ polyscan analyze --min-complexity 10 .        # list only functions at or above 
 Key flags:
 
 - `--format html|json|text` (`-f`): output format; `json` and `text` write to stdout instead of an HTML report
-- `--select` (`-s`): `complexity,deadcode,clone,cbo,deps` (all run by default); `deadcode`, `cbo` and `deps` apply to JavaScript/TypeScript only
+- `--select` (`-s`): `complexity,deadcode,clone,cbo,deps` (all run by default); `deps` applies to Go and JavaScript/TypeScript; `deadcode` and `cbo` to JavaScript/TypeScript only
 - `--no-open`: don't auto-open the HTML report in a browser (use in scripts)
 - `-o <path>`: HTML report path (default: `polyscan-report.html` in the current directory)
 - `--min-complexity <n>`: hide functions below this complexity from the listing (scores still cover everything)
@@ -33,7 +33,7 @@ With `--format json`, the machine-readable results go to stdout and the health-s
 
 ## Language coverage
 
-Complexity and clone detection cover every supported language. Dead code, coupling (CBO) and dependency analysis exist for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
+Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Dead code and coupling (CBO) exist for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
 ## CI usage
 

--- a/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
@@ -26,7 +26,7 @@ For machine-readable detail use `--format json`: full results go to stdout and t
 ## Interpreting Results
 
 - Score 0-100 with letter grade; category scores cover complexity, dead code, code duplication, coupling (CBO), and dependencies.
-- Complexity and duplication cover every language; dead code, coupling and dependencies run for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
+- Complexity and duplication cover every language; dependencies run for Go and JavaScript/TypeScript; dead code and coupling for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
 - Lead with the grade and the weakest categories, then name the top offenders (files/functions) driving them.
 - For deeper follow-up, hand off to the focused skills: refactoring targets → `refactoring`, module structure → `architecture-review`.
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Dependency analysis for Go. `polyscan analyze` builds the package import graph of a Go tree, resolving each import through the nearest `go.mod`, and reports the same instability, abstractness, main-sequence distance, depth and longest chains it reports for JavaScript/TypeScript, scored in the Dependencies dimension. Abstractness is the share of a package's exported type declarations that are interfaces. Test files, `vendor` and `testdata` directories, and imports of other modules stay out of the graph, and a tree without a `go.mod` leaves the dimension out with a warning rather than scoring it clean
+
 ## [0.2.2] - 2026-09-05
 
 ### Changed

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -34,7 +34,7 @@ polyscan analyze --select clone .
 polyscan analyze --min-complexity 10 .
 ```
 
-`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo` and `deps` (default: all); `deadcode`, `cbo` and `deps` exist for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
+`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `deadcode` and `cbo` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
 
 A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -50,10 +50,11 @@ func analyzeCmd() *cobra.Command {
 The language of each file is detected from its extension. Supported: Go, Rust,
 C++ and JavaScript/TypeScript.
 
-Complexity and clone analysis cover every language; dead code, coupling (CBO)
-and dependency analysis exist for JavaScript/TypeScript only. The health score
-is computed over the dimensions that ran: a dimension a language does not have
-is left out, not scored as clean.
+Complexity and clone analysis cover every language; dependency analysis covers
+Go and JavaScript/TypeScript; dead code and coupling (CBO) exist for
+JavaScript/TypeScript only. The health score is computed over the dimensions
+that ran: a dimension a language does not have is left out, not scored as
+clean.
 
 By default, generates an HTML report and opens it in your browser.
 
@@ -82,7 +83,7 @@ Examples:
 
 			start := time.Now()
 			var generic *analysis.Report
-			if options.Complexity || options.Clones {
+			if options.Complexity || options.Clones || options.Deps {
 				generic, err = analysis.Analyze(args, options)
 				if err != nil && !errors.Is(err, analysis.ErrNoFiles) {
 					return err
@@ -149,7 +150,7 @@ Examples:
 
 	cmd.Flags().StringSliceVarP(&selected, "select", "s", allAnalyses,
 		"Analyses to run (comma-separated): complexity,deadcode,clone,cbo,deps\n"+
-			"deadcode, cbo and deps apply to JavaScript/TypeScript only")
+			"deps applies to Go and JavaScript/TypeScript; deadcode and cbo to JavaScript/TypeScript only")
 	cmd.Flags().StringVarP(&format, "format", "f", "html", "Output format: html, json, text")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "HTML report path (default: "+defaultReportPath+")")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
@@ -245,8 +246,8 @@ func writeReportFile(path string, write func(io.Writer, jsdomain.OutputFormat) e
 }
 
 // parseSelection maps the selected analysis names onto the generic engine's
-// options and the JavaScript/TypeScript selection. deadcode, cbo and deps
-// exist only for JavaScript/TypeScript.
+// options and the JavaScript/TypeScript selection. deadcode and cbo exist
+// only for JavaScript/TypeScript.
 func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 	var options analysis.Options
 	var selection js.Selection
@@ -263,6 +264,7 @@ func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 		case selectCBO:
 			selection.CBO = true
 		case selectDeps:
+			options.Deps = true
 			selection.Deps = true
 		default:
 			return options, selection, fmt.Errorf(

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -364,3 +364,28 @@ func TestAnalyzeGoDependenciesWithoutModule(t *testing.T) {
 		t.Errorf("output lacks the go.mod warning:\n%s", out)
 	}
 }
+
+func TestAnalyzeGoDependenciesOnlyCountsSkippedFiles(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("root can read an unreadable file")
+	}
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/skip\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "b.go"), []byte("package main\n"), 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, "analyze", "--format", "json", "--select", "deps", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.Summary == nil || doc.Summary.TotalFiles != 2 || doc.Summary.SkippedFiles != 1 {
+		t.Errorf("summary = %+v, want 2 files with 1 skipped whichever analyses ran", doc.Summary)
+	}
+}

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -44,8 +44,17 @@ type analyzeJSON struct {
 			TotalClonePairs int `json:"total_clone_pairs"`
 		} `json:"statistics"`
 	} `json:"clone"`
+	Deps *struct {
+		Analysis struct {
+			TotalModules int `json:"TotalModules"`
+			MaxDepth     int `json:"MaxDepth"`
+		} `json:"analysis"`
+		Warnings []string `json:"warnings"`
+	} `json:"deps"`
 	Summary *struct {
 		HealthScore       int    `json:"health_score"`
+		DependencyScore   int    `json:"dependency_score"`
+		DepsEnabled       bool   `json:"deps_enabled"`
 		Grade             string `json:"grade"`
 		TotalFiles        int    `json:"total_files"`
 		SkippedFiles      int    `json:"skipped_files"`
@@ -298,5 +307,60 @@ func TestAnalyzeChargesParseErrorsWithoutComplexity(t *testing.T) {
 		if !strings.Contains(out, want) {
 			t.Errorf("output lacks %q:\n%s", want, out)
 		}
+	}
+}
+
+func TestAnalyzeGoDependencies(t *testing.T) {
+	out, err := run(t, "analyze", "--format", "json", "--select", "deps", "../../testdata/godeps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.Deps == nil {
+		t.Fatal("expected a deps section for a Go module")
+	}
+	if doc.Deps.Analysis.TotalModules != 3 || doc.Deps.Analysis.MaxDepth != 2 {
+		t.Errorf("deps analysis = %+v, want 3 packages at depth 2", doc.Deps.Analysis)
+	}
+	if doc.Summary == nil || !doc.Summary.DepsEnabled {
+		t.Errorf("summary = %+v, want the dependency dimension enabled", doc.Summary)
+	}
+
+	out, err = run(t, "analyze", "--format", "text", "--select", "deps", "../../testdata/godeps")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{"Total modules: 3", "Max depth: 2", "Dependencies:"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output lacks %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAnalyzeGoDependenciesWithoutModule(t *testing.T) {
+	// The fixture lies inside polyscan's own module, so it has to move out
+	// to lose its go.mod.
+	dir := t.TempDir()
+	content, err := os.ReadFile("../../testdata/go/sample.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "sample.go"), content, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, "analyze", "--format", "json", "--select", "deps,complexity", dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.Deps != nil {
+		t.Errorf("deps = %+v, want none outside a module", doc.Deps)
+	}
+	if doc.Summary == nil || doc.Summary.DepsEnabled {
+		t.Errorf("summary = %+v, want the dependency dimension left out", doc.Summary)
+	}
+	if !strings.Contains(out, "no go.mod above it") {
+		t.Errorf("output lacks the go.mod warning:\n%s", out)
 	}
 }

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -106,9 +106,11 @@ var ErrNoFiles = errors.New("no supported source files found")
 // selected analyses on it. A file that cannot be read is skipped and
 // reported in Errors, a file with a syntax error is analyzed without the
 // functions that contain it and reported in Warnings, and finding no
-// supported file at all is ErrNoFiles. The dependency analysis reads the
-// files on its own and reports the ones it leaves out in Warnings; the file
-// accounting counts only the per-file analyses.
+// supported file at all is ErrNoFiles. Every file is read and parsed
+// whichever analyses were selected, so the accounting, and with it the
+// parse-error penalty, is the same for every selection; the dependency
+// analysis reads its files again and reports the ones it leaves out in
+// Warnings.
 func Analyze(paths []string, options Options) (*Report, error) {
 	files, err := source.CollectFiles(paths, source.FileFilter{
 		IncludePatterns: lang.IncludePatterns(),
@@ -126,9 +128,6 @@ func Analyze(paths []string, options Options) (*Report, error) {
 		if err := analyzeDeps(report, files); err != nil {
 			return nil, err
 		}
-	}
-	if !options.Complexity && !options.Clones {
-		return report, nil
 	}
 	if options.Complexity {
 		report.Complexity = &Complexity{Functions: []Function{}}

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -14,13 +14,19 @@ import (
 	"github.com/ludo-technologies/polyscan/core/source"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/godeps"
+	jsdomain "github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
 )
 
 // Options selects the analyses to run.
 type Options struct {
 	Complexity bool
 	Clones     bool
+	// Deps builds the package dependency graph. Go is the only language of
+	// the generic engine with one so far.
+	Deps bool
 }
 
 // Function is the complexity result for one function.
@@ -78,6 +84,9 @@ type Report struct {
 	Files      Files         `json:"files"`
 	Complexity *Complexity   `json:"complexity,omitempty"`
 	Clones     *clone.Report `json:"clone,omitempty"`
+	// Deps is the Go package dependency graph, in the shape the unified
+	// report renders, or nil when no Go package could be placed in one.
+	Deps *jsdomain.DependencyGraphResponse `json:"deps,omitempty"`
 	// FileLines is the source line count of every analyzed file, keyed by
 	// its reported path. The unified report shows lines per hotspot file,
 	// and this run is the only place the contents are in hand.
@@ -97,7 +106,9 @@ var ErrNoFiles = errors.New("no supported source files found")
 // selected analyses on it. A file that cannot be read is skipped and
 // reported in Errors, a file with a syntax error is analyzed without the
 // functions that contain it and reported in Warnings, and finding no
-// supported file at all is ErrNoFiles.
+// supported file at all is ErrNoFiles. The dependency analysis reads the
+// files on its own and reports the ones it leaves out in Warnings; the file
+// accounting counts only the per-file analyses.
 func Analyze(paths []string, options Options) (*Report, error) {
 	files, err := source.CollectFiles(paths, source.FileFilter{
 		IncludePatterns: lang.IncludePatterns(),
@@ -111,6 +122,14 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	}
 
 	report := &Report{Files: Files{Total: len(files)}, FileLines: map[string]int{}}
+	if options.Deps {
+		if err := analyzeDeps(report, files); err != nil {
+			return nil, err
+		}
+	}
+	if !options.Complexity && !options.Clones {
+		return report, nil
+	}
 	if options.Complexity {
 		report.Complexity = &Complexity{Functions: []Function{}}
 	}
@@ -169,6 +188,33 @@ func Analyze(paths []string, options Options) (*Report, error) {
 		report.Clones.Statistics.FilesAnalyzed = cloneFiles
 	}
 	return report, nil
+}
+
+// analyzeDeps builds the dependency graph of the Go files among files. Test
+// files stay out of it: their imports describe the tests, not the package.
+func analyzeDeps(report *Report, files []string) error {
+	var goFiles []string
+	for _, file := range files {
+		if language, ok := lang.ByPath(file); ok && language == golang.Language && !language.IsTestFile(file) {
+			goFiles = append(goFiles, file)
+		}
+	}
+	if len(goFiles) == 0 {
+		return nil
+	}
+	deps, warnings, err := godeps.Analyze(goFiles, displayPath)
+	if err != nil {
+		return err
+	}
+	if deps == nil {
+		// Without a graph there is no dependency section to carry the
+		// warnings, so they travel with the run's other warnings.
+		report.Warnings = append(report.Warnings, warnings...)
+		return nil
+	}
+	deps.Warnings = warnings
+	report.Deps = deps
+	return nil
 }
 
 func analyzeFile(language *engine.Language, path string) (result *engine.Result, lines int, err error) {

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -297,7 +297,7 @@ func set(names []string) map[string]struct{} {
 
 func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function {
 	var functions []Function
-	forEachMatch(l.definitions, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.definitions, root, source, func(match *sitter.QueryMatch) {
 		var fn Function
 		var node *sitter.Node
 		var receiver string
@@ -413,7 +413,7 @@ func countCodeLines(content string) int {
 }
 
 func (l *Language) countDecisions(root *sitter.Node, source []byte, functions []Function) {
-	forEachMatch(l.decisions, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.decisions, root, source, func(match *sitter.QueryMatch) {
 		for _, capture := range match.Captures {
 			fn := innermost(functions, capture.Node.StartByte(), capture.Node.EndByte())
 			if fn == nil {
@@ -438,7 +438,7 @@ func (l *Language) measureNesting(root *sitter.Node, source []byte, functions []
 	// levels maps each captured node to the levels it opens: one, or zero
 	// for a continuation.
 	levels := map[uintptr]int{}
-	forEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
 		for _, capture := range match.Captures {
 			id := capture.Node.ID()
 			if l.nesting.CaptureNameForId(capture.Index) == continuationCapture {
@@ -448,7 +448,7 @@ func (l *Language) measureNesting(root *sitter.Node, source []byte, functions []
 			}
 		}
 	})
-	forEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.nesting, root, source, func(match *sitter.QueryMatch) {
 		for _, capture := range match.Captures {
 			node := capture.Node
 			fn := innermost(functions, node.StartByte(), node.EndByte())
@@ -478,7 +478,7 @@ func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Fun
 		return
 	}
 	var scopes []scope
-	forEachMatch(l.scopes, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.scopes, root, source, func(match *sitter.QueryMatch) {
 		var s scope
 		for _, capture := range match.Captures {
 			switch l.scopes.CaptureNameForId(capture.Index) {
@@ -522,7 +522,7 @@ func (l *Language) markTests(root *sitter.Node, source []byte, functions []Funct
 	if l.testCode == nil {
 		return
 	}
-	forEachMatch(l.testCode, root, source, func(match *sitter.QueryMatch) {
+	ForEachMatch(l.testCode, root, source, func(match *sitter.QueryMatch) {
 		for _, capture := range match.Captures {
 			start, end := capture.Node.StartByte(), capture.Node.EndByte()
 			for i := range functions {
@@ -552,7 +552,9 @@ func innermost(functions []Function, start, end uint32) *Function {
 	return found
 }
 
-func forEachMatch(query *sitter.Query, root *sitter.Node, source []byte, visit func(*sitter.QueryMatch)) {
+// ForEachMatch runs query over the tree under root and calls visit with each
+// match, its predicates already applied.
+func ForEachMatch(query *sitter.Query, root *sitter.Node, source []byte, visit func(*sitter.QueryMatch)) {
 	cursor := sitter.NewQueryCursor()
 	defer cursor.Close()
 	cursor.Exec(query, root)

--- a/polyscan/internal/godeps/file.go
+++ b/polyscan/internal/godeps/file.go
@@ -1,0 +1,103 @@
+package godeps
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
+	sitter "github.com/smacker/go-tree-sitter"
+)
+
+// fileInfo is what the dependency graph needs from one Go file.
+type fileInfo struct {
+	// Package is the name in the package clause.
+	Package string
+	// Imports are the import paths, in source order, with duplicates kept.
+	Imports []string
+	// ExportedTypes counts the exported type declarations and
+	// ExportedInterfaces the ones among them that declare an interface.
+	// Type aliases are not declarations of their own and are not counted.
+	ExportedTypes      int
+	ExportedInterfaces int
+}
+
+// query captures the package clause, every import path and every declared
+// type. An interface type matches both type patterns, so the two captures are
+// counted separately rather than the second subtracted from the first.
+const query = `
+(package_clause (package_identifier) @package)
+(import_spec path: [(interpreted_string_literal) (raw_string_literal)] @path)
+(type_declaration (type_spec name: (type_identifier) @type))
+(type_declaration (type_spec name: (type_identifier) @interface type: (interface_type)))
+`
+
+var (
+	compileOnce sync.Once
+	compiled    *sitter.Query
+	compileErr  error
+)
+
+func compile() (*sitter.Query, error) {
+	compileOnce.Do(func() {
+		compiled, compileErr = sitter.NewQuery([]byte(query), golang.Language.Grammar)
+		if compileErr != nil {
+			compileErr = fmt.Errorf("Go dependency query: %w", compileErr)
+		}
+	})
+	return compiled, compileErr
+}
+
+// parseFile extracts the package clause, imports and type declarations of one
+// Go source. A file without a package clause, which a syntax error at the top
+// of the file can cause, is an error: nothing places it in a package.
+func parseFile(source []byte) (*fileInfo, error) {
+	q, err := compile()
+	if err != nil {
+		return nil, err
+	}
+	parser := sitter.NewParser()
+	defer parser.Close()
+	parser.SetLanguage(golang.Language.Grammar)
+	tree, err := parser.ParseCtx(context.Background(), nil, source)
+	if err != nil {
+		return nil, err
+	}
+	defer tree.Close()
+
+	info := &fileInfo{}
+	engine.ForEachMatch(q, tree.RootNode(), source, func(match *sitter.QueryMatch) {
+		for _, capture := range match.Captures {
+			text := capture.Node.Content(source)
+			switch q.CaptureNameForId(capture.Index) {
+			case "package":
+				if info.Package == "" {
+					info.Package = text
+				}
+			case "path":
+				info.Imports = append(info.Imports, strings.Trim(text, "\"`"))
+			case "type":
+				if isExported(text) {
+					info.ExportedTypes++
+				}
+			case "interface":
+				if isExported(text) {
+					info.ExportedInterfaces++
+				}
+			}
+		}
+	})
+	if info.Package == "" {
+		return nil, fmt.Errorf("no package clause")
+	}
+	return info, nil
+}
+
+func isExported(name string) bool {
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
+}

--- a/polyscan/internal/godeps/file_test.go
+++ b/polyscan/internal/godeps/file_test.go
@@ -1,0 +1,50 @@
+package godeps
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestParseFile(t *testing.T) {
+	info, err := parseFile([]byte(`package model
+
+import "fmt"
+
+import (
+	"strings"
+	_ "embed"
+	. "math"
+	alias "example.com/x/y"
+	` + "`example.com/raw`" + `
+)
+
+type Store interface{ Get() }
+type Record struct{}
+type hidden interface{}
+type Alias = Record
+type (
+	Reader interface{ Read() }
+	name   struct{}
+)
+
+var _ = fmt.Sprint(strings.ToUpper(alias.X), Pi)
+`))
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := &fileInfo{
+		Package:            "model",
+		Imports:            []string{"fmt", "strings", "embed", "math", "example.com/x/y", "example.com/raw"},
+		ExportedTypes:      3,
+		ExportedInterfaces: 2,
+	}
+	if !reflect.DeepEqual(info, want) {
+		t.Errorf("got %+v, want %+v", info, want)
+	}
+}
+
+func TestParseFileWithoutPackageClause(t *testing.T) {
+	if _, err := parseFile([]byte("func main() {}\n")); err == nil {
+		t.Error("expected an error for a file without a package clause")
+	}
+}

--- a/polyscan/internal/godeps/godeps.go
+++ b/polyscan/internal/godeps/godeps.go
@@ -1,0 +1,34 @@
+package godeps
+
+import (
+	"context"
+	"time"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/analyzer"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/service"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/version"
+)
+
+// Analyze builds the package graph of files and derives the dependency
+// analysis from it: coupling metrics, depth and chains, and the cycle report,
+// which is always empty because the Go compiler rejects import cycles. The
+// response is nil when no package could be placed in the graph, so a tree
+// without a go.mod leaves the dependency dimension out rather than scoring
+// it clean; the warnings say why.
+func Analyze(files []string, display func(string) string) (*domain.DependencyGraphResponse, []string, error) {
+	graph, warnings := Build(files, display)
+	if graph.NodeCount() == 0 {
+		return nil, warnings, nil
+	}
+	analysis, err := service.AnalyzeDependencyGraph(context.Background(), graph, analyzer.DefaultCouplingMetricsConfig(), true)
+	if err != nil {
+		return nil, warnings, err
+	}
+	return &domain.DependencyGraphResponse{
+		Graph:       graph,
+		Analysis:    analysis,
+		GeneratedAt: time.Now().Format(time.RFC3339),
+		Version:     version.GetVersion(),
+	}, warnings, nil
+}

--- a/polyscan/internal/godeps/graph.go
+++ b/polyscan/internal/godeps/graph.go
@@ -1,0 +1,138 @@
+package godeps
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
+)
+
+// pkg accumulates the files of one package directory.
+type pkg struct {
+	importPath string
+	dir        string
+	name       string
+	// imports counts, per imported path, the files that import it.
+	imports            map[string]int
+	exportedTypes      int
+	exportedInterfaces int
+}
+
+// Build builds the package graph of files. Every file must be a Go source and
+// is placed in the package of its directory; files in a directory the go tool
+// ignores, such as vendor and testdata, are ignored too. A file whose
+// directory lies in no module, or that cannot be read or parsed, is left out
+// and reported in the warnings. display shortens a directory for the report.
+//
+// Edges join packages of the tree only: an import of the standard library, of
+// another module or of a vendored copy names no node and is dropped. Each
+// pair of packages is joined by one edge whose weight is the number of files
+// that import the target.
+func Build(files []string, display func(string) string) (*domain.DependencyGraph, []string) {
+	var warnings []string
+	warn := func(format string, args ...any) {
+		warnings = append(warnings, fmt.Sprintf(format, args...))
+	}
+
+	finder := newModuleFinder()
+	packages := map[string]*pkg{}
+	noModule := map[string]bool{}
+	sorted := append([]string{}, files...)
+	sort.Strings(sorted)
+	for _, file := range sorted {
+		absolute, err := filepath.Abs(file)
+		if err != nil {
+			warn("%s: %v", display(file), err)
+			continue
+		}
+		dir := filepath.Dir(absolute)
+		m, err := finder.find(dir)
+		if err != nil {
+			warn("%s: %v", display(file), err)
+			continue
+		}
+		if m == nil {
+			if !noModule[dir] {
+				noModule[dir] = true
+				warn("%s: no go.mod above it; its packages are absent from the dependency graph", display(dir))
+			}
+			continue
+		}
+		importPath, ignored, err := m.importPath(dir)
+		if err != nil {
+			warn("%s: %v", display(file), err)
+			continue
+		}
+		if ignored {
+			continue
+		}
+		content, err := os.ReadFile(absolute)
+		if err != nil {
+			warn("%s: %v", display(file), err)
+			continue
+		}
+		info, err := parseFile(content)
+		if err != nil {
+			warn("%s: %v; excluded from the dependency graph", display(file), err)
+			continue
+		}
+		p, ok := packages[importPath]
+		if !ok {
+			p = &pkg{importPath: importPath, dir: display(dir), name: info.Package, imports: map[string]int{}}
+			packages[importPath] = p
+		} else if p.name != info.Package {
+			warn("%s: package %s differs from package %s in the same directory; reported as %s", display(file), info.Package, p.name, p.name)
+		}
+		seen := map[string]bool{}
+		for _, imported := range info.Imports {
+			if !seen[imported] {
+				seen[imported] = true
+				p.imports[imported]++
+			}
+		}
+		p.exportedTypes += info.ExportedTypes
+		p.exportedInterfaces += info.ExportedInterfaces
+	}
+
+	graph := domain.NewDependencyGraph()
+	for _, p := range packages {
+		graph.AddNode(&domain.ModuleNode{
+			ID:           p.importPath,
+			Name:         p.name,
+			FilePath:     p.dir,
+			ModuleType:   domain.ModuleTypePackage,
+			Abstractness: abstractness(p),
+		})
+	}
+	for _, from := range graph.NodeIDs() {
+		p := packages[from]
+		targets := make([]string, 0, len(p.imports))
+		for to := range p.imports {
+			if graph.HasNode(to) && to != from {
+				targets = append(targets, to)
+			}
+		}
+		sort.Strings(targets)
+		for _, to := range targets {
+			graph.AddEdge(&domain.DependencyEdge{
+				From:     from,
+				To:       to,
+				EdgeType: domain.EdgeTypeImport,
+				Weight:   p.imports[to],
+			})
+		}
+	}
+	graph.UpdateNodeFlags()
+	return graph, warnings
+}
+
+// abstractness is Martin's A for a Go package: the share of its exported type
+// declarations that are interfaces. A package exporting no type is concrete.
+func abstractness(p *pkg) float64 {
+	if p.exportedTypes == 0 {
+		return 0
+	}
+	return float64(p.exportedInterfaces) / float64(p.exportedTypes)
+}

--- a/polyscan/internal/godeps/graph_test.go
+++ b/polyscan/internal/godeps/graph_test.go
@@ -1,0 +1,153 @@
+package godeps
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/source"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
+)
+
+const fixture = "../../testdata/godeps"
+
+func fixtureFiles(t *testing.T) []string {
+	t.Helper()
+	files, err := source.CollectFiles([]string{fixture}, source.FileFilter{IncludePatterns: []string{"*.go"}, Recursive: true})
+	if err != nil {
+		t.Fatal(err)
+	}
+	var kept []string
+	for _, file := range files {
+		if !strings.HasSuffix(file, "_test.go") {
+			kept = append(kept, file)
+		}
+	}
+	return kept
+}
+
+func identity(path string) string { return path }
+
+func TestBuildFixture(t *testing.T) {
+	graph, warnings := Build(fixtureFiles(t), identity)
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+
+	want := []string{"example.com/godeps/app", "example.com/godeps/lib", "example.com/godeps/model"}
+	if got := graph.NodeIDs(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("nodes = %v, want %v", got, want)
+	}
+
+	edges := map[string][]string{}
+	for _, from := range graph.NodeIDs() {
+		edges[from] = graph.Successors(from)
+	}
+	wantEdges := map[string][]string{
+		"example.com/godeps/app":   {"example.com/godeps/lib", "example.com/godeps/model"},
+		"example.com/godeps/lib":   {"example.com/godeps/model"},
+		"example.com/godeps/model": nil,
+	}
+	if !reflect.DeepEqual(edges, wantEdges) {
+		t.Errorf("edges = %v, want %v", edges, wantEdges)
+	}
+
+	// app imports lib from two files and model from one; each pair keeps
+	// one edge whose weight counts the files.
+	for _, edge := range graph.GetOutgoingEdges("example.com/godeps/app") {
+		want := 1
+		if edge.To == "example.com/godeps/lib" {
+			want = 2
+		}
+		if edge.Weight != want || edge.EdgeType != domain.EdgeTypeImport {
+			t.Errorf("edge app -> %s: weight %d type %s, want weight %d type import", edge.To, edge.Weight, edge.EdgeType, want)
+		}
+	}
+
+	app := graph.GetNode("example.com/godeps/app")
+	model := graph.GetNode("example.com/godeps/model")
+	if app.Name != "main" || !app.IsEntryPoint || app.IsLeaf {
+		t.Errorf("app = %+v, want package main entry point", app)
+	}
+	if model.Name != "model" || model.IsEntryPoint || !model.IsLeaf {
+		t.Errorf("model = %+v, want a leaf", model)
+	}
+	if model.Abstractness != 0.5 {
+		t.Errorf("model abstractness = %v, want 0.5 (Store among Store and Record)", model.Abstractness)
+	}
+	if app.Abstractness != 0 {
+		t.Errorf("app abstractness = %v, want 0", app.Abstractness)
+	}
+	if want := filepath.Join("godeps", "model"); !strings.HasSuffix(model.FilePath, want) {
+		t.Errorf("model file path = %q, want a path ending in %q", model.FilePath, want)
+	}
+}
+
+func TestBuildOutsideModule(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a", "a.go"), "package a\n")
+	writeFile(t, filepath.Join(dir, "a", "b.go"), "package a\n")
+	writeFile(t, filepath.Join(dir, "broken", "broken.go"), "package broken\n")
+	writeFile(t, filepath.Join(dir, "broken", "go.mod"), "module example.com/broken\n")
+	writeFile(t, filepath.Join(dir, "broken", "bad.go"), "func f() {}\n")
+
+	graph, warnings := Build([]string{
+		filepath.Join(dir, "a", "a.go"),
+		filepath.Join(dir, "a", "b.go"),
+		filepath.Join(dir, "broken", "broken.go"),
+		filepath.Join(dir, "broken", "bad.go"),
+	}, identity)
+
+	if want := []string{"example.com/broken"}; !reflect.DeepEqual(graph.NodeIDs(), want) {
+		t.Errorf("nodes = %v, want %v", graph.NodeIDs(), want)
+	}
+	if len(warnings) != 2 {
+		t.Fatalf("warnings = %v, want one per directory without go.mod and one per unparsable file", warnings)
+	}
+	if !strings.Contains(warnings[0], "no go.mod") || !strings.Contains(warnings[0], filepath.Join(dir, "a")) {
+		t.Errorf("warning[0] = %q", warnings[0])
+	}
+	if !strings.Contains(warnings[1], "bad.go") || !strings.Contains(warnings[1], "no package clause") {
+		t.Errorf("warning[1] = %q", warnings[1])
+	}
+}
+
+func TestAnalyzeFixture(t *testing.T) {
+	response, warnings, err := Analyze(fixtureFiles(t), identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(warnings) != 0 {
+		t.Errorf("unexpected warnings: %v", warnings)
+	}
+	analysis := response.Analysis
+	if analysis.TotalModules != 3 || analysis.TotalDependencies != 3 || analysis.MaxDepth != 2 {
+		t.Errorf("modules=%d dependencies=%d depth=%d, want 3, 3, 2", analysis.TotalModules, analysis.TotalDependencies, analysis.MaxDepth)
+	}
+	if analysis.CircularDependencies == nil || analysis.CircularDependencies.HasCircularDependencies {
+		t.Errorf("cycles = %+v, want an empty cycle report", analysis.CircularDependencies)
+	}
+	model := analysis.ModuleMetrics["example.com/godeps/model"]
+	if model.AfferentCoupling != 2 || model.EfferentCoupling != 0 || model.Instability != 0 || model.Abstractness != 0.5 || model.Distance != 0.5 {
+		t.Errorf("model metrics = %+v", model)
+	}
+	if len(analysis.LongestChains) != 1 || analysis.LongestChains[0].Length != 2 {
+		t.Errorf("chains = %+v, want one chain of length 2 from app", analysis.LongestChains)
+	}
+}
+
+func TestAnalyzeWithoutPackages(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, filepath.Join(dir, "a.go"), "package a\n")
+	response, warnings, err := Analyze([]string{filepath.Join(dir, "a.go")}, identity)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if response != nil {
+		t.Errorf("response = %+v, want nil when no package resolves", response)
+	}
+	if len(warnings) != 1 {
+		t.Errorf("warnings = %v, want one", warnings)
+	}
+}

--- a/polyscan/internal/godeps/module.go
+++ b/polyscan/internal/godeps/module.go
@@ -1,0 +1,108 @@
+// Package godeps builds the package import graph of a Go tree. A package's
+// identity is its import path, which the nearest go.mod's module path and the
+// package directory determine exactly, so an import statement resolves without
+// the alias heuristics other languages need.
+package godeps
+
+import (
+	"bufio"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// module is the go.mod that contains a directory.
+type module struct {
+	// dir is the directory holding go.mod.
+	dir string
+	// path is the module path declared by its module directive.
+	path string
+}
+
+// moduleFinder resolves directories to their enclosing module and remembers
+// every answer, since a package tree asks about each of its directories and
+// most of them share one go.mod.
+type moduleFinder struct {
+	byDir map[string]*module
+}
+
+func newModuleFinder() *moduleFinder {
+	return &moduleFinder{byDir: map[string]*module{}}
+}
+
+// find returns the module of the nearest go.mod at or above dir, or nil when
+// no directory up to the root has one.
+func (f *moduleFinder) find(dir string) (*module, error) {
+	if m, ok := f.byDir[dir]; ok {
+		return m, nil
+	}
+	var m *module
+	path := filepath.Join(dir, "go.mod")
+	if _, err := os.Stat(path); err == nil {
+		modulePath, err := readModulePath(path)
+		if err != nil {
+			return nil, err
+		}
+		m = &module{dir: dir, path: modulePath}
+	} else if parent := filepath.Dir(dir); parent != dir {
+		m, err = f.find(parent)
+		if err != nil {
+			return nil, err
+		}
+	}
+	f.byDir[dir] = m
+	return m, nil
+}
+
+// readModulePath returns the module directive of a go.mod file. Only that
+// directive matters here, so the file is not parsed any further.
+func readModulePath(path string) (string, error) {
+	file, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer file.Close()
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if comment := strings.Index(line, "//"); comment >= 0 {
+			line = strings.TrimSpace(line[:comment])
+		}
+		rest, ok := strings.CutPrefix(line, "module")
+		if !ok || (rest != "" && rest[0] != ' ' && rest[0] != '\t') {
+			continue
+		}
+		modulePath := strings.Trim(strings.TrimSpace(rest), "\"`")
+		if modulePath == "" {
+			return "", fmt.Errorf("%s: module directive has no path", path)
+		}
+		return modulePath, nil
+	}
+	if err := scanner.Err(); err != nil {
+		return "", err
+	}
+	return "", fmt.Errorf("%s: no module directive", path)
+}
+
+// importPath is the import path of the package in dir, which must lie inside
+// the module. ignored reports a directory the go tool does not build as part
+// of the module: vendor, testdata, and any directory whose name starts with a
+// dot or an underscore.
+func (m *module) importPath(dir string) (path string, ignored bool, err error) {
+	rel, err := filepath.Rel(m.dir, dir)
+	if err != nil {
+		return "", false, err
+	}
+	if rel == "." {
+		return m.path, false, nil
+	}
+	rel = filepath.ToSlash(rel)
+	for _, component := range strings.Split(rel, "/") {
+		if component == "vendor" || component == "testdata" ||
+			strings.HasPrefix(component, ".") || strings.HasPrefix(component, "_") {
+			return "", true, nil
+		}
+	}
+	return m.path + "/" + rel, false, nil
+}

--- a/polyscan/internal/godeps/module_test.go
+++ b/polyscan/internal/godeps/module_test.go
@@ -1,0 +1,104 @@
+package godeps
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReadModulePath(t *testing.T) {
+	dir := t.TempDir()
+	cases := map[string]string{
+		"plain":   "module example.com/plain\n\ngo 1.24\n",
+		"quoted":  "// leading comment\nmodule \"example.com/quoted\" // trailing\n",
+		"indent":  "\n  module\texample.com/indent\n",
+		"prefix":  "modules := 1\nmodule example.com/prefix\n",
+		"missing": "go 1.24\n",
+		"empty":   "module\n",
+	}
+	want := map[string]string{
+		"plain":  "example.com/plain",
+		"quoted": "example.com/quoted",
+		"indent": "example.com/indent",
+		"prefix": "example.com/prefix",
+	}
+	for name, content := range cases {
+		path := filepath.Join(dir, name, "go.mod")
+		writeFile(t, path, content)
+		got, err := readModulePath(path)
+		if expected, ok := want[name]; ok {
+			if err != nil || got != expected {
+				t.Errorf("%s: got %q, %v; want %q", name, got, err, expected)
+			}
+		} else if err == nil {
+			t.Errorf("%s: got %q, want an error", name, got)
+		}
+	}
+}
+
+func TestModuleFinder(t *testing.T) {
+	root := t.TempDir()
+	writeFile(t, filepath.Join(root, "outer", "go.mod"), "module example.com/outer\n")
+	writeFile(t, filepath.Join(root, "outer", "nested", "go.mod"), "module example.com/nested\n")
+	finder := newModuleFinder()
+
+	cases := []struct {
+		dir  string
+		path string
+	}{
+		{filepath.Join(root, "outer"), "example.com/outer"},
+		{filepath.Join(root, "outer", "a", "b"), "example.com/outer"},
+		{filepath.Join(root, "outer", "nested", "c"), "example.com/nested"},
+		{filepath.Join(root, "elsewhere"), ""},
+	}
+	for _, tc := range cases {
+		m, err := finder.find(tc.dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if tc.path == "" {
+			if m != nil {
+				t.Errorf("%s: found module %q, want none", tc.dir, m.path)
+			}
+			continue
+		}
+		if m == nil || m.path != tc.path {
+			t.Errorf("%s: got %v, want module %q", tc.dir, m, tc.path)
+		}
+	}
+}
+
+func TestImportPath(t *testing.T) {
+	m := &module{dir: filepath.Join("root", "mod"), path: "example.com/mod"}
+	cases := []struct {
+		dir     string
+		path    string
+		ignored bool
+	}{
+		{filepath.Join("root", "mod"), "example.com/mod", false},
+		{filepath.Join("root", "mod", "internal", "x"), "example.com/mod/internal/x", false},
+		{filepath.Join("root", "mod", "vendor", "example.com", "dep"), "", true},
+		{filepath.Join("root", "mod", "x", "testdata"), "", true},
+		{filepath.Join("root", "mod", "_tools"), "", true},
+		{filepath.Join("root", "mod", ".git", "x"), "", true},
+	}
+	for _, tc := range cases {
+		path, ignored, err := m.importPath(tc.dir)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if path != tc.path || ignored != tc.ignored {
+			t.Errorf("%s: got %q ignored=%v, want %q ignored=%v", tc.dir, path, ignored, tc.path, tc.ignored)
+		}
+	}
+}

--- a/polyscan/internal/js/analyzer/coupling_metrics.go
+++ b/polyscan/internal/js/analyzer/coupling_metrics.go
@@ -195,27 +195,14 @@ func (c *CouplingMetricsCalculator) CalculateCouplingAnalysis(graph *domain.Depe
 	}
 }
 
-// calculateAbstractness calculates A = abstractions / total declarations
-// Simplified: based on the ratio of exports to a baseline
-// In a more complete implementation, this would analyze actual abstractions (interfaces, abstract classes)
+// calculateAbstractness reads the abstractness the graph builder measured for
+// the node, which is language-specific; a node the graph does not know is
+// concrete.
 func (c *CouplingMetricsCalculator) calculateAbstractness(node *domain.ModuleNode) float64 {
 	if node == nil {
 		return 0.0
 	}
-
-	// Simplified abstractness calculation based on exports
-	// More exports generally indicate more abstraction
-	exports := len(node.Exports)
-	if exports == 0 {
-		return 0.0 // Concrete - no exports
-	}
-
-	// Cap at 1.0, with 10+ exports being fully abstract
-	abstractness := float64(exports) / 10.0
-	if abstractness > 1.0 {
-		abstractness = 1.0
-	}
-	return abstractness
+	return node.Abstractness
 }
 
 // classifyStabilityZone classifies a module into a stability zone.

--- a/polyscan/internal/js/analyzer/coupling_metrics_test.go
+++ b/polyscan/internal/js/analyzer/coupling_metrics_test.go
@@ -372,9 +372,7 @@ func TestGetDependents(t *testing.T) {
 	}
 }
 
-func TestCalculateAbstractness(t *testing.T) {
-	calc := NewCouplingMetricsCalculator(nil)
-
+func TestExportAbstractness(t *testing.T) {
 	testCases := []struct {
 		exports  []string
 		expected float64
@@ -388,8 +386,7 @@ func TestCalculateAbstractness(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		node := &domain.ModuleNode{Exports: tc.exports}
-		result := calc.calculateAbstractness(node)
+		result := ExportAbstractness(tc.exports)
 		if math.Abs(result-tc.expected) > 0.001 {
 			t.Errorf("Abstractness(exports=%d) = %f, expected %f", len(tc.exports), result, tc.expected)
 		}

--- a/polyscan/internal/js/analyzer/dependency_graph.go
+++ b/polyscan/internal/js/analyzer/dependency_graph.go
@@ -155,13 +155,21 @@ func (b *DependencyGraphBuilder) createModuleNode(filePath string, info *domain.
 	}
 
 	return &domain.ModuleNode{
-		ID:         id,
-		Name:       name,
-		FilePath:   filePath,
-		ModuleType: domain.ModuleTypeRelative,
-		IsExternal: false,
-		Exports:    exports,
+		ID:           id,
+		Name:         name,
+		FilePath:     filePath,
+		ModuleType:   domain.ModuleTypeRelative,
+		IsExternal:   false,
+		Exports:      exports,
+		Abstractness: ExportAbstractness(exports),
 	}
+}
+
+// ExportAbstractness grades a JavaScript module's abstractness by its export
+// count: more exports generally indicate more abstraction, and ten or more
+// count as fully abstract. A module with no exports is concrete.
+func ExportAbstractness(exports []string) float64 {
+	return min(float64(len(exports))/10.0, 1.0)
 }
 
 // createExternalNode creates a ModuleNode for an external/unresolved module.

--- a/polyscan/internal/js/domain/dependency_graph.go
+++ b/polyscan/internal/js/domain/dependency_graph.go
@@ -44,6 +44,12 @@ type ModuleNode struct {
 
 	// Exports lists the exported names from this module
 	Exports []string `json:"exports,omitempty"`
+
+	// Abstractness is Martin's A for the module, between 0 and 1. The
+	// builder that creates the node measures it, since what counts as an
+	// abstraction depends on the language: a JavaScript module is graded by
+	// its export count, a Go package by its exported interface ratio.
+	Abstractness float64 `json:"abstractness"`
 }
 
 // DependencyEdge represents a directed edge in the dependency graph

--- a/polyscan/internal/js/service/dependency_graph_service.go
+++ b/polyscan/internal/js/service/dependency_graph_service.go
@@ -95,14 +95,7 @@ func (s *DependencyGraphServiceImpl) AnalyzeSnapshot(ctx context.Context, snapsh
 		}, nil
 	}
 
-	// Detect cycles
-	var circularDeps *domain.CircularDependencyAnalysis
-	if req.DetectCycles == nil || *req.DetectCycles {
-		cycleDetector := analyzer.NewCircularDependencyDetector()
-		circularDeps = cycleDetector.DetectCycles(graph)
-	}
-
-	// Calculate coupling metrics
+	// Apply request thresholds to the coupling configuration
 	couplingConfig := *s.couplingConfig
 	if req.InstabilityHighThreshold > 0 {
 		couplingConfig.InstabilityHighThreshold = req.InstabilityHighThreshold
@@ -114,22 +107,10 @@ func (s *DependencyGraphServiceImpl) AnalyzeSnapshot(ctx context.Context, snapsh
 		couplingConfig.DistanceThreshold = req.DistanceThreshold
 	}
 
-	couplingCalc := analyzer.NewCouplingMetricsCalculator(&couplingConfig)
-	moduleMetrics := couplingCalc.CalculateMetrics(graph)
-	couplingAnalysis := couplingCalc.CalculateCouplingAnalysis(graph, moduleMetrics)
-
-	// The max depth and the reported chains are the same search over the same
-	// condensation, so build the finder once and let both read from it. It runs
-	// over the load-time graph, so a dynamic import() cannot add a layer that
-	// the cycle report has already ruled out.
-	chainFinder, err := coregraph.NewChainFinder(ctx, analyzer.LoadTimeGraph(graph))
+	analysis, err := AnalyzeDependencyGraph(ctx, graph, &couplingConfig, req.DetectCycles == nil || *req.DetectCycles)
 	if err != nil {
-		return nil, fmt.Errorf("dependency chain search cancelled: %w", err)
+		return nil, err
 	}
-	maxDepth := couplingCalc.CalculateMaxDepthFrom(chainFinder)
-
-	// Build analysis result
-	analysis := s.buildAnalysisResult(graph, circularDeps, couplingAnalysis, moduleMetrics, maxDepth, chainFinder)
 
 	return &domain.DependencyGraphResponse{
 		Graph:       graph,
@@ -168,8 +149,36 @@ func collectSnapshotASTs(ctx context.Context, snapshot *ProjectSnapshot) (map[st
 	return asts, warnings, errors
 }
 
+// AnalyzeDependencyGraph derives every structural result from a built graph:
+// the cycles, the Martin coupling metrics, the maximum depth and the ranked
+// chains. The graph builder is language-specific, this step is not, so a Go
+// package graph and a JavaScript module graph share it. Cycle detection can be
+// left out; it fails only when ctx is cancelled during the chain search.
+func AnalyzeDependencyGraph(ctx context.Context, graph *domain.DependencyGraph, couplingConfig *analyzer.CouplingMetricsConfig, detectCycles bool) (*domain.DependencyAnalysisResult, error) {
+	var circularDeps *domain.CircularDependencyAnalysis
+	if detectCycles {
+		circularDeps = analyzer.NewCircularDependencyDetector().DetectCycles(graph)
+	}
+
+	couplingCalc := analyzer.NewCouplingMetricsCalculator(couplingConfig)
+	moduleMetrics := couplingCalc.CalculateMetrics(graph)
+	couplingAnalysis := couplingCalc.CalculateCouplingAnalysis(graph, moduleMetrics)
+
+	// The max depth and the reported chains are the same search over the same
+	// condensation, so build the finder once and let both read from it. It runs
+	// over the load-time graph, so a dynamic import() cannot add a layer that
+	// the cycle report has already ruled out.
+	chainFinder, err := coregraph.NewChainFinder(ctx, analyzer.LoadTimeGraph(graph))
+	if err != nil {
+		return nil, fmt.Errorf("dependency chain search cancelled: %w", err)
+	}
+	maxDepth := couplingCalc.CalculateMaxDepthFrom(chainFinder)
+
+	return buildAnalysisResult(graph, circularDeps, couplingAnalysis, moduleMetrics, maxDepth, chainFinder), nil
+}
+
 // buildAnalysisResult builds a DependencyAnalysisResult from the analysis components
-func (s *DependencyGraphServiceImpl) buildAnalysisResult(
+func buildAnalysisResult(
 	graph *domain.DependencyGraph,
 	circularDeps *domain.CircularDependencyAnalysis,
 	couplingAnalysis *domain.CouplingAnalysis,
@@ -207,7 +216,7 @@ func (s *DependencyGraphServiceImpl) buildAnalysisResult(
 	}
 
 	// Find longest dependency chains
-	longestChains := s.findLongestChains(graph, chainFinder, maxDepth)
+	longestChains := findLongestChains(graph, chainFinder, maxDepth)
 
 	return &domain.DependencyAnalysisResult{
 		TotalModules:         graph.NodeCount(),
@@ -230,7 +239,7 @@ const maxReportedChains = 5
 // entry-point module. Chains come from the caller's condensation-based finder,
 // which is linear in the graph size — an exhaustive simple-path search would be
 // exponential on the cyclic import graphs real projects produce.
-func (s *DependencyGraphServiceImpl) findLongestChains(graph *domain.DependencyGraph, finder *coregraph.ChainFinder, maxDepth int) []domain.DependencyPath {
+func findLongestChains(graph *domain.DependencyGraph, finder *coregraph.ChainFinder, maxDepth int) []domain.DependencyPath {
 	if maxDepth == 0 || finder == nil {
 		return nil
 	}

--- a/polyscan/internal/js/service/dependency_graph_service_test.go
+++ b/polyscan/internal/js/service/dependency_graph_service_test.go
@@ -1,0 +1,48 @@
+package service
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
+)
+
+func TestAnalyzeDependencyGraph(t *testing.T) {
+	graph := domain.NewDependencyGraph()
+	for _, id := range []string{"a", "b", "c", "d"} {
+		graph.AddNode(&domain.ModuleNode{ID: id, Name: id, FilePath: id + ".js", Abstractness: 0.5})
+	}
+	for _, edge := range [][2]string{{"a", "b"}, {"b", "c"}, {"c", "b"}, {"c", "d"}} {
+		graph.AddEdge(&domain.DependencyEdge{From: edge[0], To: edge[1], EdgeType: domain.EdgeTypeImport})
+	}
+	graph.UpdateNodeFlags()
+
+	analysis, err := AnalyzeDependencyGraph(context.Background(), graph, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if analysis.TotalModules != 4 || analysis.TotalDependencies != 4 {
+		t.Errorf("modules=%d dependencies=%d, want 4 and 4", analysis.TotalModules, analysis.TotalDependencies)
+	}
+	if analysis.CircularDependencies == nil || analysis.CircularDependencies.TotalModulesInCycles != 2 {
+		t.Errorf("cycles = %+v, want b and c in one cycle", analysis.CircularDependencies)
+	}
+	// The chain routes through the cycle once: a -> b -> c -> d.
+	if analysis.MaxDepth != 3 {
+		t.Errorf("max depth = %d, want 3", analysis.MaxDepth)
+	}
+	if got := analysis.RootModules; len(got) != 1 || got[0] != "a" {
+		t.Errorf("roots = %v, want [a]", got)
+	}
+	if m := analysis.ModuleMetrics["b"]; m == nil || m.AfferentCoupling != 2 || m.EfferentCoupling != 1 || m.Abstractness != 0.5 {
+		t.Errorf("metrics for b = %+v", m)
+	}
+
+	analysis, err = AnalyzeDependencyGraph(context.Background(), graph, nil, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if analysis.CircularDependencies != nil {
+		t.Errorf("cycles = %+v, want none when detection is off", analysis.CircularDependencies)
+	}
+}

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -5,6 +5,7 @@
 package report
 
 import (
+	"context"
 	"path/filepath"
 	"sort"
 	"time"
@@ -13,13 +14,15 @@ import (
 	"github.com/ludo-technologies/polyscan/polyscan/internal/analysis"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/analyzer"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/service"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/version"
 )
 
 // Combine merges the generic-engine report with the JavaScript/TypeScript
-// result into the shape the output formatter renders. Complexity and clone
-// results merge across languages; dead code, coupling and dependencies exist
+// result into the shape the output formatter renders. Complexity, clone and
+// dependency results merge across languages; dead code and coupling exist
 // only for JavaScript/TypeScript and pass through. The file accounting adds
 // up across both sides, so the health score charges every unparsable file
 // whichever analyses ran. Either input may be nil when its side found no
@@ -46,8 +49,51 @@ func Combine(generic *analysis.Report, javascript *js.Result) (domain.AnalysisRe
 		})
 		results.Complexity = mergeComplexity(complexity, results.Complexity)
 		results.Clone = mergeClones(genericClones(generic), results.Clone)
+		results.Deps, err = mergeDeps(generic.Deps, results.Deps)
+		if err != nil {
+			return domain.AnalysisResults{}, err
+		}
 	}
 	return results, nil
+}
+
+// mergeDeps joins the Go package graph and the JavaScript module graph into
+// one dependency response. A node is a Go import path on one side and a file
+// path on the other, so the two never collide, and no import crosses from one
+// language to the other; the union is re-analyzed so the depth, chains and
+// coupling summary describe the whole graph.
+func mergeDeps(generic, javascript *domain.DependencyGraphResponse) (*domain.DependencyGraphResponse, error) {
+	if generic == nil {
+		return javascript, nil
+	}
+	if javascript == nil {
+		return generic, nil
+	}
+
+	graph := domain.NewDependencyGraph()
+	for _, source := range []*domain.DependencyGraph{generic.Graph, javascript.Graph} {
+		for _, node := range source.Nodes {
+			graph.AddNode(node)
+		}
+		for _, edges := range source.Edges {
+			for _, edge := range edges {
+				graph.AddEdge(edge)
+			}
+		}
+	}
+	graph.UpdateNodeFlags()
+	analysis, err := service.AnalyzeDependencyGraph(context.Background(), graph, analyzer.DefaultCouplingMetricsConfig(), true)
+	if err != nil {
+		return nil, err
+	}
+	return &domain.DependencyGraphResponse{
+		Graph:       graph,
+		Analysis:    analysis,
+		Warnings:    mergeStrings(generic.Warnings, javascript.Warnings),
+		Errors:      mergeStrings(generic.Errors, javascript.Errors),
+		GeneratedAt: javascript.GeneratedAt,
+		Version:     javascript.Version,
+	}, nil
 }
 
 // genericComplexity converts the generic engine's complexity analysis into

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -263,3 +263,51 @@ func TestCombineJavaScriptSkippedFilesWithoutComplexity(t *testing.T) {
 		t.Errorf("files = %+v, want %+v", responses.Files, javascript.Files)
 	}
 }
+
+func depsResponse(ids ...string) *domain.DependencyGraphResponse {
+	graph := domain.NewDependencyGraph()
+	for _, id := range ids {
+		graph.AddNode(&domain.ModuleNode{ID: id, Name: id, FilePath: id})
+	}
+	for i := 1; i < len(ids); i++ {
+		graph.AddEdge(&domain.DependencyEdge{From: ids[i-1], To: ids[i], EdgeType: domain.EdgeTypeImport})
+	}
+	graph.UpdateNodeFlags()
+	return &domain.DependencyGraphResponse{
+		Graph:       graph,
+		Analysis:    &domain.DependencyAnalysisResult{TotalModules: len(ids), MaxDepth: len(ids) - 1},
+		Warnings:    []string{ids[0] + " warning"},
+		GeneratedAt: "now",
+		Version:     "test",
+	}
+}
+
+func TestCombineGoDependencies(t *testing.T) {
+	generic := &analysis.Report{Deps: depsResponse("example.com/m/app", "example.com/m/lib")}
+
+	results, err := Combine(generic, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if results.Deps != generic.Deps {
+		t.Error("a Go-only run should pass its dependency response through")
+	}
+
+	results, err = Combine(generic, &js.Result{Deps: depsResponse("src/a.js", "src/b.js", "src/c.js")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	deps := results.Deps
+	if deps.Graph.NodeCount() != 5 || deps.Graph.EdgeCount() != 3 {
+		t.Errorf("merged graph has %d nodes and %d edges, want 5 and 3", deps.Graph.NodeCount(), deps.Graph.EdgeCount())
+	}
+	if deps.Analysis.TotalModules != 5 || deps.Analysis.MaxDepth != 2 {
+		t.Errorf("merged analysis = modules %d depth %d, want 5 and 2 (re-analyzed over the union)", deps.Analysis.TotalModules, deps.Analysis.MaxDepth)
+	}
+	if want := []string{"example.com/m/app", "src/a.js"}; !reflect.DeepEqual(deps.Analysis.RootModules, want) {
+		t.Errorf("roots = %v, want %v", deps.Analysis.RootModules, want)
+	}
+	if want := []string{"example.com/m/app warning", "src/a.js warning"}; !reflect.DeepEqual(deps.Warnings, want) {
+		t.Errorf("warnings = %v, want %v", deps.Warnings, want)
+	}
+}

--- a/polyscan/testdata/godeps/app/extra.go
+++ b/polyscan/testdata/godeps/app/extra.go
@@ -1,0 +1,5 @@
+package main
+
+import "example.com/godeps/lib"
+
+var _ = lib.Count

--- a/polyscan/testdata/godeps/app/main.go
+++ b/polyscan/testdata/godeps/app/main.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"fmt"
+
+	"example.com/godeps/lib"
+	"example.com/godeps/model"
+)
+
+func main() {
+	fmt.Println(lib.Count(model.Record{}))
+}

--- a/polyscan/testdata/godeps/go.mod
+++ b/polyscan/testdata/godeps/go.mod
@@ -1,0 +1,3 @@
+module example.com/godeps
+
+go 1.24

--- a/polyscan/testdata/godeps/lib/lib.go
+++ b/polyscan/testdata/godeps/lib/lib.go
@@ -1,0 +1,13 @@
+package lib
+
+import (
+	"fmt"
+
+	"example.com/godeps/model"
+)
+
+// Count returns the number of records and prints it.
+func Count(records ...model.Record) int {
+	fmt.Println(len(records))
+	return len(records)
+}

--- a/polyscan/testdata/godeps/lib/lib_test.go
+++ b/polyscan/testdata/godeps/lib/lib_test.go
@@ -1,0 +1,11 @@
+package lib_test
+
+import (
+	"testing"
+
+	"example.com/godeps/app"
+)
+
+func TestCount(t *testing.T) {
+	_ = app.Version
+}

--- a/polyscan/testdata/godeps/model/model.go
+++ b/polyscan/testdata/godeps/model/model.go
@@ -1,0 +1,16 @@
+package model
+
+// Store is an abstraction.
+type Store interface {
+	Get(id string) Record
+}
+
+// Record is concrete.
+type Record struct {
+	ID string
+}
+
+type hidden struct{}
+
+// Alias is not a declaration of its own.
+type Alias = Record

--- a/polyscan/testdata/godeps/model/testdata/x.go
+++ b/polyscan/testdata/godeps/model/testdata/x.go
@@ -1,0 +1,5 @@
+package ignored
+
+import "example.com/godeps/app"
+
+var _ = app.Version

--- a/polyscan/testdata/godeps/vendor/example.com/dep/dep.go
+++ b/polyscan/testdata/godeps/vendor/example.com/dep/dep.go
@@ -1,0 +1,4 @@
+package dep
+
+// Vendored code is not part of the tree.
+func Dep() {}

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -25,7 +25,7 @@ polyscan analyze src/ test/ scripts/build.ts             # Several paths at once
 
 | Flag | Short | Default | Description |
 | --- | --- | --- | --- |
-| `--select` | `-s` | `complexity,deadcode,clone,cbo,deps` | Comma-separated list of analyses to run. `deadcode`, `cbo` and `deps` apply to JavaScript/TypeScript only |
+| `--select` | `-s` | `complexity,deadcode,clone,cbo,deps` | Comma-separated list of analyses to run. `deps` applies to Go and JavaScript/TypeScript; `deadcode` and `cbo` to JavaScript/TypeScript only |
 | `--format` | `-f` | `html` | Output format. Accepts `html`, `json`, or `text` |
 | `--no-open` | | `false` | Write the HTML report without opening a browser |
 | `--output` | `-o` | `polyscan-report.html` | Path for the HTML report file |
@@ -35,7 +35,7 @@ The configuration file for the JavaScript/TypeScript analysis is discovered auto
 
 ## Language coverage
 
-The language of each file is detected from its extension. Complexity and clone detection cover every supported language. Dead code, coupling (CBO) and dependency analysis exist for JavaScript/TypeScript only, and the health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
+The language of each file is detected from its extension. Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Dead code and coupling (CBO) exist for JavaScript/TypeScript only, and the health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
 A file that cannot be read is skipped and listed under errors. A file with a syntax error is analyzed without the functions that contain it, counted as partial, and listed under warnings. C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
@@ -145,9 +145,11 @@ In Go, Rust and C++, test code is analyzed for complexity but excluded from clon
 
 ### Dependencies {#deps}
 
-*JavaScript/TypeScript only.* Builds the module import graph, resolving both ECMAScript modules and CommonJS `require` calls. From the graph polyscan derives the circular imports, the maximum dependency depth, and the Martin coupling metrics for each module.
+*Go and JavaScript/TypeScript.* Builds the import graph and derives from it the circular imports, the maximum dependency depth, and the Martin coupling metrics for each module.
 
-Circular imports are found with Tarjan's strongly connected components algorithm. Dynamic imports are excluded from the cycle check, because a dynamic import does not create a load-time cycle.
+For JavaScript/TypeScript a module is a file. The graph resolves both ECMAScript modules and CommonJS `require` calls. Circular imports are found with Tarjan's strongly connected components algorithm. Dynamic imports are excluded from the cycle check, because a dynamic import does not create a load-time cycle.
+
+For Go a module is a package. Each file's import paths resolve through the nearest `go.mod`: the package's import path is the module path plus its directory, so no path aliasing is involved. `_test.go` files are left out, because their imports describe the tests rather than the package, and so are the `vendor` and `testdata` directories the go tool ignores. An import of the standard library or of another module names no package in the tree and becomes no edge. The compiler forbids import cycles, so the cycle report is always empty for Go, and the value lies in the instability, the distance from the main sequence and the dependency depth. Abstractness is the share of a package's exported type declarations that are interfaces. A Go file outside any `go.mod` cannot be placed in a package; it is reported as a warning and, when no package resolves at all, the dependency dimension is left out of the score.
 
 The full graph — nodes, edges, per-module metrics, cycles — is in the `deps` section of the [JSON output](../output/json-schema.md#deps).
 

--- a/website/docs/faq.md
+++ b/website/docs/faq.md
@@ -4,7 +4,7 @@
 
 ### Which languages does polyscan analyze?
 
-JavaScript, TypeScript, Go, Rust and C++, detected by file extension in one run. Complexity and clone detection cover every language; dead code, coupling (CBO) and dependency analysis exist for JavaScript/TypeScript. Python has its own analyzer, [pyscn](https://github.com/ludo-technologies/pyscn), built on the same core.
+JavaScript, TypeScript, Go, Rust and C++, detected by file extension in one run. Complexity and clone detection cover every language; dependency analysis covers Go and JavaScript/TypeScript; dead code and coupling (CBO) exist for JavaScript/TypeScript. Python has its own analyzer, [pyscn](https://github.com/ludo-technologies/pyscn), built on the same core.
 
 ### What happened to jscan?
 

--- a/website/docs/guides/dependency-graph.md
+++ b/website/docs/guides/dependency-graph.md
@@ -1,6 +1,6 @@
 # Read the Dependency Graph
 
-`polyscan analyze --select deps` builds the module import graph for the JavaScript/TypeScript files and reports metrics derived from it. The numbers come from Robert Martin's package metrics, which are widely used but easy to misread. This guide explains what each one means and what to do about a bad value.
+`polyscan analyze --select deps` builds the import graph of the Go packages and the JavaScript/TypeScript files and reports metrics derived from it. For Go the module in every metric below is a package, resolved through `go.mod`; the Go compiler rejects import cycles, so the cycle section is always empty for Go. The numbers come from Robert Martin's package metrics, which are widely used but easy to misread. This guide explains what each one means and what to do about a bad value.
 
 ```bash
 polyscan analyze --format text --select deps src/

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -32,7 +32,7 @@ polyscan analyze --format json src/ > report.json
 | `dead_code` | object | Present only when dead code detection ran (JavaScript/TypeScript) |
 | `clone` | object | Present only when clone detection ran |
 | `cbo` | object | Present only when coupling analysis ran (JavaScript/TypeScript) |
-| `deps` | object | Present only when dependency analysis ran (JavaScript/TypeScript) |
+| `deps` | object | Present only when dependency analysis ran (Go, JavaScript/TypeScript) |
 | `module_quality` | array | Per-file rollups joined across the analyses that ran |
 | `summary` | object | Always present |
 
@@ -343,7 +343,7 @@ The `summary` object carries a `findings_by_reason` map, which is the most conve
 
 ## `deps`
 
-*JavaScript/TypeScript only.*
+*Go and JavaScript/TypeScript.*
 
 ```json
 {
@@ -354,7 +354,7 @@ The `summary` object carries a `findings_by_reason` map, which is the most conve
 }
 ```
 
-`graph` holds the nodes and edges of the module import graph. `analysis` holds the derived results, including the circular dependencies, the maximum depth, the per-module Martin metrics, and the coupling analysis with its Zone of Pain and main-sequence module lists.
+`graph` holds the nodes and edges of the import graph. A node is a JavaScript/TypeScript file, identified by its path, or a Go package, identified by its import path with `name` holding the package name and `file_path` its directory. Every node carries the `abstractness` the graph builder measured: the export count for a JavaScript module, the share of exported types that are interfaces for a Go package. A Go edge joins two packages once, with `weight` counting the files that import the target, and carries no `location`. `analysis` holds the derived results, including the circular dependencies, the maximum depth, the per-module Martin metrics, and the coupling analysis with its Zone of Pain and main-sequence module lists.
 
 ## `module_quality`
 
@@ -375,7 +375,7 @@ One entry per file, joining what each analysis measured about it, across every l
 }
 ```
 
-`module_name` comes from dependency analysis and is omitted when that analysis did not run or the file is not JavaScript/TypeScript. The complexity columns come from complexity analysis and the dead-code columns from dead code detection, so a run that skipped one of them leaves those columns at zero rather than dropping the file.
+`module_name` comes from dependency analysis and is omitted when that analysis did not run or the file is not JavaScript/TypeScript; Go dependency nodes are packages, not files, so they name no entry here. The complexity columns come from complexity analysis and the dead-code columns from dead code detection, so a run that skipped one of them leaves those columns at zero rather than dropping the file.
 
 Unlike the rest of the report, these counts are taken before the presentation filters: `--min-complexity` and `min_severity` change what `complexity.functions` and `dead_code.files` show without changing what a module is measured as carrying. The entries are ranked worst first: high-risk functions, then maximum complexity, then average complexity, then dead-code findings.
 


### PR DESCRIPTION
Adds `deps` for Go. Each package becomes a node keyed by its import path (nearest `go.mod` module path + directory), imports between packages of the tree become deduplicated edges, and the graph runs through the same coupling, depth and chain analysis as the JavaScript module graph, so the Dependencies score, the JSON `deps` section and the Architecture tab light up for Go.

- Abstractness lives on `ModuleNode` now: export count for JavaScript, exported interface / exported type ratio for Go
- `service.AnalyzeDependencyGraph` is extracted from the JS service and shared; a mixed Go + JS tree is merged and re-analyzed in `report.mergeDeps`
- `_test.go`, `vendor/`, `testdata/`, `.`/`_` directories, and imports of the standard library or other modules stay out of the graph; a tree without `go.mod` gets a warning and no Dependencies dimension
- Docs, plugin skills and the changelog updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr
