### PR TITLE
feat(polyscan): class cohesion (LCOM4) for Go and Rust

### DIFF
--- a/.claude/skills/polyscan-fp-audit/SKILL.md
+++ b/.claude/skills/polyscan-fp-audit/SKILL.md
@@ -75,12 +75,13 @@ The single `analyze.json` holds every analysis under these top-level keys:
 | `clone` | all | `.clone.clone_pairs[]` → `clone1`/`clone2` (`language`, `location.{file_path,start_line,end_line}`, `content`, `line_count`), `similarity`, `type`; `.clone.clone_groups[]` |
 | `dead_code` | JS/TS only | `.dead_code.files[].functions[].findings[]` → `location`, `reason`, `severity`, `description` |
 | `cbo` | JS/TS only | `.cbo.classes[]` → `Name`, `FilePath`, `Metrics.CouplingCount`, `RiskLevel` |
+| `lcom` | Go, Rust | `.lcom.classes[]` → `name`, `file_path`, `language`, `start_line`, `metrics.lcom4`, `metrics.method_groups`, `risk_level` |
 | `deps` | Go, JS/TS | `.deps.analysis`, `.deps.graph` (Go nodes are packages keyed by import path) |
 | `summary` | — | `health_score`, `grade`, `total_loc`, `total_files`, `skipped_files`, per-dimension scores |
 
-To narrow scope, add `--select complexity,deadcode,clone,cbo,deps`.
+To narrow scope, add `--select complexity,deadcode,clone,cbo,lcom,deps`.
 
-**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected. For Go `deps.analysis.CircularDependencies` is always empty (the compiler forbids import cycles), Go edges carry no `location`, and Go files outside any `go.mod`, `_test.go` files, and `vendor`/`testdata` directories are absent from the graph by design.
+**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected. For Go `deps.analysis.CircularDependencies` is always empty (the compiler forbids import cycles), Go edges carry no `location`, and Go files outside any `go.mod`, `_test.go` files, and `vendor`/`testdata` directories are absent from the graph by design. A Go type in `lcom.classes[]` is measured over the methods of its whole package and placed in the first file that declares one, so `file_path` need not be the file that declares the type; `excluded_methods` counts methods without a receiver parameter, which is expected for Rust `new`-style associated functions.
 
 ### 4. Cluster findings
 
@@ -91,6 +92,7 @@ Read the JSON output. Group findings by `(analysis, language, rule_or_pattern)`.
 - `clone / cpp / cross-file-header-impl`
 - `deadcode / ts / unreachable_after_return`
 - `cbo / ts / coupling >= 10`
+- `lcom / go / lcom4 >= 6`
 
 For each cluster, record the total count and pick **3–5 representative samples** (prefer variety: different files, different sizes, mix of risk levels). Also collect:
 

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Every analyzer scores your codebase (0-100 with an A-F grade) and generates an H
 |---|---|:-:|:-:|:-:|:-:|:-:|---|
 | JavaScript / TypeScript | `.js` `.jsx` `.mjs` `.cjs` `.ts` `.tsx` `.mts` `.cts` | ✅ | ✅ | ✅ | ✅ | ✅ CBO | `polyscan` |
 | Python | `.py` | ✅ | ✅ | ✅ | ✅ | ✅ CBO, LCOM | `pyscn` |
-| Go | `.go` | ✅ | ✅ | — | ✅ | — | `polyscan` |
-| Rust | `.rs` | ✅ | ✅ | — | — | — | `polyscan` |
+| Go | `.go` | ✅ | ✅ | — | ✅ | ✅ LCOM | `polyscan` |
+| Rust | `.rs` | ✅ | ✅ | — | — | ✅ LCOM | `polyscan` |
 | C++ | `.cpp` `.cc` `.cxx` `.hpp` `.hh` `.hxx` `.h` `.ipp` `.inl` | ✅ | ✅ | — | — | — | `polyscan` |
 
-Complexity and duplicate code cover every language. Dependencies cover Go, JavaScript/TypeScript and Python: for Go the nodes are packages, resolved through `go.mod`. Dead code and class design need the class model and the file-level import graph that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
+Complexity and duplicate code cover every language. Dependencies cover Go, JavaScript/TypeScript and Python: for Go the nodes are packages, resolved through `go.mod`. Class design covers coupling (CBO) for JavaScript/TypeScript and Python and cohesion (LCOM4) for Python, Go and Rust: a Go type is measured over the methods of its package, a Rust type over the methods of its `impl` blocks in a file. Dead code needs the file-level import graph that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
 
 ## Polyscan for GitHub
 

--- a/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
@@ -1,17 +1,18 @@
 ---
 name: architecture-review
-description: Analyze JavaScript/TypeScript module architecture using polyscan - class coupling (CBO), instability metrics, and circular dependency detection. Use when user asks about architecture, module structure, coupling, or circular dependencies.
+description: Analyze module architecture using polyscan - class coupling (CBO), class cohesion (LCOM4), instability metrics, and circular dependency detection. Use when user asks about architecture, module structure, coupling, or circular dependencies.
 ---
 
 # Architecture Review with polyscan
 
-Run the polyscan CLI to understand module structure and coupling. Dependency analysis exists for Go (package graph) and JavaScript/TypeScript (module graph); coupling (CBO) for JavaScript/TypeScript; Rust and C++ get complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
+Run the polyscan CLI to understand module structure and coupling. Dependency analysis exists for Go (package graph) and JavaScript/TypeScript (module graph); coupling (CBO) for JavaScript/TypeScript; class cohesion (LCOM4) for Go and Rust; C++ gets complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
 
 ## Commands
 
 | User Request | Command |
 |-------------|---------|
 | "Check class coupling" | `npx polyscan@latest analyze --format text --select cbo <path>` |
+| "Which Go or Rust types do too many things?" | `npx polyscan@latest analyze --format text --select lcom <path>` |
 | "Find circular dependencies" | `npx polyscan@latest analyze --format text --select deps <path>` |
 | "Which modules are risky to change?" | `npx polyscan@latest analyze --format json --select deps,cbo <path>` |
 
@@ -20,6 +21,7 @@ Text output shows per-class CBO and cycle membership, but only **aggregate** cou
 ## Interpreting Coupling Results
 
 - High CBO classes depend on many others; changes ripple widely. Suggest interface extraction or dependency inversion.
+- A high LCOM4 type has methods that fall into several groups sharing no field or call; each group is a candidate for its own type.
 - Martin metrics per module (from the JSON output above): instability I = Ce / (Ca + Ce) and distance from the main sequence. Modules in the Zone of Pain (stable but concrete) are risky to change; name them explicitly.
 - Dependency cycles are the highest-priority architectural issue; name the modules in each cycle and the weakest edge to break.
 

--- a/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
@@ -24,7 +24,7 @@ polyscan analyze --min-complexity 10 .        # list only functions at or above 
 Key flags:
 
 - `--format html|json|text` (`-f`): output format; `json` and `text` write to stdout instead of an HTML report
-- `--select` (`-s`): `complexity,deadcode,clone,cbo,deps` (all run by default); `deps` applies to Go and JavaScript/TypeScript; `deadcode` and `cbo` to JavaScript/TypeScript only
+- `--select` (`-s`): `complexity,deadcode,clone,cbo,lcom,deps` (all run by default); `deps` applies to Go and JavaScript/TypeScript; `lcom` to Go and Rust; `deadcode` and `cbo` to JavaScript/TypeScript only
 - `--no-open`: don't auto-open the HTML report in a browser (use in scripts)
 - `-o <path>`: HTML report path (default: `polyscan-report.html` in the current directory)
 - `--min-complexity <n>`: hide functions below this complexity from the listing (scores still cover everything)
@@ -33,7 +33,7 @@ With `--format json`, the machine-readable results go to stdout and the health-s
 
 ## Language coverage
 
-Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Dead code and coupling (CBO) exist for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
+Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Class cohesion (LCOM4) covers Go and Rust. Dead code and coupling (CBO) exist for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
 ## CI usage
 

--- a/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
@@ -25,8 +25,8 @@ For machine-readable detail use `--format json`: full results go to stdout and t
 
 ## Interpreting Results
 
-- Score 0-100 with letter grade; category scores cover complexity, dead code, code duplication, coupling (CBO), and dependencies.
-- Complexity and duplication cover every language; dependencies run for Go and JavaScript/TypeScript; dead code and coupling for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
+- Score 0-100 with letter grade; category scores cover complexity, dead code, code duplication, coupling (CBO), cohesion (LCOM4), and dependencies.
+- Complexity and duplication cover every language; dependencies run for Go and JavaScript/TypeScript; cohesion for Go and Rust; dead code and coupling for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
 - Lead with the grade and the weakest categories, then name the top offenders (files/functions) driving them.
 - For deeper follow-up, hand off to the focused skills: refactoring targets → `refactoring`, module structure → `architecture-review`.
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Class cohesion (LCOM4) for Go and Rust. `polyscan analyze` measures, for each type, how many groups its methods fall into when two methods are connected by a shared field or a call between them, and scores the result in a Cohesion dimension with the thresholds pyscn uses (low up to 2, medium up to 5). A Go type is measured over every method of its package, since they may be spread across files; a Rust type over the `impl` blocks in a file. Methods without a receiver parameter, such as Rust associated functions and Go methods with an unnamed receiver, cannot touch instance state and are listed as excluded. Test files and `#[cfg(test)]` code stay out. `--select lcom` runs it alone
 - Dependency analysis for Go. `polyscan analyze` builds the package import graph of a Go tree, resolving each import through the nearest `go.mod`, and reports the same instability, abstractness, main-sequence distance, depth and longest chains it reports for JavaScript/TypeScript, scored in the Dependencies dimension. Abstractness is the share of a package's exported type declarations that are interfaces. Test files, `vendor` and `testdata` directories, and imports of other modules stay out of the graph, and a tree without a `go.mod` leaves the dimension out with a warning rather than scoring it clean
 
 ## [0.2.2] - 2026-09-05

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-A multi-language code quality analyzer. It detects the language of each file by its extension. Go, Rust and C++ get cyclomatic complexity and code clone detection from the generic engine; JavaScript/TypeScript files get the full [jscan](../jscan/README.md) analysis (complexity, dead code, clones, coupling, dependencies). Every language lands in one report with one health score: each analyzed dimension is scored against what it could have charged, and a dimension a language does not have is left out of the score rather than scored as clean.
+A multi-language code quality analyzer. It detects the language of each file by its extension. Go, Rust and C++ get cyclomatic complexity and code clone detection from the generic engine, Go and Rust also class cohesion (LCOM4) and Go package dependencies; JavaScript/TypeScript files get the full [jscan](../jscan/README.md) analysis (complexity, dead code, clones, coupling, dependencies). Every language lands in one report with one health score: each analyzed dimension is scored against what it could have charged, and a dimension a language does not have is left out of the score rather than scored as clean.
 
 ## Installation
 
@@ -34,7 +34,7 @@ polyscan analyze --select clone .
 polyscan analyze --min-complexity 10 .
 ```
 
-`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `deadcode` and `cbo` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
+`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo`, `lcom` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `lcom` for Go and Rust, `deadcode` and `cbo` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
 
 A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -25,13 +25,14 @@ const (
 	selectDeadCode   = "deadcode"
 	selectClone      = "clone"
 	selectCBO        = "cbo"
+	selectLCOM       = "lcom"
 	selectDeps       = "deps"
 
 	defaultReportPath = "polyscan-report.html"
 )
 
 // allAnalyses is the default selection: every analysis a language supports.
-var allAnalyses = []string{selectComplexity, selectDeadCode, selectClone, selectCBO, selectDeps}
+var allAnalyses = []string{selectComplexity, selectDeadCode, selectClone, selectCBO, selectLCOM, selectDeps}
 
 func analyzeCmd() *cobra.Command {
 	var (
@@ -51,10 +52,10 @@ The language of each file is detected from its extension. Supported: Go, Rust,
 C++ and JavaScript/TypeScript.
 
 Complexity and clone analysis cover every language; dependency analysis covers
-Go and JavaScript/TypeScript; dead code and coupling (CBO) exist for
-JavaScript/TypeScript only. The health score is computed over the dimensions
-that ran: a dimension a language does not have is left out, not scored as
-clean.
+Go and JavaScript/TypeScript; cohesion (LCOM4) covers Go and Rust; dead code
+and coupling (CBO) exist for JavaScript/TypeScript only. The health score is
+computed over the dimensions that ran: a dimension a language does not have is
+left out, not scored as clean.
 
 By default, generates an HTML report and opens it in your browser.
 
@@ -83,15 +84,18 @@ Examples:
 
 			start := time.Now()
 			var generic *analysis.Report
-			if options.Complexity || options.Clones || options.Deps {
+			if options != (analysis.Options{}) {
 				generic, err = analysis.Analyze(args, options)
 				if err != nil && !errors.Is(err, analysis.ErrNoFiles) {
 					return err
 				}
 			}
-			javascript, err := analyzeJavaScript(args, selection, cmd.ErrOrStderr())
-			if err != nil {
-				return err
+			var javascript *js.Result
+			if selection != (js.Selection{}) {
+				javascript, err = analyzeJavaScript(args, selection, cmd.ErrOrStderr())
+				if err != nil {
+					return err
+				}
 			}
 			if generic == nil && javascript == nil {
 				return analysis.ErrNoFiles
@@ -149,8 +153,9 @@ Examples:
 	}
 
 	cmd.Flags().StringSliceVarP(&selected, "select", "s", allAnalyses,
-		"Analyses to run (comma-separated): complexity,deadcode,clone,cbo,deps\n"+
-			"deps applies to Go and JavaScript/TypeScript; deadcode and cbo to JavaScript/TypeScript only")
+		"Analyses to run (comma-separated): complexity,deadcode,clone,cbo,lcom,deps\n"+
+			"deps applies to Go and JavaScript/TypeScript; lcom to Go and Rust;\n"+
+			"deadcode and cbo to JavaScript/TypeScript only")
 	cmd.Flags().StringVarP(&format, "format", "f", "html", "Output format: html, json, text")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "HTML report path (default: "+defaultReportPath+")")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
@@ -247,7 +252,7 @@ func writeReportFile(path string, write func(io.Writer, jsdomain.OutputFormat) e
 
 // parseSelection maps the selected analysis names onto the generic engine's
 // options and the JavaScript/TypeScript selection. deadcode and cbo exist
-// only for JavaScript/TypeScript.
+// only for JavaScript/TypeScript, lcom only for the generic engine.
 func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 	var options analysis.Options
 	var selection js.Selection
@@ -263,6 +268,8 @@ func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 			selection.DeadCode = true
 		case selectCBO:
 			selection.CBO = true
+		case selectLCOM:
+			options.LCOM = true
 		case selectDeps:
 			options.Deps = true
 			selection.Deps = true
@@ -271,7 +278,7 @@ func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 				"invalid analysis %q, must be one of: %s", name, strings.Join(allAnalyses, ", "))
 		}
 	}
-	if selection == (js.Selection{}) {
+	if selection == (js.Selection{}) && options == (analysis.Options{}) {
 		return options, selection, fmt.Errorf("no analysis selected")
 	}
 	return options, selection, nil

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -51,8 +51,22 @@ type analyzeJSON struct {
 		} `json:"analysis"`
 		Warnings []string `json:"warnings"`
 	} `json:"deps"`
+	LCOM *struct {
+		Classes []struct {
+			Name     string `json:"name"`
+			Language string `json:"language"`
+			Metrics  struct {
+				LCOM4 int `json:"lcom4"`
+			} `json:"metrics"`
+		} `json:"classes"`
+		Summary struct {
+			TotalClasses int `json:"total_classes"`
+		} `json:"summary"`
+	} `json:"lcom"`
 	Summary *struct {
 		HealthScore       int    `json:"health_score"`
+		CohesionScore     int    `json:"cohesion_score"`
+		LCOMEnabled       bool   `json:"lcom_enabled"`
 		DependencyScore   int    `json:"dependency_score"`
 		DepsEnabled       bool   `json:"deps_enabled"`
 		Grade             string `json:"grade"`
@@ -387,5 +401,43 @@ func TestAnalyzeGoDependenciesOnlyCountsSkippedFiles(t *testing.T) {
 	doc := decodeAnalyzeJSON(t, out)
 	if doc.Summary == nil || doc.Summary.TotalFiles != 2 || doc.Summary.SkippedFiles != 1 {
 		t.Errorf("summary = %+v, want 2 files with 1 skipped whichever analyses ran", doc.Summary)
+	}
+}
+
+func TestAnalyzeCohesion(t *testing.T) {
+	dir := t.TempDir()
+	// A Go type next to a JavaScript file: lcom alone must not start the
+	// JavaScript pipeline with nothing selected.
+	if err := os.WriteFile(filepath.Join(dir, "a.go"), []byte("package p\n\ntype T struct{ a, b int }\n\nfunc (t *T) A() { t.a++ }\nfunc (t *T) B() { t.b++ }\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "a.js"), []byte("export function f() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, err := run(t, "analyze", "--format", "json", "--select", "lcom", dir)
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.LCOM == nil || len(doc.LCOM.Classes) != 1 {
+		t.Fatalf("lcom = %+v, want one class", doc.LCOM)
+	}
+	class := doc.LCOM.Classes[0]
+	if class.Name != "T" || class.Language != "Go" || class.Metrics.LCOM4 != 2 {
+		t.Errorf("class = %+v, want T (Go) with LCOM4 2", class)
+	}
+	if doc.Summary == nil || !doc.Summary.LCOMEnabled || doc.Summary.CohesionScore != 100 {
+		t.Errorf("summary = %+v, want cohesion enabled at 100", doc.Summary)
+	}
+
+	out, err = run(t, "analyze", "--format", "text", "--select", "lcom", dir)
+	if err != nil {
+		t.Fatalf("analyze text: %v\n%s", err, out)
+	}
+	for _, want := range []string{"=== LCOM Analysis ===", "T: LCOM4=2 [low]", "Cohesion:         100/100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output lacks %q:\n%s", want, out)
+		}
 	}
 }

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -27,6 +27,9 @@ type Options struct {
 	// Deps builds the package dependency graph. Go is the only language of
 	// the generic engine with one so far.
 	Deps bool
+	// LCOM measures the cohesion of each type's methods, for the languages
+	// whose definition declares how a method reaches its fields.
+	LCOM bool
 }
 
 // Function is the complexity result for one function.
@@ -87,6 +90,9 @@ type Report struct {
 	// Deps is the Go package dependency graph, in the shape the unified
 	// report renders, or nil when no Go package could be placed in one.
 	Deps *jsdomain.DependencyGraphResponse `json:"deps,omitempty"`
+	// Cohesion is the LCOM4 analysis, or nil when no analyzed file belongs
+	// to a language that has one.
+	Cohesion *Cohesion `json:"cohesion,omitempty"`
 	// FileLines is the source line count of every analyzed file, keyed by
 	// its reported path. The unified report shows lines per hotspot file,
 	// and this run is the only place the contents are in hand.
@@ -134,6 +140,8 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	}
 	detectors := map[*engine.Language]*clone.Detector{}
 	cloneLines, cloneFiles := 0, 0
+	cohesion := newCohesionBuilder()
+	cohesionFiles := 0
 
 	for _, file := range files {
 		language, ok := lang.ByPath(file)
@@ -175,6 +183,17 @@ func Analyze(paths []string, options Options) (*Report, error) {
 				}
 			}
 		}
+		// Test files stay out for the same reason as in clone detection: a
+		// test's types are fixtures, and a test may add helper methods to
+		// a type its package declares.
+		if options.LCOM && language.HasCohesion() && !language.IsTestFile(display) {
+			cohesionFiles++
+			for _, fn := range functions {
+				if !fn.IsTest {
+					cohesion.add(language, display, fn)
+				}
+			}
+		}
 	}
 
 	if options.Complexity {
@@ -185,6 +204,9 @@ func Analyze(paths []string, options Options) (*Report, error) {
 		report.Clones = detectClones(detectors)
 		report.Clones.Statistics.LinesAnalyzed = cloneLines
 		report.Clones.Statistics.FilesAnalyzed = cloneFiles
+	}
+	if cohesionFiles > 0 {
+		report.Cohesion = cohesion.build()
 	}
 	return report, nil
 }

--- a/polyscan/internal/analysis/cohesion.go
+++ b/polyscan/internal/analysis/cohesion.go
@@ -1,0 +1,202 @@
+package analysis
+
+import (
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/core/lcom"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+// Class is the cohesion result for one type.
+type Class struct {
+	Name     string `json:"name"`
+	FilePath string `json:"file_path"`
+	Language string `json:"language"`
+	// StartLine and EndLine span the type's methods in FilePath. A type
+	// whose methods are spread over several files is placed in the first of
+	// them.
+	StartLine int `json:"start_line"`
+	EndLine   int `json:"end_line"`
+	// LCOM4 is the number of connected components among the methods, where
+	// two methods are connected when they share a field or one calls the
+	// other.
+	LCOM4 int `json:"lcom4"`
+	// TotalMethods counts every method of the type; ExcludedMethods the
+	// ones without a receiver parameter, which cannot reach instance state
+	// and stay out of the graph.
+	TotalMethods      int              `json:"total_methods"`
+	ExcludedMethods   int              `json:"excluded_methods"`
+	InstanceVariables []string         `json:"instance_variables"`
+	MethodGroups      [][]string       `json:"method_groups"`
+	RiskLevel         domain.RiskLevel `json:"risk_level"`
+}
+
+// CohesionSummary aggregates every analyzed type.
+type CohesionSummary struct {
+	TotalClasses      int     `json:"total_classes"`
+	AverageLCOM       float64 `json:"average_lcom"`
+	MaxLCOM           int     `json:"max_lcom"`
+	MinLCOM           int     `json:"min_lcom"`
+	LowRiskClasses    int     `json:"low_risk_classes"`
+	MediumRiskClasses int     `json:"medium_risk_classes"`
+	HighRiskClasses   int     `json:"high_risk_classes"`
+}
+
+// Cohesion is the LCOM4 analysis of a set of paths.
+type Cohesion struct {
+	// Classes is sorted by descending LCOM4, then by location.
+	Classes []Class         `json:"classes"`
+	Summary CohesionSummary `json:"summary"`
+}
+
+// classMethods collects the methods of one type before they are measured.
+type classMethods struct {
+	name     string
+	language *engine.Language
+	methods  []classMethod
+}
+
+type classMethod struct {
+	engine.Function
+	file string
+}
+
+// cohesionBuilder groups methods by type. A type is identified by its
+// language, its receiver name and the file that declares its methods, or
+// the directory when the language lets a type's methods span one.
+type cohesionBuilder struct {
+	classes map[string]*classMethods
+	keys    []string
+}
+
+func newCohesionBuilder() *cohesionBuilder {
+	return &cohesionBuilder{classes: map[string]*classMethods{}}
+}
+
+func (b *cohesionBuilder) add(language *engine.Language, display string, fn engine.Function) {
+	if fn.Receiver == "" {
+		return
+	}
+	location := display
+	if language.TypeSpansDirectory {
+		location = filepath.Dir(display)
+	}
+	key := language.Name + "\x00" + location + "\x00" + fn.Receiver
+	class, ok := b.classes[key]
+	if !ok {
+		class = &classMethods{name: fn.Receiver, language: language}
+		b.classes[key] = class
+		b.keys = append(b.keys, key)
+	}
+	class.methods = append(class.methods, classMethod{Function: fn, file: display})
+}
+
+// build measures every type that has at least one method with a receiver
+// parameter. A type with none, such as one that only has constructors, has
+// no cohesion to measure and is left out.
+func (b *cohesionBuilder) build() *Cohesion {
+	cohesion := &Cohesion{Classes: []Class{}}
+	for _, key := range b.keys {
+		class := b.classes[key].measure()
+		if class.TotalMethods > class.ExcludedMethods {
+			cohesion.Classes = append(cohesion.Classes, class)
+		}
+	}
+	sort.SliceStable(cohesion.Classes, func(i, j int) bool {
+		a, b := cohesion.Classes[i], cohesion.Classes[j]
+		if a.LCOM4 != b.LCOM4 {
+			return a.LCOM4 > b.LCOM4
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		return a.StartLine < b.StartLine
+	})
+	cohesion.Summary = summarizeCohesion(cohesion.Classes)
+	return cohesion
+}
+
+// measure computes the class's LCOM4. A call whose name is not a sibling
+// method, such as a call of a function-typed field, is an access to that
+// field.
+func (c *classMethods) measure() Class {
+	sort.SliceStable(c.methods, func(i, j int) bool {
+		if c.methods[i].file != c.methods[j].file {
+			return c.methods[i].file < c.methods[j].file
+		}
+		return c.methods[i].StartLine < c.methods[j].StartLine
+	})
+	prefix := c.name + c.language.Separator()
+	names := map[string]bool{}
+	for _, method := range c.methods {
+		names[strings.TrimPrefix(method.Name, prefix)] = true
+	}
+
+	class := Class{
+		Name:      c.name,
+		FilePath:  c.methods[0].file,
+		Language:  c.language.Name,
+		StartLine: c.methods[0].StartLine,
+	}
+	var accesses []lcom.MethodAccess
+	for _, method := range c.methods {
+		class.TotalMethods++
+		if method.file == class.FilePath {
+			class.EndLine = max(class.EndLine, method.EndLine)
+		}
+		if !method.HasSelf {
+			class.ExcludedMethods++
+			continue
+		}
+		access := lcom.MethodAccess{
+			MethodName:   strings.TrimPrefix(method.Name, prefix),
+			InstanceVars: map[string]bool{},
+			Calls:        map[string]bool{},
+		}
+		for field := range method.Fields {
+			access.InstanceVars[field] = true
+		}
+		for call := range method.Calls {
+			if names[call] {
+				access.Calls[call] = true
+			} else {
+				access.InstanceVars[call] = true
+			}
+		}
+		accesses = append(accesses, access)
+	}
+
+	result := lcom.ComputeLCOM4(accesses, lcom.DefaultConfig())
+	class.LCOM4 = result.LCOM4
+	class.InstanceVariables = result.InstanceVariables
+	class.MethodGroups = result.MethodGroups
+	class.RiskLevel = result.RiskLevel
+	return class
+}
+
+func summarizeCohesion(classes []Class) CohesionSummary {
+	summary := CohesionSummary{TotalClasses: len(classes)}
+	if len(classes) == 0 {
+		return summary
+	}
+	total := 0
+	summary.MinLCOM = classes[0].LCOM4
+	for _, class := range classes {
+		total += class.LCOM4
+		summary.MaxLCOM = max(summary.MaxLCOM, class.LCOM4)
+		summary.MinLCOM = min(summary.MinLCOM, class.LCOM4)
+		switch class.RiskLevel {
+		case domain.RiskLevelLow:
+			summary.LowRiskClasses++
+		case domain.RiskLevelMedium:
+			summary.MediumRiskClasses++
+		case domain.RiskLevelHigh:
+			summary.HighRiskClasses++
+		}
+	}
+	summary.AverageLCOM = float64(total) / float64(len(classes))
+	return summary
+}

--- a/polyscan/internal/analysis/cohesion_test.go
+++ b/polyscan/internal/analysis/cohesion_test.go
@@ -1,0 +1,169 @@
+package analysis
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
+)
+
+func writeFiles(t *testing.T, files map[string]string) string {
+	t.Helper()
+	dir := t.TempDir()
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	return dir
+}
+
+func TestAnalyzeCohesionGroupsGoMethodsByPackage(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		// Server's methods span two files. Start/Stop share running,
+		// Log calls a function-typed field that Stop also touches, and
+		// Version touches nothing: three components in total.
+		"server.go": `package p
+
+type Server struct {
+	running bool
+	logf    func(string)
+}
+
+func (s *Server) Start() { s.running = true }
+func (s *Server) Stop()  { s.running = false; s.logf("bye") }
+func (Server) Version() string { return "1" }
+`,
+		"log.go": `package p
+
+func (s *Server) Log(msg string) { s.logf(msg) }
+func (s *Server) Name() string  { return "srv" }
+`,
+		// A type declared in a test file is a fixture and stays out.
+		"server_test.go": `package p
+
+type fake struct{ n int }
+
+func (f *fake) A() { f.n++ }
+func (f *fake) B() {}
+`,
+		// A second package with a type of the same name is another class.
+		"other/server.go": `package other
+
+type Server struct{ a int }
+
+func (s *Server) A() { s.a++ }
+func (s *Server) B() {}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Cohesion == nil {
+		t.Fatal("cohesion is nil for a Go tree")
+	}
+	if report.Complexity != nil || report.Clones != nil {
+		t.Error("only cohesion was selected")
+	}
+	classes := report.Cohesion.Classes
+	if len(classes) != 2 {
+		t.Fatalf("got %d classes, want 2: %+v", len(classes), classes)
+	}
+
+	server := classes[0]
+	if server.Name != "Server" || server.Language != "Go" || filepath.Base(server.FilePath) != "log.go" {
+		t.Errorf("first class = %+v, want Server placed in log.go", server)
+	}
+	if server.LCOM4 != 2 || server.TotalMethods != 5 || server.ExcludedMethods != 1 {
+		t.Errorf("Server: LCOM4 %d, methods %d, excluded %d; want 2, 5, 1", server.LCOM4, server.TotalMethods, server.ExcludedMethods)
+	}
+	wantGroups := [][]string{{"Log", "Start", "Stop"}, {"Name"}}
+	if !reflect.DeepEqual(server.MethodGroups, wantGroups) {
+		t.Errorf("Server groups = %v, want %v", server.MethodGroups, wantGroups)
+	}
+	if !reflect.DeepEqual(server.InstanceVariables, []string{"logf", "running"}) {
+		t.Errorf("Server variables = %v", server.InstanceVariables)
+	}
+	if server.StartLine != 3 || server.EndLine != 4 {
+		t.Errorf("Server spans %d-%d in log.go, want 3-4", server.StartLine, server.EndLine)
+	}
+
+	other := classes[1]
+	if other.LCOM4 != 2 || filepath.Base(filepath.Dir(other.FilePath)) != "other" {
+		t.Errorf("second class = %+v, want other.Server with LCOM4 2", other)
+	}
+
+	summary := report.Cohesion.Summary
+	want := CohesionSummary{TotalClasses: 2, AverageLCOM: 2, MaxLCOM: 2, MinLCOM: 2, LowRiskClasses: 2}
+	if summary != want {
+		t.Errorf("summary = %+v, want %+v", summary, want)
+	}
+}
+
+func TestAnalyzeCohesionRust(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"lib.rs": `
+pub struct Counter { n: u32, log: Vec<String> }
+
+impl Counter {
+    pub fn new() -> Self { Counter { n: 0, log: vec![] } }
+    pub fn inc(&mut self) { self.n += 1; self.record() }
+    fn record(&mut self) { self.log.push(String::new()) }
+    pub fn a(&self) -> u32 { 1 }
+    pub fn b(&self) -> u32 { 2 }
+    pub fn c(&self) -> u32 { 3 }
+    pub fn d(&self) -> u32 { 4 }
+    pub fn e(&self) -> u32 { 5 }
+}
+
+pub struct Builder;
+impl Builder { pub fn new() -> Self { Builder } }
+
+#[cfg(test)]
+mod tests {
+    struct Fixture;
+    impl Fixture { fn x(&self) {} fn y(&self) {} }
+}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	classes := report.Cohesion.Classes
+	if len(classes) != 1 {
+		t.Fatalf("got %d classes, want only Counter (Builder has no method with a receiver): %+v", len(classes), classes)
+	}
+	counter := classes[0]
+	if counter.Name != "Counter" || counter.LCOM4 != 6 || counter.ExcludedMethods != 1 || counter.RiskLevel != domain.RiskLevelHigh {
+		t.Errorf("Counter = %+v, want LCOM4 6 (high) with new excluded", counter)
+	}
+}
+
+func TestAnalyzeCohesionAbsentWithoutSupportedLanguage(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; void m() { a = 1; } };\n"})
+	report, err := Analyze([]string{dir}, Options{LCOM: true, Complexity: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Cohesion != nil {
+		t.Errorf("cohesion = %+v, want none for a C++ tree", report.Cohesion)
+	}
+	dir = writeFiles(t, map[string]string{"a.go": "package p\n\nfunc F() {}\n"})
+	report, err = Analyze([]string{dir}, Options{LCOM: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Cohesion == nil || report.Cohesion.Summary.TotalClasses != 0 {
+		t.Errorf("cohesion = %+v, want an empty result for a Go tree without types", report.Cohesion)
+	}
+}

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -61,6 +61,14 @@ type Language struct {
 	// state and is left out of cohesion. A language without a Members
 	// query has no cohesion analysis.
 	Members string
+	// Bindings is an optional tree-sitter query for the local declarations
+	// that can shadow the receiver a Members match goes through: @binding
+	// is the declared name, @declaration the node after whose end the name
+	// is in scope, as the right-hand side of a short variable declaration
+	// still sees the outer name, and @scope the node at whose end it goes
+	// out of scope. A Members match whose @object is shadowed at that point
+	// is not an access to the receiver.
+	Bindings string
 	// Nesting is a tree-sitter query whose captures are the constructs that
 	// open a nesting level: branches, loops, switches and try blocks. A
 	// capture named @continuation marks a construct that continues the
@@ -95,6 +103,7 @@ type Language struct {
 	nesting     *sitter.Query
 	scopes      *sitter.Query
 	members     *sitter.Query
+	bindings    *sitter.Query
 	testCode    *sitter.Query
 	identifiers map[string]struct{}
 	literals    map[string]struct{}
@@ -191,6 +200,8 @@ const (
 	fieldCapture        = "field"
 	callCapture         = "call"
 	objectCapture       = "object"
+	bindingCapture      = "binding"
+	declarationCapture  = "declaration"
 	continuationCapture = "continuation"
 	operatorField       = "operator"
 )
@@ -322,6 +333,14 @@ func (l *Language) compile() error {
 				return
 			}
 			l.members = members
+		}
+		if l.Bindings != "" {
+			bindings, err := sitter.NewQuery([]byte(l.Bindings), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s bindings query: %w", l.Name, err)
+				return
+			}
+			l.bindings = bindings
 		}
 		if l.TestCode != "" {
 			testCode, err := sitter.NewQuery([]byte(l.TestCode), l.Grammar)
@@ -613,10 +632,11 @@ func (l *Language) collectMembers(root *sitter.Node, source []byte, functions []
 	}
 	fields := map[uintptr]member{}
 	calls := map[uintptr]struct{}{}
+	bindings := l.collectBindings(root, source)
 	ForEachMatch(l.members, root, source, func(match *sitter.QueryMatch) {
 		var fn *Function
-		var node *sitter.Node
-		var kind, object string
+		var node, object *sitter.Node
+		var kind string
 		for _, capture := range match.Captures {
 			switch l.members.CaptureNameForId(capture.Index) {
 			case fieldCapture, callCapture:
@@ -624,11 +644,17 @@ func (l *Language) collectMembers(root *sitter.Node, source []byte, functions []
 				node = capture.Node
 				fn = innermost(functions, node.StartByte(), node.EndByte())
 			case objectCapture:
-				object = capture.Node.Content(source)
+				object = capture.Node
 			}
 		}
-		if fn == nil || fn.Fields == nil || (object != "" && object != fn.self) {
+		if fn == nil || fn.Fields == nil {
 			return
+		}
+		if object != nil {
+			name := object.Content(source)
+			if name != fn.self || bindings.shadows(name, object.StartByte()) {
+				return
+			}
 		}
 		name := node.Content(source)
 		if kind == callCapture {
@@ -643,6 +669,51 @@ func (l *Language) collectMembers(root *sitter.Node, source []byte, functions []
 			field.fn.Fields[field.name] = true
 		}
 	}
+}
+
+// binding is one local declaration from the Bindings query: the name is in
+// scope from the end of its declaration to the end of its scope.
+type binding struct {
+	declarationEnd, scopeStart, scopeEnd uint32
+}
+
+type bindings map[string][]binding
+
+// collectBindings gathers the file's local declarations by name.
+func (l *Language) collectBindings(root *sitter.Node, source []byte) bindings {
+	result := bindings{}
+	if l.bindings == nil {
+		return result
+	}
+	ForEachMatch(l.bindings, root, source, func(match *sitter.QueryMatch) {
+		var name string
+		var b binding
+		for _, capture := range match.Captures {
+			switch l.bindings.CaptureNameForId(capture.Index) {
+			case bindingCapture:
+				name = capture.Node.Content(source)
+			case declarationCapture:
+				b.declarationEnd = capture.Node.EndByte()
+			case scopeCapture:
+				b.scopeStart, b.scopeEnd = capture.Node.StartByte(), capture.Node.EndByte()
+			}
+		}
+		if name != "" && b.scopeEnd > b.scopeStart {
+			result[name] = append(result[name], b)
+		}
+	})
+	return result
+}
+
+// shadows reports whether a local declaration of name is in scope at the
+// byte position.
+func (b bindings) shadows(name string, position uint32) bool {
+	for _, binding := range b[name] {
+		if position >= binding.declarationEnd && position >= binding.scopeStart && position < binding.scopeEnd {
+			return true
+		}
+	}
+	return false
 }
 
 // markTests flags every function inside a span the TestCode query captures.

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -688,6 +688,7 @@ func (l *Language) collectBindings(root *sitter.Node, source []byte) bindings {
 	ForEachMatch(l.bindings, root, source, func(match *sitter.QueryMatch) {
 		var name string
 		var b binding
+		var scope *sitter.Node
 		for _, capture := range match.Captures {
 			switch l.bindings.CaptureNameForId(capture.Index) {
 			case bindingCapture:
@@ -695,10 +696,13 @@ func (l *Language) collectBindings(root *sitter.Node, source []byte) bindings {
 			case declarationCapture:
 				b.declarationEnd = capture.Node.EndByte()
 			case scopeCapture:
-				b.scopeStart, b.scopeEnd = capture.Node.StartByte(), capture.Node.EndByte()
+				scope = capture.Node
+				b.scopeStart, b.scopeEnd = scope.StartByte(), scope.EndByte()
 			}
 		}
-		if name != "" && b.scopeEnd > b.scopeStart {
+		// A declaration whose scope is the whole file is a package-level
+		// one, which a receiver shadows rather than the other way around.
+		if name != "" && scope != nil && scope.Parent() != nil {
 			result[name] = append(result[name], b)
 		}
 	})

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -30,14 +30,16 @@ type Language struct {
 	// Its @definition.<kind> capture spans the whole function and @name its
 	// name. An optional @receiver capture holds a receiver type declared on
 	// the function itself, as Go methods do, and is prefixed to the name
-	// with the ScopeSeparator.
+	// with the ScopeSeparator. An optional @self capture holds the receiver
+	// parameter of a method that has one.
 	Definitions string
 	// Scopes is an optional tree-sitter query for the named scopes that
 	// enclose functions, such as classes, impl blocks and namespaces:
-	// @scope spans the scope and @receiver holds its name. A function is
-	// named after the scopes that contain it, outermost first, so a member
-	// defined inside its class and one defined outside it with a qualified
-	// name read the same.
+	// @scope spans the scope and @receiver or @module holds its name. A
+	// function is named after the scopes that contain it, outermost first,
+	// so a member defined inside its class and one defined outside it with a
+	// qualified name read the same. A @receiver scope is a type whose
+	// functions are its methods; a @module scope only qualifies names.
 	Scopes string
 	// ScopeSeparator joins scope and receiver names to function names;
 	// empty means ".".
@@ -47,6 +49,18 @@ type Language struct {
 	// that contains it and counted under the capture's name, so the capture
 	// names double as the breakdown reported next to the complexity.
 	Decisions string
+	// Members is an optional tree-sitter query for what a method does with
+	// its own type: @field captures the name of a field it reads or writes
+	// and @call the name of a sibling method it calls. A match may also
+	// capture @object, the variable the access goes through, and then only
+	// counts when that variable is the method's receiver, as Go's named
+	// receivers require; a language whose receiver is a keyword, as Rust's
+	// self is, leaves @object out. The Definitions query marks the receiver
+	// with @self: a function with a receiver type but no @self, such as a
+	// Rust associated function, is a method that cannot touch instance
+	// state and is left out of cohesion. A language without a Members
+	// query has no cohesion analysis.
+	Members string
 	// Nesting is a tree-sitter query whose captures are the constructs that
 	// open a nesting level: branches, loops, switches and try blocks. A
 	// capture named @continuation marks a construct that continues the
@@ -68,6 +82,11 @@ type Language struct {
 	// report.
 	TestFiles []string
 	TestCode  string
+	// TypeSpansDirectory reports that the methods of one type may be
+	// declared across the files of a directory, as Go's may be across the
+	// files of a package, so cohesion is computed per directory and type
+	// rather than per file and type.
+	TypeSpansDirectory bool
 
 	compileOnce sync.Once
 	compileErr  error
@@ -75,6 +94,7 @@ type Language struct {
 	decisions   *sitter.Query
 	nesting     *sitter.Query
 	scopes      *sitter.Query
+	members     *sitter.Query
 	testCode    *sitter.Query
 	identifiers map[string]struct{}
 	literals    map[string]struct{}
@@ -144,22 +164,45 @@ type Function struct {
 	// IsTest reports that the function lies in a span the language's
 	// TestCode query captured.
 	IsTest bool
+	// Receiver is the qualified name of the type the function is a method
+	// of, or empty for a free function.
+	Receiver string
+	// HasSelf reports that the method has a receiver parameter through
+	// which it can reach instance state. Fields and Calls are the names of
+	// the fields it accesses and the sibling methods it calls, per the
+	// language's Members query.
+	HasSelf bool
+	Fields  map[string]bool
+	Calls   map[string]bool
 
 	startByte uint32
 	endByte   uint32
 	hasError  bool
+	self      string
 }
 
 const (
 	definitionPrefix    = "definition."
 	nameCapture         = "name"
 	receiverCapture     = "receiver"
+	selfCapture         = "self"
 	scopeCapture        = "scope"
+	moduleCapture       = "module"
+	fieldCapture        = "field"
+	callCapture         = "call"
+	objectCapture       = "object"
 	continuationCapture = "continuation"
 	operatorField       = "operator"
 )
 
-func (l *Language) separator() string {
+// HasCohesion reports whether the language declares what a method does
+// with its type, which the cohesion (LCOM4) analysis needs.
+func (l *Language) HasCohesion() bool {
+	return l.Members != ""
+}
+
+// Separator is the ScopeSeparator, or "." when none is set.
+func (l *Language) Separator() string {
 	if l.ScopeSeparator == "" {
 		return "."
 	}
@@ -225,6 +268,7 @@ func (l *Language) Analyze(source []byte) (*Result, error) {
 	l.applyScopes(root, source, functions)
 	l.countDecisions(root, source, functions)
 	l.measureNesting(root, source, functions)
+	l.collectMembers(root, source, functions)
 	l.markTests(root, source, functions)
 	for i := range functions {
 		functions[i].Complexity = 1
@@ -271,6 +315,14 @@ func (l *Language) compile() error {
 			}
 			l.scopes = scopes
 		}
+		if l.Members != "" {
+			members, err := sitter.NewQuery([]byte(l.Members), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s members query: %w", l.Name, err)
+				return
+			}
+			l.members = members
+		}
 		if l.TestCode != "" {
 			testCode, err := sitter.NewQuery([]byte(l.TestCode), l.Grammar)
 			if err != nil {
@@ -311,14 +363,20 @@ func (l *Language) extractFunctions(root *sitter.Node, source []byte) []Function
 				fn.Name = capture.Node.Content(source)
 			case name == receiverCapture:
 				receiver = capture.Node.Content(source)
+			case name == selfCapture:
+				fn.self = capture.Node.Content(source)
 			}
 		}
 		if node == nil || fn.Name == "" {
 			return
 		}
 		if receiver != "" {
-			fn.Name = receiver + l.separator() + fn.Name
+			fn.Name = receiver + l.Separator() + fn.Name
+			fn.Receiver = receiver
 		}
+		// A blank receiver name cannot be referred to, so the method has no
+		// way to reach instance state.
+		fn.HasSelf = fn.self != "" && fn.self != "_"
 		fn.StartLine = int(node.StartPoint().Row) + 1
 		fn.StartColumn = int(node.StartPoint().Column) + 1
 		fn.EndLine = int(node.EndPoint().Row) + 1
@@ -464,15 +522,19 @@ func (l *Language) measureNesting(root *sitter.Node, source []byte, functions []
 	})
 }
 
-// scope is a named span from the Scopes query.
+// scope is a named span from the Scopes query. isType marks a @receiver
+// scope, whose functions are methods.
 type scope struct {
 	start, end uint32
 	name       string
+	isType     bool
 }
 
 // applyScopes prefixes each function with the names of the scopes that
-// contain it, outermost first. Functions and scopes are both in start
-// order, so one sweep with a stack of the open scopes covers them.
+// contain it, outermost first, and makes a function whose innermost scope
+// is a type a method of that type, named with the same prefix. Functions
+// and scopes are both in start order, so one sweep with a stack of the open
+// scopes covers them.
 func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Function) {
 	if l.scopes == nil {
 		return
@@ -485,6 +547,9 @@ func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Fun
 			case scopeCapture:
 				s.start, s.end = capture.Node.StartByte(), capture.Node.EndByte()
 			case receiverCapture:
+				s.name = capture.Node.Content(source)
+				s.isType = true
+			case moduleCapture:
 				s.name = capture.Node.Content(source)
 			}
 		}
@@ -506,13 +571,76 @@ func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Fun
 			open = open[:len(open)-1]
 		}
 		var names []string
+		innermostIsType := false
 		for _, s := range open {
 			if s.end >= fn.endByte {
 				names = append(names, s.name)
+				innermostIsType = s.isType
 			}
 		}
-		if len(names) > 0 {
-			fn.Name = strings.Join(names, l.separator()) + l.separator() + fn.Name
+		if len(names) == 0 {
+			continue
+		}
+		prefix := strings.Join(names, l.Separator())
+		fn.Name = prefix + l.Separator() + fn.Name
+		switch {
+		case fn.Receiver != "":
+			fn.Receiver = prefix + l.Separator() + fn.Receiver
+		case innermostIsType:
+			fn.Receiver = prefix
+		}
+	}
+}
+
+// collectMembers records, for each method with a receiver parameter, the
+// fields it accesses and the sibling methods it calls; a free function or a
+// method without one keeps nil maps. A name captured as
+// both, as the callee of a method call is by a field pattern that also
+// matches it, is a call.
+func (l *Language) collectMembers(root *sitter.Node, source []byte, functions []Function) {
+	if l.members == nil {
+		return
+	}
+	for i := range functions {
+		if functions[i].Receiver != "" && functions[i].HasSelf {
+			functions[i].Fields = map[string]bool{}
+			functions[i].Calls = map[string]bool{}
+		}
+	}
+	type member struct {
+		fn   *Function
+		name string
+	}
+	fields := map[uintptr]member{}
+	calls := map[uintptr]struct{}{}
+	ForEachMatch(l.members, root, source, func(match *sitter.QueryMatch) {
+		var fn *Function
+		var node *sitter.Node
+		var kind, object string
+		for _, capture := range match.Captures {
+			switch l.members.CaptureNameForId(capture.Index) {
+			case fieldCapture, callCapture:
+				kind = l.members.CaptureNameForId(capture.Index)
+				node = capture.Node
+				fn = innermost(functions, node.StartByte(), node.EndByte())
+			case objectCapture:
+				object = capture.Node.Content(source)
+			}
+		}
+		if fn == nil || fn.Fields == nil || (object != "" && object != fn.self) {
+			return
+		}
+		name := node.Content(source)
+		if kind == callCapture {
+			fn.Calls[name] = true
+			calls[node.ID()] = struct{}{}
+			return
+		}
+		fields[node.ID()] = member{fn, name}
+	})
+	for id, field := range fields {
+		if _, isCall := calls[id]; !isCall {
+			field.fn.Fields[field.name] = true
 		}
 	}
 }

--- a/polyscan/internal/js/domain/analyze.go
+++ b/polyscan/internal/js/domain/analyze.go
@@ -33,6 +33,12 @@ const (
 	CouplingMediumWeight    = coredomain.CouplingMediumWeight
 	CouplingSaturationRatio = coredomain.CouplingSaturationRatio
 
+	// LCOM cohesion scoring curve (used by calculateCohesionPenalty), the
+	// same curve pyscn applies. Penalty grows linearly with the weighted
+	// ratio of low-cohesion classes and saturates at CohesionSaturationRatio.
+	CohesionMediumWeight    = 0.3  // Medium-risk classes count 0.3 vs High = 1.0
+	CohesionSaturationRatio = 0.40 // weighted ratio at which the penalty maxes out
+
 	// Complexity scoring curve (used by calculateComplexityPenalty)
 	// Penalty grows linearly with the weighted ratio of high and medium risk
 	// functions and saturates at ComplexitySaturationRatio. The ratio is
@@ -105,6 +111,7 @@ type AnalyzeResponse struct {
 	DeadCode   *DeadCodeResponse       `json:"dead_code,omitempty" yaml:"dead_code,omitempty"`
 	Clone      *CloneResponse          `json:"clone,omitempty" yaml:"clone,omitempty"`
 	CBO        *CBOResponse            `json:"cbo,omitempty" yaml:"cbo,omitempty"`
+	LCOM       *LCOMResponse           `json:"lcom,omitempty" yaml:"lcom,omitempty"`
 	System     *SystemAnalysisResponse `json:"system,omitempty" yaml:"system,omitempty"`
 
 	// Overall summary
@@ -147,6 +154,7 @@ type AnalysisResults struct {
 	DeadCode   *DeadCodeResponse
 	Clone      *CloneResponse
 	CBO        *CBOResponse
+	LCOM       *LCOMResponse
 	Deps       *DependencyGraphResponse
 }
 
@@ -162,6 +170,7 @@ type AnalyzeSummary struct {
 	DeadCodeEnabled   bool `json:"dead_code_enabled" yaml:"dead_code_enabled"`
 	CloneEnabled      bool `json:"clone_enabled" yaml:"clone_enabled"`
 	CBOEnabled        bool `json:"cbo_enabled" yaml:"cbo_enabled"`
+	LCOMEnabled       bool `json:"lcom_enabled" yaml:"lcom_enabled"`
 
 	// System-level (module dependencies & architecture) summary used for scoring
 	DepsEnabled               bool    `json:"deps_enabled" yaml:"deps_enabled"`
@@ -203,6 +212,11 @@ type AnalyzeSummary struct {
 	MediumCouplingClasses int     `json:"medium_coupling_classes" yaml:"medium_coupling_classes"` // 3 < CBO ≤ 7 (Medium Risk)
 	AverageCoupling       float64 `json:"average_coupling" yaml:"average_coupling"`
 
+	LCOMClasses       int     `json:"lcom_classes" yaml:"lcom_classes"`
+	HighLCOMClasses   int     `json:"high_lcom_classes" yaml:"high_lcom_classes"`     // LCOM4 > 5 (High Risk)
+	MediumLCOMClasses int     `json:"medium_lcom_classes" yaml:"medium_lcom_classes"` // 2 < LCOM4 <= 5 (Medium Risk)
+	AverageLCOM       float64 `json:"average_lcom" yaml:"average_lcom"`
+
 	// Project scale
 	// TotalLOC is the number of lines the clone analysis read; it is 0 when
 	// clone analysis is disabled.
@@ -218,6 +232,7 @@ type AnalyzeSummary struct {
 	DeadCodeScore     int `json:"dead_code_score" yaml:"dead_code_score"`
 	DuplicationScore  int `json:"duplication_score" yaml:"duplication_score"`
 	CouplingScore     int `json:"coupling_score" yaml:"coupling_score"`
+	CohesionScore     int `json:"cohesion_score" yaml:"cohesion_score"`
 	DependencyScore   int `json:"dependency_score" yaml:"dependency_score"`
 	ArchitectureScore int `json:"architecture_score" yaml:"architecture_score"`
 }
@@ -276,6 +291,12 @@ func (s *AnalyzeSummary) Validate() error {
 			return fmt.Errorf("HighCouplingClasses + MediumCouplingClasses (%d) cannot exceed CBOClasses (%d)",
 				s.HighCouplingClasses+s.MediumCouplingClasses, s.CBOClasses)
 		}
+	}
+
+	// LCOM checks
+	if s.LCOMClasses > 0 && s.HighLCOMClasses+s.MediumLCOMClasses > s.LCOMClasses {
+		return fmt.Errorf("HighLCOMClasses + MediumLCOMClasses (%d) cannot exceed LCOMClasses (%d)",
+			s.HighLCOMClasses+s.MediumLCOMClasses, s.LCOMClasses)
 	}
 
 	return nil
@@ -346,6 +367,17 @@ func (s *AnalyzeSummary) calculateCouplingPenalty() int {
 	return coredomain.CouplingPenalty(s.HighCouplingClasses, s.MediumCouplingClasses, s.CBOClasses)
 }
 
+// calculateCohesionPenalty calculates the penalty for class cohesion (max 20)
+// from the weighted ratio of low-cohesion classes, with a medium-risk class
+// weighing CohesionMediumWeight of a high-risk one.
+func (s *AnalyzeSummary) calculateCohesionPenalty() int {
+	if s.LCOMClasses == 0 {
+		return 0
+	}
+	weighted := float64(s.HighLCOMClasses) + CohesionMediumWeight*float64(s.MediumLCOMClasses)
+	return coredomain.LinearPenalty(weighted/float64(s.LCOMClasses), 0, CohesionSaturationRatio)
+}
+
 // calculateDependencyPenalty calculates the penalty for module dependencies (max 16: cycles=10, depth=3, MSD=3)
 func (s *AnalyzeSummary) calculateDependencyPenalty() int {
 	if !s.DepsEnabled {
@@ -395,6 +427,7 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 		s.DeadCodeScore = 0
 		s.DuplicationScore = 0
 		s.CouplingScore = 0
+		s.CohesionScore = 0
 		s.DependencyScore = 0
 		s.ArchitectureScore = 0
 		return fmt.Errorf("invalid summary data: %w", err)
@@ -413,6 +446,9 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 
 	couplingPenalty := s.calculateCouplingPenalty()
 	s.CouplingScore = penaltyToScore(couplingPenalty, MaxScoreBase)
+
+	cohesionPenalty := s.calculateCohesionPenalty()
+	s.CohesionScore = penaltyToScore(cohesionPenalty, MaxScoreBase)
 
 	// Dependencies and Architecture need normalization since their max penalties differ from MaxScoreBase
 	dependencyPenalty := s.calculateDependencyPenalty()
@@ -444,6 +480,7 @@ func (s *AnalyzeSummary) CalculateHealthScore() error {
 	charge(s.DeadCodeEnabled, deadCodePenalty, MaxScoreBase)
 	charge(s.CloneEnabled, duplicationPenalty, MaxScoreBase)
 	charge(s.CBOEnabled, couplingPenalty, MaxScoreBase)
+	charge(s.LCOMEnabled, cohesionPenalty, MaxScoreBase)
 	charge(s.DepsEnabled, dependencyPenalty, MaxDependencyPenalty)
 	charge(s.ArchEnabled, architecturePenalty, MaxArchitecturePenalty)
 
@@ -543,5 +580,5 @@ func (s *AnalyzeSummary) IsHealthy() bool {
 
 // HasIssues returns true if any issues were found
 func (s *AnalyzeSummary) HasIssues() bool {
-	return s.HighComplexityCount > 0 || s.DeadCodeCount > 0 || s.ClonePairs > 0 || s.HighCouplingClasses > 0
+	return s.HighComplexityCount > 0 || s.DeadCodeCount > 0 || s.ClonePairs > 0 || s.HighCouplingClasses > 0 || s.HighLCOMClasses > 0
 }

--- a/polyscan/internal/js/domain/analyze_test.go
+++ b/polyscan/internal/js/domain/analyze_test.go
@@ -353,3 +353,30 @@ func TestCalculateHealthScore_MSDPenalty(t *testing.T) {
 		})
 	}
 }
+
+func TestCalculateHealthScore_CohesionCalibration(t *testing.T) {
+	// 10 high and 20 medium of 100 classes weigh 16%, which is 40% of the
+	// way to the 0.40 saturation: an 8-point penalty on the 20-point scale.
+	s := &AnalyzeSummary{
+		LCOMEnabled:       true,
+		LCOMClasses:       100,
+		HighLCOMClasses:   10,
+		MediumLCOMClasses: 20,
+		AverageLCOM:       1.8,
+	}
+	if err := s.CalculateHealthScore(); err != nil {
+		t.Fatalf("CalculateHealthScore: %v", err)
+	}
+	if s.CohesionScore != 60 {
+		t.Errorf("CohesionScore = %d, want 60", s.CohesionScore)
+	}
+	// Cohesion is the only enabled dimension, so it is the health score.
+	if s.HealthScore != 60 {
+		t.Errorf("HealthScore = %d, want 60", s.HealthScore)
+	}
+
+	s = &AnalyzeSummary{LCOMEnabled: true, LCOMClasses: 3, HighLCOMClasses: 2, MediumLCOMClasses: 2}
+	if err := s.CalculateHealthScore(); err == nil {
+		t.Error("expected a validation error when risk counts exceed the class count")
+	}
+}

--- a/polyscan/internal/js/domain/lcom.go
+++ b/polyscan/internal/js/domain/lcom.go
@@ -1,0 +1,57 @@
+package domain
+
+// LCOMMetrics is the cohesion measurement of one class.
+type LCOMMetrics struct {
+	// LCOM4 is the number of connected components among the methods, where
+	// two methods are connected when they share an instance variable or one
+	// calls the other.
+	LCOM4 int `json:"lcom4" yaml:"lcom4"`
+	// TotalMethods counts every method of the class; ExcludedMethods the
+	// ones kept out of the graph because they cannot reach instance state.
+	TotalMethods    int `json:"total_methods" yaml:"total_methods"`
+	ExcludedMethods int `json:"excluded_methods" yaml:"excluded_methods"`
+	// InstanceVariables counts the distinct instance variables the methods
+	// access.
+	InstanceVariables int `json:"instance_variables" yaml:"instance_variables"`
+	// MethodGroups lists the method names of each connected component.
+	MethodGroups [][]string `json:"method_groups" yaml:"method_groups"`
+}
+
+// ClassCohesion is the LCOM result for a single class.
+type ClassCohesion struct {
+	Name      string `json:"name" yaml:"name"`
+	FilePath  string `json:"file_path" yaml:"file_path"`
+	Language  string `json:"language,omitempty" yaml:"language,omitempty"`
+	StartLine int    `json:"start_line" yaml:"start_line"`
+	EndLine   int    `json:"end_line" yaml:"end_line"`
+
+	Metrics LCOMMetrics `json:"metrics" yaml:"metrics"`
+
+	RiskLevel RiskLevel `json:"risk_level" yaml:"risk_level"`
+}
+
+// LCOMSummary aggregates LCOM statistics.
+type LCOMSummary struct {
+	TotalClasses int     `json:"total_classes" yaml:"total_classes"`
+	AverageLCOM  float64 `json:"average_lcom" yaml:"average_lcom"`
+	MaxLCOM      int     `json:"max_lcom" yaml:"max_lcom"`
+	MinLCOM      int     `json:"min_lcom" yaml:"min_lcom"`
+
+	LowRiskClasses    int `json:"low_risk_classes" yaml:"low_risk_classes"`
+	MediumRiskClasses int `json:"medium_risk_classes" yaml:"medium_risk_classes"`
+	HighRiskClasses   int `json:"high_risk_classes" yaml:"high_risk_classes"`
+}
+
+// LCOMResponse is the complete LCOM analysis result.
+type LCOMResponse struct {
+	// Classes is sorted by descending LCOM4, then by location.
+	Classes []ClassCohesion `json:"classes" yaml:"classes"`
+	Summary LCOMSummary     `json:"summary" yaml:"summary"`
+
+	Warnings []string `json:"warnings" yaml:"warnings"`
+	Errors   []string `json:"errors" yaml:"errors"`
+
+	GeneratedAt string      `json:"generated_at" yaml:"generated_at"`
+	Version     string      `json:"version" yaml:"version"`
+	Config      interface{} `json:"config" yaml:"config"`
+}

--- a/polyscan/internal/js/service/html_formatter.go
+++ b/polyscan/internal/js/service/html_formatter.go
@@ -108,6 +108,7 @@ type analyzeReportView struct {
 	DeadCode      *domain.DeadCodeResponse
 	Clone         *domain.CloneResponse
 	CBO           *domain.CBOResponse
+	LCOM          *domain.LCOMResponse
 	Deps          *domain.DependencyGraphResponse
 	ModuleQuality []domain.ModuleQualityMetrics
 	Summary       *domain.AnalyzeSummary
@@ -264,6 +265,7 @@ func buildAnalyzeReportView(
 		DeadCode:        results.DeadCode,
 		Clone:           results.Clone,
 		CBO:             results.CBO,
+		LCOM:            results.LCOM,
 		Deps:            results.Deps,
 		ModuleQuality:   moduleQuality,
 		Summary:         summary,
@@ -284,7 +286,7 @@ func buildAnalyzeReportView(
 	view.Hotspots = buildReportHotspots(moduleQuality, results.Clone, risk)
 	view.Histogram = buildReportHistogram(results.Complexity, risk)
 	view.Duplication = buildReportDuplication(summary, results.Clone)
-	view.Classes = buildReportClasses(summary, results.CBO)
+	view.Classes = buildReportClasses(summary, results.CBO, results.LCOM)
 	view.Structure = buildReportStructure(results.Deps)
 	return view
 }
@@ -402,8 +404,8 @@ func buildReportTabs(
 		}
 		tabs = append(tabs, tab)
 	}
-	if summary.CBOEnabled {
-		tab := reportTab{ID: "classes", Label: "Classes", Count: summary.HighCouplingClasses}
+	if summary.CBOEnabled || summary.LCOMEnabled {
+		tab := reportTab{ID: "classes", Label: "Classes", Count: summary.HighCouplingClasses + summary.HighLCOMClasses}
 		if tab.Count > 0 {
 			tab.CountBand = "bad"
 		}
@@ -465,6 +467,11 @@ func buildReportDimensions(summary *domain.AnalyzeSummary, tabs []reportTab) []r
 		add("Coupling", summary.CouplingScore,
 			fmt.Sprintf("avg CBO %.1f", summary.AverageCoupling),
 			fmt.Sprintf("%d of %d high", summary.HighCouplingClasses, summary.CBOClasses), "classes")
+	}
+	if summary.LCOMEnabled {
+		add("Cohesion", summary.CohesionScore,
+			fmt.Sprintf("avg LCOM4 %.1f", summary.AverageLCOM),
+			fmt.Sprintf("%d of %d low", summary.HighLCOMClasses, summary.LCOMClasses), "classes")
 	}
 	if summary.DepsEnabled {
 		cycles := "no cycles"
@@ -614,8 +621,9 @@ func buildReportFacts(summary *domain.AnalyzeSummary, moduleQuality []domain.Mod
 	if summary.ComplexityEnabled {
 		facts = append(facts, reportFact{Value: formatThousands(summary.TotalFunctions), Label: "functions"})
 	}
-	if summary.CBOEnabled {
-		facts = append(facts, reportFact{Value: formatThousands(summary.CBOClasses), Label: "classes"})
+	// CBO and LCOM cover disjoint languages, so their class counts add up.
+	if classes := summary.CBOClasses + summary.LCOMClasses; summary.CBOEnabled || summary.LCOMEnabled {
+		facts = append(facts, reportFact{Value: formatThousands(classes), Label: "classes"})
 	}
 	return facts
 }
@@ -1116,24 +1124,51 @@ func cloneContent(fragment *domain.Clone) string {
 	return strings.Join(lines[:maxLines], "\n") + "\n..."
 }
 
-func buildReportClasses(summary *domain.AnalyzeSummary, cbo *domain.CBOResponse) *reportClasses {
+// buildReportClasses summarizes the class analyses that ran: coupling for
+// JavaScript/TypeScript, cohesion for Go and Rust. The two cover disjoint
+// languages, so the class counts add up.
+func buildReportClasses(summary *domain.AnalyzeSummary, cbo *domain.CBOResponse, lcom *domain.LCOMResponse) *reportClasses {
 	if !summary.CBOEnabled || cbo == nil {
+		cbo = nil
+	}
+	if !summary.LCOMEnabled || lcom == nil {
+		lcom = nil
+	}
+	if cbo == nil && lcom == nil {
 		return nil
 	}
-	classes := &reportClasses{
-		Total: cbo.Summary.TotalClasses,
-		Facts: []reportKV{
-			{Key: "High coupling", Value: formatThousands(cbo.Summary.HighRiskClasses), Band: warnIfPositive(cbo.Summary.HighRiskClasses)},
-			{Key: "Medium coupling", Value: formatThousands(cbo.Summary.MediumRiskClasses)},
-			{Key: "Average CBO", Value: fmt.Sprintf("%.2f", cbo.Summary.AverageCBO)},
-		},
+	classes := &reportClasses{}
+	if cbo != nil {
+		classes.Total += cbo.Summary.TotalClasses
+		classes.Facts = append(classes.Facts,
+			reportKV{Key: "High coupling", Value: formatThousands(cbo.Summary.HighRiskClasses), Band: warnIfPositive(cbo.Summary.HighRiskClasses)},
+			reportKV{Key: "Medium coupling", Value: formatThousands(cbo.Summary.MediumRiskClasses)},
+			reportKV{Key: "Average CBO", Value: fmt.Sprintf("%.2f", cbo.Summary.AverageCBO)},
+		)
+		if top := mostCoupledClass(cbo.Classes); top != nil {
+			classes.Facts = append(classes.Facts, reportKV{
+				Key:   "Most coupled",
+				Value: fmt.Sprintf("%s (%d)", top.Name, top.Metrics.CouplingCount),
+				Mono:  true,
+			})
+		}
 	}
-	if top := mostCoupledClass(cbo.Classes); top != nil {
-		classes.Facts = append(classes.Facts, reportKV{
-			Key:   "Most coupled",
-			Value: fmt.Sprintf("%s (%d)", top.Name, top.Metrics.CouplingCount),
-			Mono:  true,
-		})
+	if lcom != nil {
+		classes.Total += lcom.Summary.TotalClasses
+		classes.Facts = append(classes.Facts,
+			reportKV{Key: "Low cohesion", Value: formatThousands(lcom.Summary.HighRiskClasses), Band: warnIfPositive(lcom.Summary.HighRiskClasses)},
+			reportKV{Key: "Medium cohesion", Value: formatThousands(lcom.Summary.MediumRiskClasses)},
+			reportKV{Key: "Average LCOM4", Value: fmt.Sprintf("%.2f", lcom.Summary.AverageLCOM)},
+		)
+		// Classes are sorted by descending LCOM4.
+		if len(lcom.Classes) > 0 {
+			top := lcom.Classes[0]
+			classes.Facts = append(classes.Facts, reportKV{
+				Key:   "Least cohesive",
+				Value: fmt.Sprintf("%s (%d)", top.Name, top.Metrics.LCOM4),
+				Mono:  true,
+			})
+		}
 	}
 	return classes
 }

--- a/polyscan/internal/js/service/output_formatter.go
+++ b/polyscan/internal/js/service/output_formatter.go
@@ -88,6 +88,17 @@ type CBOResponseJSON struct {
 	Config      interface{}            `json:"config,omitempty"`
 }
 
+// LCOMResponseJSON wraps LCOMResponse with JSON metadata
+type LCOMResponseJSON struct {
+	Version     string                 `json:"version"`
+	GeneratedAt string                 `json:"generated_at"`
+	Classes     []domain.ClassCohesion `json:"classes"`
+	Summary     domain.LCOMSummary     `json:"summary"`
+	Warnings    []string               `json:"warnings,omitempty"`
+	Errors      []string               `json:"errors,omitempty"`
+	Config      interface{}            `json:"config,omitempty"`
+}
+
 // DepsResponseJSON wraps DependencyGraphResponse with JSON metadata
 type DepsResponseJSON struct {
 	Version     string                           `json:"version"`
@@ -107,6 +118,7 @@ type AnalyzeResponseJSON struct {
 	DeadCode      *DeadCodeResponseJSON         `json:"dead_code,omitempty"`
 	Clone         *CloneResponseJSON            `json:"clone,omitempty"`
 	CBO           *CBOResponseJSON              `json:"cbo,omitempty"`
+	LCOM          *LCOMResponseJSON             `json:"lcom,omitempty"`
 	Deps          *DepsResponseJSON             `json:"deps,omitempty"`
 	ModuleQuality []domain.ModuleQualityMetrics `json:"module_quality,omitempty"`
 	Summary       *domain.AnalyzeSummary        `json:"summary,omitempty"`
@@ -177,6 +189,17 @@ func newAnalyzeResponseJSON(
 			Warnings:    results.CBO.Warnings,
 			Errors:      results.CBO.Errors,
 			Config:      results.CBO.Config,
+		}
+	}
+	if results.LCOM != nil {
+		response.LCOM = &LCOMResponseJSON{
+			Version:     version.Version,
+			GeneratedAt: results.LCOM.GeneratedAt,
+			Classes:     results.LCOM.Classes,
+			Summary:     results.LCOM.Summary,
+			Warnings:    results.LCOM.Warnings,
+			Errors:      results.LCOM.Errors,
+			Config:      results.LCOM.Config,
 		}
 	}
 	if results.Deps != nil {
@@ -306,6 +329,14 @@ func BuildAnalyzeSummary(results domain.AnalysisResults) *domain.AnalyzeSummary 
 		summary.AverageCoupling = results.CBO.Summary.AverageCBO
 	}
 
+	if results.LCOM != nil {
+		summary.LCOMEnabled = true
+		summary.LCOMClasses = results.LCOM.Summary.TotalClasses
+		summary.HighLCOMClasses = results.LCOM.Summary.HighRiskClasses
+		summary.MediumLCOMClasses = results.LCOM.Summary.MediumRiskClasses
+		summary.AverageLCOM = results.LCOM.Summary.AverageLCOM
+	}
+
 	if results.Deps != nil {
 		summary.DepsEnabled = true
 		if results.Deps.Graph != nil {
@@ -377,6 +408,11 @@ func FormatCLISummary(summary *domain.AnalyzeSummary, duration time.Duration, sk
 		fmt.Fprintf(w, "  Coupling (CBO):  %3d/100 %s  (avg: %.1f, %d/%d high-coupling)\n",
 			summary.CouplingScore, scoreIndicator(summary.CouplingScore),
 			summary.AverageCoupling, summary.HighCouplingClasses, summary.CBOClasses)
+	}
+	if summary.LCOMEnabled {
+		fmt.Fprintf(w, "  Cohesion (LCOM): %3d/100 %s  (avg: %.1f, %d/%d low-cohesion)\n",
+			summary.CohesionScore, scoreIndicator(summary.CohesionScore),
+			summary.AverageLCOM, summary.HighLCOMClasses, summary.LCOMClasses)
 	}
 	if summary.DepsEnabled {
 		cycles := 0
@@ -634,6 +670,11 @@ func (f *OutputFormatterImpl) writeAnalyzeText(
 		}
 	}
 
+	// LCOM analysis results
+	if results.LCOM != nil {
+		writeLCOMText(results.LCOM, writer)
+	}
+
 	// Dependency analysis results
 	if results.Deps != nil {
 		if err := f.writeDepsText(results.Deps, writer); err != nil {
@@ -668,6 +709,9 @@ func (f *OutputFormatterImpl) writeAnalyzeText(
 	}
 	if summary.CBOEnabled {
 		fmt.Fprintf(writer, "  Coupling:         %3d/100\n", summary.CouplingScore)
+	}
+	if summary.LCOMEnabled {
+		fmt.Fprintf(writer, "  Cohesion:         %3d/100\n", summary.CohesionScore)
 	}
 	if summary.DepsEnabled {
 		fmt.Fprintf(writer, "  Dependencies:     %3d/100\n", summary.DependencyScore)
@@ -821,6 +865,36 @@ func (f *OutputFormatterImpl) writeCBOText(response *domain.CBOResponse, writer 
 	}
 
 	return nil
+}
+
+// writeLCOMText writes LCOM analysis results as plain text.
+func writeLCOMText(response *domain.LCOMResponse, writer io.Writer) {
+	fmt.Fprintf(writer, "\n=== LCOM Analysis ===\n\n")
+
+	fmt.Fprintf(writer, "Summary:\n")
+	fmt.Fprintf(writer, "  Total classes: %d\n", response.Summary.TotalClasses)
+	fmt.Fprintf(writer, "  Average LCOM4: %.2f\n", response.Summary.AverageLCOM)
+	fmt.Fprintf(writer, "  Max LCOM4: %d\n", response.Summary.MaxLCOM)
+	fmt.Fprintf(writer, "\n")
+
+	fmt.Fprintf(writer, "Risk Distribution:\n")
+	fmt.Fprintf(writer, "  High risk: %d\n", response.Summary.HighRiskClasses)
+	fmt.Fprintf(writer, "  Medium risk: %d\n", response.Summary.MediumRiskClasses)
+	fmt.Fprintf(writer, "  Low risk: %d\n", response.Summary.LowRiskClasses)
+	fmt.Fprintf(writer, "\n")
+
+	if len(response.Classes) == 0 {
+		fmt.Fprintf(writer, "No classes found for LCOM analysis.\n")
+		return
+	}
+	fmt.Fprintf(writer, "Least Cohesive Classes:\n")
+	for i, class := range response.Classes {
+		if i == 10 {
+			break
+		}
+		fmt.Fprintf(writer, "  %s: LCOM4=%d [%s] (%s:%d)\n",
+			class.Name, class.Metrics.LCOM4, class.RiskLevel, class.FilePath, class.StartLine)
+	}
 }
 
 // writeAnalyzeYAML writes unified analysis response as YAML
@@ -1021,6 +1095,34 @@ func (f *OutputFormatterImpl) writeAnalyzeCSV(
 				class.Name,
 				class.FilePath,
 				strconv.Itoa(class.Metrics.CouplingCount),
+				string(class.RiskLevel),
+			}
+			if err := csvWriter.Write(record); err != nil {
+				return err
+			}
+		}
+		needsSeparator = true
+	}
+
+	// Write LCOM results
+	if results.LCOM != nil && len(results.LCOM.Classes) > 0 {
+		if needsSeparator {
+			if err := csvWriter.Write([]string{}); err != nil {
+				return err
+			}
+		}
+		if err := csvWriter.Write([]string{
+			"type", "class", "file", "lcom4", "risk_level",
+		}); err != nil {
+			return err
+		}
+
+		for _, class := range results.LCOM.Classes {
+			record := []string{
+				"lcom",
+				class.Name,
+				class.FilePath,
+				strconv.Itoa(class.Metrics.LCOM4),
 				string(class.RiskLevel),
 			}
 			if err := csvWriter.Write(record); err != nil {

--- a/polyscan/internal/js/service/templates/analyze/report.html
+++ b/polyscan/internal/js/service/templates/analyze/report.html
@@ -411,14 +411,17 @@
 {{end}}
 
 <!-- ================= CLASSES ================= -->
-{{if .Summary.CBOEnabled}}
+{{if or .Summary.CBOEnabled .Summary.LCOMEnabled}}
 <section id="classes" class="panel">
   <div class="panel-h">
     <h2>Classes</h2>
-    <div class="scores"><span class="score-pill {{scoreBand .Summary.CouplingScore}}">Coupling <b class="num">{{.Summary.CouplingScore}}</b>/100</span></div>
+    <div class="scores">
+      {{if .Summary.CBOEnabled}}<span class="score-pill {{scoreBand .Summary.CouplingScore}}">Coupling <b class="num">{{.Summary.CouplingScore}}</b>/100</span>{{end}}
+      {{if .Summary.LCOMEnabled}}<span class="score-pill {{scoreBand .Summary.CohesionScore}}">Cohesion <b class="num">{{.Summary.CohesionScore}}</b>/100</span>{{end}}
+    </div>
   </div>
 
-  {{if .CBO}}
+  {{if and .Summary.CBOEnabled .CBO}}
   <div class="card">
     <div class="card-h"><h2>Coupling</h2><span class="muted small">Coupling Between Objects (CBO)</span></div>
     <div class="strip">
@@ -449,6 +452,42 @@
     {{if gt (len .CBO.Classes) 20}}<p class="muted small note">Showing top 20 of {{len .CBO.Classes}} classes</p>{{end}}
     {{else}}
     <p class="muted note">No classes found for coupling analysis</p>
+    {{end}}
+  </div>
+  {{end}}
+
+  {{if and .Summary.LCOMEnabled .LCOM}}
+  <div class="card">
+    <div class="card-h"><h2>Cohesion</h2><span class="muted small">Lack of Cohesion of Methods (LCOM4)</span></div>
+    <div class="strip">
+      <div class="s"><div class="v num">{{.LCOM.Summary.TotalClasses}}</div><div class="l">classes</div></div>
+      <div class="s"><div class="v num{{if .LCOM.Summary.HighRiskClasses}} bad{{end}}">{{.LCOM.Summary.HighRiskClasses}}</div><div class="l">low cohesion</div></div>
+      <div class="s"><div class="v num{{if .LCOM.Summary.MediumRiskClasses}} warn{{end}}">{{.LCOM.Summary.MediumRiskClasses}}</div><div class="l">medium cohesion</div></div>
+      <div class="s"><div class="v num">{{printf "%.2f" .LCOM.Summary.AverageLCOM}}</div><div class="l">average LCOM4</div></div>
+      <div class="s"><div class="v num">{{.LCOM.Summary.MaxLCOM}}</div><div class="l">max LCOM4</div></div>
+    </div>
+    {{if .LCOM.Classes}}
+    <h3>Least cohesive classes</h3>
+    <div class="tbl-wrap">
+      <table class="tbl">
+        <thead><tr><th>Class</th><th>File</th><th class="r">LCOM4</th><th>Risk</th><th class="r">Methods</th><th class="r">Fields</th></tr></thead>
+        <tbody>
+          {{range $i, $c := .LCOM.Classes}}{{if lt $i 20}}
+          <tr>
+            <td class="mono">{{$c.Name}}</td>
+            <td class="mono muted">{{$c.FilePath}}:{{$c.StartLine}}</td>
+            <td class="r num">{{$c.Metrics.LCOM4}}</td>
+            <td><span class="pill risk-{{$c.RiskLevel}}">{{$c.RiskLevel}}</span></td>
+            <td class="r num">{{sub $c.Metrics.TotalMethods $c.Metrics.ExcludedMethods}}</td>
+            <td class="r num">{{$c.Metrics.InstanceVariables}}</td>
+          </tr>
+          {{end}}{{end}}
+        </tbody>
+      </table>
+    </div>
+    {{if gt (len .LCOM.Classes) 20}}<p class="muted small note">Showing top 20 of {{len .LCOM.Classes}} classes</p>{{end}}
+    {{else}}
+    <p class="muted note">No types with methods found for cohesion analysis</p>
     {{end}}
   </div>
   {{end}}

--- a/polyscan/internal/lang/cpp/cpp.go
+++ b/polyscan/internal/lang/cpp/cpp.go
@@ -50,7 +50,7 @@ var Language = &engine.Language{
 (class_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
 (struct_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
 (union_specifier name: (type_identifier) @receiver body: (field_declaration_list) @scope)
-(namespace_definition name: (namespace_identifier) @receiver body: (declaration_list) @scope)
+(namespace_definition name: (namespace_identifier) @module body: (declaration_list) @scope)
 `,
 	// A case without a value is the default, the path the other cases
 	// branch away from. A catch clause is the exception edge core/cfg

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -50,6 +50,22 @@ var Language = &engine.Language{
 (selector_expression operand: (identifier) @object field: (field_identifier) @field)
 (call_expression function: (selector_expression operand: (identifier) @object field: (field_identifier) @call))
 `,
+	// A local declaration hides the receiver from its end to the end of
+	// the block, case clause, if, for or switch statement that holds it; a
+	// type switch alias from the end of the switched value; a function
+	// literal's parameters throughout the literal.
+	Bindings: `
+(_ (short_var_declaration left: (expression_list (identifier) @binding)) @declaration) @scope
+(for_statement (for_clause initializer: (short_var_declaration left: (expression_list (identifier) @binding)) @declaration)) @scope
+(_ (range_clause left: (expression_list (identifier) @binding)) @declaration) @scope
+(_ (var_declaration (var_spec name: (identifier) @binding)) @declaration) @scope
+(_ (var_declaration (var_spec_list (var_spec name: (identifier) @binding))) @declaration) @scope
+(_ (const_declaration (const_spec name: (identifier) @binding)) @declaration) @scope
+(type_switch_statement alias: (expression_list (identifier) @binding) value: (_) @declaration) @scope
+(_ (receive_statement left: (expression_list (identifier) @binding)) @declaration) @scope
+(func_literal parameters: (parameter_list [(parameter_declaration name: (identifier) @binding) (variadic_parameter_declaration name: (identifier) @binding)] @declaration)) @scope
+(func_literal result: (parameter_list (parameter_declaration name: (identifier) @binding) @declaration)) @scope
+`,
 	// Methods of one type may be spread over the files of its package.
 	TypeSpansDirectory: true,
 	// default_case is deliberately absent: the default arm is the no-match

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -15,10 +15,11 @@ var Language = &engine.Language{
 	Grammar:    tsgo.GetLanguage(),
 	TestFiles:  []string{"*_test.go"},
 	// The definition patterns of tree-sitter-go's queries/tags.scm, with the
-	// receiver captured so methods report as "Type.Method". The Go
-	// specification allows a receiver type of T or *T, where T may carry
-	// type parameters, and the whole type may be parenthesized, which gofmt
-	// removes but the compiler accepts.
+	// receiver captured so methods report as "Type.Method" and its name, when
+	// the receiver has one, as the variable the method reaches its fields
+	// through. The Go specification allows a receiver type of T or *T, where
+	// T may carry type parameters, and the whole type may be parenthesized,
+	// which gofmt removes but the compiler accepts.
 	Definitions: `
 (function_declaration
   name: (identifier) @name) @definition.function
@@ -26,6 +27,7 @@ var Language = &engine.Language{
 (method_declaration
   receiver: (parameter_list
     (parameter_declaration
+      name: (identifier)? @self
       type: [
         (type_identifier) @receiver
         (pointer_type (type_identifier) @receiver)
@@ -40,6 +42,16 @@ var Language = &engine.Language{
       ]))
   name: (field_identifier) @name) @definition.method
 `,
+	// A field is anything selected from the receiver variable, so a promoted
+	// method of an embedded type counts as the embedded field it comes
+	// through; a sibling method is a call through the receiver. The engine
+	// discards a match whose @object is not the method's receiver.
+	Members: `
+(selector_expression operand: (identifier) @object field: (field_identifier) @field)
+(call_expression function: (selector_expression operand: (identifier) @object field: (field_identifier) @call))
+`,
+	// Methods of one type may be spread over the files of its package.
+	TypeSpansDirectory: true,
 	// default_case is deliberately absent: the default arm is the no-match
 	// path that the other cases already branch away from.
 	Decisions: `

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -53,7 +53,9 @@ var Language = &engine.Language{
 	// A local declaration hides the receiver from its end to the end of
 	// the block, case clause, if, for or switch statement that holds it; a
 	// type switch alias from the end of the switched value; a function
-	// literal's parameters throughout the literal.
+	// literal's parameters throughout the literal. The var and const
+	// patterns also match package-level declarations, whose scope is the
+	// file; the engine drops those, as a receiver shadows them instead.
 	Bindings: `
 (_ (short_var_declaration left: (expression_list (identifier) @binding)) @declaration) @scope
 (for_statement (for_clause initializer: (short_var_declaration left: (expression_list (identifier) @binding)) @declaration)) @scope

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -293,3 +293,106 @@ func equalStrings(got, want []string) bool {
 	}
 	return true
 }
+
+func TestMembersIgnoreShadowedReceiver(t *testing.T) {
+	functions := analyze(t, `package p
+
+type License struct{ TTL int; items []License; ch chan License }
+
+// The right-hand side of the declaration still sees the receiver.
+func (x *License) GetText() string {
+	if x, ok := x.GetSource().(*Text); ok {
+		return x.Text
+	}
+	return ""
+}
+
+func (x *License) Range() {
+	for _, x := range x.items {
+		x.Do()
+	}
+}
+
+func (x *License) ForClause() {
+	for x := 0; x < 3; x++ {
+		_ = x.Idx
+	}
+}
+
+func (x *License) Block() {
+	{
+		x := other()
+		x.Inner()
+	}
+	x.Outer()
+}
+
+func (x *License) Var() {
+	var x = 1
+	var (
+		y = x.Y
+	)
+	_ = y
+}
+
+func (x *License) TypeSwitch(v interface{}) {
+	switch x := x.Value().(type) {
+	case int:
+		_ = x.Int
+	}
+}
+
+func (x *License) Case(v int) {
+	switch v {
+	case 1:
+		x := 2
+		_ = x.One
+	case 2:
+		_ = x.Two
+	}
+}
+
+func (x *License) Select() {
+	select {
+	case x := <-x.ch:
+		x.Recv()
+	}
+}
+
+func (x *License) Closure() {
+	f := func(x int, rest ...int) (r int) { return x.Param + r.Result }
+	g := func() { x.Captured() }
+	f(1)
+	g()
+}
+`)
+
+	cases := []struct {
+		name   string
+		fields []string
+		calls  []string
+	}{
+		{"License.GetText", []string{}, []string{"GetSource"}},
+		{"License.Range", []string{"items"}, []string{}},
+		{"License.ForClause", []string{}, []string{}},
+		{"License.Block", []string{}, []string{"Outer"}},
+		{"License.Var", []string{}, []string{}},
+		{"License.TypeSwitch", []string{}, []string{"Value"}},
+		{"License.Case", []string{"Two"}, []string{}},
+		{"License.Select", []string{"ch"}, []string{}},
+		{"License.Closure", []string{}, []string{"Captured"}},
+	}
+	for _, tc := range cases {
+		fn, ok := functions[tc.name]
+		if !ok {
+			t.Errorf("missing function %q", tc.name)
+			continue
+		}
+		if got := slices.Sorted(maps.Keys(fn.Fields)); !equalStrings(got, tc.fields) {
+			t.Errorf("%s: fields = %v, want %v", tc.name, got, tc.fields)
+		}
+		if got := slices.Sorted(maps.Keys(fn.Calls)); !equalStrings(got, tc.calls) {
+			t.Errorf("%s: calls = %v, want %v", tc.name, got, tc.calls)
+		}
+	}
+}

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -299,6 +299,24 @@ func TestMembersIgnoreShadowedReceiver(t *testing.T) {
 
 type License struct{ TTL int; items []License; ch chan License }
 
+// Package-level names are the ones a receiver shadows.
+var x = newThing()
+
+const c = "x"
+
+func (c *License) Package() int {
+	c.Warm()
+	return c.TTL
+}
+
+func (x *License) Default(v int) {
+	switch v {
+	default:
+		var x = 1
+		_ = x.Def
+	}
+}
+
 // The right-hand side of the declaration still sees the receiver.
 func (x *License) GetText() string {
 	if x, ok := x.GetSource().(*Text); ok {
@@ -372,6 +390,8 @@ func (x *License) Closure() {
 		fields []string
 		calls  []string
 	}{
+		{"License.Package", []string{"TTL"}, []string{"Warm"}},
+		{"License.Default", []string{}, []string{}},
 		{"License.GetText", []string{}, []string{"GetSource"}},
 		{"License.Range", []string{"items"}, []string{}},
 		{"License.ForClause", []string{}, []string{}},

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -1,6 +1,8 @@
 package golang
 
 import (
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -211,4 +213,83 @@ func Closure(a, b bool) func() {
 			t.Errorf("%s: nesting depth = %d, want %d", name, got, depth)
 		}
 	}
+}
+
+func TestMembers(t *testing.T) {
+	functions := analyze(t, `package p
+
+type Base struct{}
+
+func (Base) Promoted() {}
+
+type T struct {
+	Base
+	a, b int
+	cb   func()
+}
+
+func (t *T) Fields() {
+	t.a = 1
+	t.b.c = 2
+	other.x = 3
+	go func() { t.a++ }()
+}
+
+func (t *T) Calls() {
+	t.Fields()
+	t.cb()
+	t.Base.Promoted()
+	t.Promoted()
+	other.Fields()
+}
+
+func (T) Static() {}
+
+func (_ T) Blank() {}
+
+func Free() {}
+`)
+
+	cases := []struct {
+		name     string
+		receiver string
+		hasSelf  bool
+		fields   []string
+		calls    []string
+	}{
+		{"Base.Promoted", "Base", false, nil, nil},
+		{"T.Fields", "T", true, []string{"a", "b"}, []string{}},
+		{"T.Calls", "T", true, []string{"Base"}, []string{"Fields", "Promoted", "cb"}},
+		{"T.Static", "T", false, nil, nil},
+		{"T.Blank", "T", false, nil, nil},
+		{"Free", "", false, nil, nil},
+	}
+	for _, tc := range cases {
+		fn, ok := functions[tc.name]
+		if !ok {
+			t.Errorf("missing function %q", tc.name)
+			continue
+		}
+		if fn.Receiver != tc.receiver || fn.HasSelf != tc.hasSelf {
+			t.Errorf("%s: receiver %q hasSelf %v, want %q %v", tc.name, fn.Receiver, fn.HasSelf, tc.receiver, tc.hasSelf)
+		}
+		if got := slices.Sorted(maps.Keys(fn.Fields)); !equalStrings(got, tc.fields) {
+			t.Errorf("%s: fields = %v, want %v", tc.name, got, tc.fields)
+		}
+		if got := slices.Sorted(maps.Keys(fn.Calls)); !equalStrings(got, tc.calls) {
+			t.Errorf("%s: calls = %v, want %v", tc.name, got, tc.calls)
+		}
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -40,14 +40,30 @@ var Language = &engine.Language{
   [(function_item) (impl_item) (trait_item) (mod_item)] @test
   (#eq? @attr "cfg") (#eq? @combinator "all") (#eq? @flag "test"))
 `,
-	// The function pattern of tree-sitter-rust's queries/tags.scm. Impl
+	// The function pattern of tree-sitter-rust's queries/tags.scm, with the
+	// self parameter captured in both its shorthand and typed forms. Impl
 	// and trait bodies are scopes, so their functions read Type::method,
-	// and so are modules.
-	Definitions: `(function_item name: (identifier) @name) @definition.function`,
+	// and so are modules. Only an impl makes its functions methods: a trait
+	// has no fields for its default methods to share, and a function of a
+	// module is free.
+	Definitions: `
+(function_item
+  name: (identifier) @name
+  parameters: (parameters [(self_parameter) (parameter pattern: (self))]? @self)) @definition.function
+`,
 	Scopes: `
 (impl_item type: (_) @receiver body: (declaration_list) @scope)
-(trait_item name: (type_identifier) @receiver body: (declaration_list) @scope)
-(mod_item name: (identifier) @receiver body: (declaration_list) @scope)
+(trait_item name: (type_identifier) @module body: (declaration_list) @scope)
+(mod_item name: (identifier) @module body: (declaration_list) @scope)
+`,
+	// A field is anything reached from self, including a tuple struct's
+	// numbered fields; a sibling method is a method call on self or an
+	// associated function called through Self.
+	Members: `
+(field_expression value: (self) field: [(field_identifier) (integer_literal)] @field)
+(call_expression function: (field_expression value: (self) field: (field_identifier) @call))
+((call_expression function: (scoped_identifier path: (identifier) @path name: (identifier) @call))
+  (#eq? @path "Self"))
 `,
 	// A match is exhaustive, so its last arm is the path the other arms
 	// branch away from and only arms followed by another arm count; an

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -1,6 +1,8 @@
 package rust
 
 import (
+	"maps"
+	"slices"
 	"strings"
 	"testing"
 
@@ -258,4 +260,77 @@ fn outer(a: bool) {
 			t.Errorf("%s: nesting depth = %d, want %d", name, fn.NestingDepth, depth)
 		}
 	}
+}
+
+func TestMembers(t *testing.T) {
+	functions := analyze(t, `
+pub struct S<T> { a: T, b: u32, cb: fn() }
+
+impl<T> S<T> {
+    pub fn new() -> Self { Self { a: 1, b: 2, cb: || {} } }
+    pub fn fields(&mut self) { self.a = 1; self.b.c = 2; other.x = 3; let f = || self.a; }
+    pub fn calls(&self) { self.fields(); (self.cb)(); Self::helper(self); Self::new(); other.fields() }
+    fn helper(this: &Self) {}
+    fn boxed(self: Box<Self>) { self.b; }
+}
+
+struct Pair(u32, u32);
+impl Pair { fn sum(&self) -> u32 { self.0 + self.1 } }
+
+trait Tr {
+    fn default_method(&self) { self.other() }
+}
+
+mod inner {
+    pub fn free(&self) {}
+    pub struct N;
+    impl N { pub fn m(&self) { self.x; } }
+}
+`)
+
+	cases := []struct {
+		name     string
+		receiver string
+		hasSelf  bool
+		fields   []string
+		calls    []string
+	}{
+		{"S<T>::new", "S<T>", false, nil, nil},
+		{"S<T>::fields", "S<T>", true, []string{"a", "b"}, []string{}},
+		{"S<T>::calls", "S<T>", true, []string{"cb"}, []string{"fields", "helper", "new"}},
+		{"S<T>::helper", "S<T>", false, nil, nil},
+		{"S<T>::boxed", "S<T>", true, []string{"b"}, []string{}},
+		{"Pair::sum", "Pair", true, []string{"0", "1"}, []string{}},
+		{"Tr::default_method", "", true, nil, nil},
+		{"inner::free", "", true, nil, nil},
+		{"inner::N::m", "inner::N", true, []string{"x"}, []string{}},
+	}
+	for _, tc := range cases {
+		fn, ok := functions[tc.name]
+		if !ok {
+			t.Errorf("missing function %q", tc.name)
+			continue
+		}
+		if fn.Receiver != tc.receiver || fn.HasSelf != tc.hasSelf {
+			t.Errorf("%s: receiver %q hasSelf %v, want %q %v", tc.name, fn.Receiver, fn.HasSelf, tc.receiver, tc.hasSelf)
+		}
+		if got := slices.Sorted(maps.Keys(fn.Fields)); !equalStrings(got, tc.fields) {
+			t.Errorf("%s: fields = %v, want %v", tc.name, got, tc.fields)
+		}
+		if got := slices.Sorted(maps.Keys(fn.Calls)); !equalStrings(got, tc.calls) {
+			t.Errorf("%s: calls = %v, want %v", tc.name, got, tc.calls)
+		}
+	}
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
 }

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -23,7 +23,8 @@ import (
 // Combine merges the generic-engine report with the JavaScript/TypeScript
 // result into the shape the output formatter renders. Complexity, clone and
 // dependency results merge across languages; dead code and coupling exist
-// only for JavaScript/TypeScript and pass through. The file accounting adds
+// only for JavaScript/TypeScript and pass through, and cohesion only for the
+// generic engine. The file accounting adds
 // up across both sides, so the health score charges every unparsable file
 // whichever analyses ran. Either input may be nil when its side found no
 // files.
@@ -49,6 +50,7 @@ func Combine(generic *analysis.Report, javascript *js.Result) (domain.AnalysisRe
 		})
 		results.Complexity = mergeComplexity(complexity, results.Complexity)
 		results.Clone = mergeClones(genericClones(generic), results.Clone)
+		results.LCOM = genericCohesion(generic)
 		results.Deps, err = mergeDeps(generic.Deps, results.Deps)
 		if err != nil {
 			return domain.AnalysisResults{}, err
@@ -250,6 +252,53 @@ func genericClones(report *analysis.Report) *domain.CloneResponse {
 			FilesAnalyzed:     src.Statistics.FilesAnalyzed,
 		},
 		Success: true,
+	}
+}
+
+// genericCohesion converts the generic engine's cohesion analysis into the
+// formatter's LCOM response.
+func genericCohesion(report *analysis.Report) *domain.LCOMResponse {
+	if report.Cohesion == nil {
+		return nil
+	}
+	src := report.Cohesion
+	classes := make([]domain.ClassCohesion, 0, len(src.Classes))
+	for _, class := range src.Classes {
+		classes = append(classes, domain.ClassCohesion{
+			Name:      class.Name,
+			FilePath:  class.FilePath,
+			Language:  class.Language,
+			StartLine: class.StartLine,
+			EndLine:   class.EndLine,
+			Metrics: domain.LCOMMetrics{
+				LCOM4:             class.LCOM4,
+				TotalMethods:      class.TotalMethods,
+				ExcludedMethods:   class.ExcludedMethods,
+				InstanceVariables: len(class.InstanceVariables),
+				MethodGroups:      class.MethodGroups,
+			},
+			RiskLevel: domain.RiskLevel(class.RiskLevel),
+		})
+	}
+	return &domain.LCOMResponse{
+		Classes: classes,
+		Summary: domain.LCOMSummary{
+			TotalClasses:      src.Summary.TotalClasses,
+			AverageLCOM:       src.Summary.AverageLCOM,
+			MaxLCOM:           src.Summary.MaxLCOM,
+			MinLCOM:           src.Summary.MinLCOM,
+			LowRiskClasses:    src.Summary.LowRiskClasses,
+			MediumRiskClasses: src.Summary.MediumRiskClasses,
+			HighRiskClasses:   src.Summary.HighRiskClasses,
+		},
+		Warnings:    []string{},
+		Errors:      []string{},
+		GeneratedAt: time.Now().Format(time.RFC3339),
+		Version:     version.Version,
+		Config: map[string]interface{}{
+			"low_threshold":    coredomain.DefaultLCOMLowThreshold,
+			"medium_threshold": coredomain.DefaultLCOMMediumThreshold,
+		},
 	}
 }
 


### PR DESCRIPTION
Adds a Cohesion dimension for Go and Rust.

- The engine gets a per-language `Members` query (`@field`, `@call`, optional `@object`) and marks receivers with `@self`; Scopes distinguish `@receiver` (types) from `@module` (namespaces). Each function now carries `Receiver`, `HasSelf`, `Fields` and `Calls`.
- `analysis` groups methods by type and runs `core/lcom`. A Go type is measured over the methods of its package (they may span files), a Rust type over the `impl` blocks in a file. Methods without a receiver parameter (Rust associated functions, Go unnamed receivers) are excluded; a call of a non-method through the receiver counts as a field access; test files and `#[cfg(test)]` code stay out.
- New `lcom` selection, `LCOMResponse` in the unified report, `cohesion_score` with pyscn's curve, and text, JSON, CSV and HTML output.

Smoke test on tokio 1.52: 545 types, average LCOM4 1.49, 4 high risk. Known limits: code inside macro invocations is not seen, and a stateless type with many trait methods scores high by definition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr