### PR TITLE
feat(polyscan): class coupling (CBO) for Go and Rust

### DIFF
--- a/.claude/skills/polyscan-fp-audit/SKILL.md
+++ b/.claude/skills/polyscan-fp-audit/SKILL.md
@@ -74,14 +74,14 @@ The single `analyze.json` holds every analysis under these top-level keys:
 | `complexity` | all | `.complexity.functions[]` → `name`, `file_path`, `language`, `start_line`, `end_line`, `metrics.complexity`, `risk_level` |
 | `clone` | all | `.clone.clone_pairs[]` → `clone1`/`clone2` (`language`, `location.{file_path,start_line,end_line}`, `content`, `line_count`), `similarity`, `type`; `.clone.clone_groups[]` |
 | `dead_code` | JS/TS only | `.dead_code.files[].functions[].findings[]` → `location`, `reason`, `severity`, `description` |
-| `cbo` | JS/TS only | `.cbo.classes[]` → `Name`, `FilePath`, `Metrics.CouplingCount`, `RiskLevel` |
+| `cbo` | Go, Rust, JS/TS | `.cbo.classes[]` → `Name`, `FilePath`, `language` (Go, Rust; absent for JS/TS), `StartLine`, `Metrics.CouplingCount`, `Metrics.DependentClasses`, `RiskLevel` |
 | `lcom` | Go, Rust | `.lcom.classes[]` → `name`, `file_path`, `language`, `start_line`, `metrics.lcom4`, `metrics.method_groups`, `risk_level` |
 | `deps` | Go, JS/TS | `.deps.analysis`, `.deps.graph` (Go nodes are packages keyed by import path) |
 | `summary` | — | `health_score`, `grade`, `total_loc`, `total_files`, `skipped_files`, per-dimension scores |
 
 To narrow scope, add `--select complexity,deadcode,clone,cbo,lcom,deps`.
 
-**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected. For Go `deps.analysis.CircularDependencies` is always empty (the compiler forbids import cycles), Go edges carry no `location`, and Go files outside any `go.mod`, `_test.go` files, and `vendor`/`testdata` directories are absent from the graph by design. A Go type in `lcom.classes[]` is measured over the methods of its whole package and placed in the first file that declares one, so `file_path` need not be the file that declares the type; `excluded_methods` counts methods without a receiver parameter, which is expected for Rust `new`-style associated functions.
+**Known structural zeros — never report these as bugs.** For Go/Rust/C++ the generic engine fills only `metrics.complexity` and `metrics.nesting_depth`; `nodes`, `edges`, `if_statements`, `loop_statements`, `exception_handlers` and `switch_cases` are always `0`. Clone fragments always have `hash: ""`, `complexity: 0` and `start_col`/`end_col` `0`. `cbo.classes[]` for JS lists one pseudo-class per file (module-level coupling), so a `Name` equal to the file basename is expected. For Go and Rust a `cbo` entry is one type, and `DependentClasses` only ever names types declared in the analyzed tree: standard library, third-party and other-module types are absent by design, a type coupled to nothing is not listed, and a Go tree without `go.mod` lists same-package dependencies only (a warning says so). For Go `deps.analysis.CircularDependencies` is always empty (the compiler forbids import cycles), Go edges carry no `location`, and Go files outside any `go.mod`, `_test.go` files, and `vendor`/`testdata` directories are absent from the graph by design. A Go type in `lcom.classes[]` is measured over the methods of its whole package and placed in the first file that declares one, so `file_path` need not be the file that declares the type; `excluded_methods` counts methods without a receiver parameter, which is expected for Rust `new`-style associated functions.
 
 ### 4. Cluster findings
 
@@ -92,6 +92,7 @@ Read the JSON output. Group findings by `(analysis, language, rule_or_pattern)`.
 - `clone / cpp / cross-file-header-impl`
 - `deadcode / ts / unreachable_after_return`
 - `cbo / ts / coupling >= 10`
+- `cbo / go / coupling >= 8`
 - `lcom / go / lcom4 >= 6`
 
 For each cluster, record the total count and pick **3–5 representative samples** (prefer variety: different files, different sizes, mix of risk levels). Also collect:

--- a/README.md
+++ b/README.md
@@ -49,11 +49,11 @@ Every analyzer scores your codebase (0-100 with an A-F grade) and generates an H
 |---|---|:-:|:-:|:-:|:-:|:-:|---|
 | JavaScript / TypeScript | `.js` `.jsx` `.mjs` `.cjs` `.ts` `.tsx` `.mts` `.cts` | ✅ | ✅ | ✅ | ✅ | ✅ CBO | `polyscan` |
 | Python | `.py` | ✅ | ✅ | ✅ | ✅ | ✅ CBO, LCOM | `pyscn` |
-| Go | `.go` | ✅ | ✅ | — | ✅ | ✅ LCOM | `polyscan` |
-| Rust | `.rs` | ✅ | ✅ | — | — | ✅ LCOM | `polyscan` |
+| Go | `.go` | ✅ | ✅ | — | ✅ | ✅ CBO, LCOM | `polyscan` |
+| Rust | `.rs` | ✅ | ✅ | — | — | ✅ CBO, LCOM | `polyscan` |
 | C++ | `.cpp` `.cc` `.cxx` `.hpp` `.hh` `.hxx` `.h` `.ipp` `.inl` | ✅ | ✅ | — | — | — | `polyscan` |
 
-Complexity and duplicate code cover every language. Dependencies cover Go, JavaScript/TypeScript and Python: for Go the nodes are packages, resolved through `go.mod`. Class design covers coupling (CBO) for JavaScript/TypeScript and Python and cohesion (LCOM4) for Python, Go and Rust: a Go type is measured over the methods of its package, a Rust type over the methods of its `impl` blocks in a file. Dead code needs the file-level import graph that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
+Complexity and duplicate code cover every language. Dependencies cover Go, JavaScript/TypeScript and Python: for Go the nodes are packages, resolved through `go.mod`. Class design covers coupling (CBO) for Go, Rust, JavaScript/TypeScript and Python and cohesion (LCOM4) for Python, Go and Rust. For Go and Rust, coupling counts the types of the analyzed tree that a type refers to from its declaration and methods, so the standard library and other modules do not count; a Go type is measured over the methods of its package, a Rust type over the methods of its `impl` blocks in a file. Dead code needs the file-level import graph that only the JavaScript/TypeScript and Python backends build today. A dimension a language does not have is left out of its score rather than counted as clean, so scores stay comparable across languages.
 
 ## Polyscan for GitHub
 

--- a/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/architecture-review/SKILL.md
@@ -5,7 +5,7 @@ description: Analyze module architecture using polyscan - class coupling (CBO), 
 
 # Architecture Review with polyscan
 
-Run the polyscan CLI to understand module structure and coupling. Dependency analysis exists for Go (package graph) and JavaScript/TypeScript (module graph); coupling (CBO) for JavaScript/TypeScript; class cohesion (LCOM4) for Go and Rust; C++ gets complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
+Run the polyscan CLI to understand module structure and coupling. Dependency analysis exists for Go (package graph) and JavaScript/TypeScript (module graph); coupling (CBO) for Go, Rust and JavaScript/TypeScript; class cohesion (LCOM4) for Go and Rust; C++ gets complexity and clone detection only. No install needed: `npx polyscan@latest analyze <path>`.
 
 ## Commands
 
@@ -20,7 +20,7 @@ Text output shows per-class CBO and cycle membership, but only **aggregate** cou
 
 ## Interpreting Coupling Results
 
-- High CBO classes depend on many others; changes ripple widely. Suggest interface extraction or dependency inversion.
+- High CBO classes depend on many others; changes ripple widely. Suggest interface extraction or dependency inversion. For Go and Rust the count covers types declared in the analyzed tree only, so a type coupled only to the standard library reads as 0 and is not listed.
 - A high LCOM4 type has methods that fall into several groups sharing no field or call; each group is a candidate for its own type.
 - Martin metrics per module (from the JSON output above): instability I = Ce / (Ca + Ce) and distance from the main sequence. Modules in the Zone of Pain (stable but concrete) are risky to change; name them explicitly.
 - Dependency cycles are the highest-priority architectural issue; name the modules in each cycle and the weakest edge to break.

--- a/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
@@ -24,7 +24,7 @@ polyscan analyze --min-complexity 10 .        # list only functions at or above 
 Key flags:
 
 - `--format html|json|text` (`-f`): output format; `json` and `text` write to stdout instead of an HTML report
-- `--select` (`-s`): `complexity,deadcode,clone,cbo,lcom,deps` (all run by default); `deps` applies to Go and JavaScript/TypeScript; `lcom` to Go and Rust; `deadcode` and `cbo` to JavaScript/TypeScript only
+- `--select` (`-s`): `complexity,deadcode,clone,cbo,lcom,deps` (all run by default); `deps` applies to Go and JavaScript/TypeScript; `cbo` to Go, Rust and JavaScript/TypeScript; `lcom` to Go and Rust; `deadcode` to JavaScript/TypeScript only
 - `--no-open`: don't auto-open the HTML report in a browser (use in scripts)
 - `-o <path>`: HTML report path (default: `polyscan-report.html` in the current directory)
 - `--min-complexity <n>`: hide functions below this complexity from the listing (scores still cover everything)
@@ -33,7 +33,7 @@ With `--format json`, the machine-readable results go to stdout and the health-s
 
 ## Language coverage
 
-Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Class cohesion (LCOM4) covers Go and Rust. Dead code and coupling (CBO) exist for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
+Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Class coupling (CBO) covers Go, Rust and JavaScript/TypeScript, and class cohesion (LCOM4) Go and Rust. Dead code exists for JavaScript/TypeScript only. The health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
 ## CI usage
 

--- a/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/health-check/SKILL.md
@@ -26,7 +26,7 @@ For machine-readable detail use `--format json`: full results go to stdout and t
 ## Interpreting Results
 
 - Score 0-100 with letter grade; category scores cover complexity, dead code, code duplication, coupling (CBO), cohesion (LCOM4), and dependencies.
-- Complexity and duplication cover every language; dependencies run for Go and JavaScript/TypeScript; cohesion for Go and Rust; dead code and coupling for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
+- Complexity and duplication cover every language; dependencies run for Go and JavaScript/TypeScript; coupling for Go, Rust and JavaScript/TypeScript; cohesion for Go and Rust; dead code for JavaScript/TypeScript only. A dimension a language does not have is left out of its score, not counted as clean.
 - Lead with the grade and the weakest categories, then name the top offenders (files/functions) driving them.
 - For deeper follow-up, hand off to the focused skills: refactoring targets → `refactoring`, module structure → `architecture-review`.
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,14 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Class coupling (CBO) for Go and Rust. `polyscan analyze` counts, for each type, the other types of the analyzed tree that its declaration and methods refer to, and scores the result in the Coupling dimension with the thresholds pyscn uses (low up to 3, medium up to 7). Only types the tree declares count: for Go an unqualified name is a type of the same package and `pkg.T` resolves through `go.mod` to a package of the tree, for Rust a bare name resolves to a declaration in the same file or elsewhere in the tree, so the standard library and other modules never count. An embedded field or interface and an implemented trait count as inheritance. Types coupled to nothing, test files and `#[cfg(test)]` code stay out. A Go tree without a `go.mod` keeps only its same-package references, with a warning. In the report a Go or Rust type can now have both a coupling and a cohesion row, and the class count in the overview counts it once
+- Class cohesion (LCOM4) for Go and Rust. `polyscan analyze` measures, for each type, how many groups its methods fall into when two methods are connected by a shared field or a call between them, and scores the result in a Cohesion dimension with the thresholds pyscn uses (low up to 2, medium up to 5). A Go type is measured over every method of its package, since they may be spread across files; a Rust type over the `impl` blocks in a file. Methods without a receiver parameter, such as Rust associated functions and Go methods with an unnamed receiver, cannot touch instance state and are listed as excluded. Test files and `#[cfg(test)]` code stay out. `--select lcom` runs it alone
+- Dependency analysis for Go. `polyscan analyze` builds the package import graph of a Go tree, resolving each import through the nearest `go.mod`, and reports the same instability, abstractness, main-sequence distance, depth and longest chains it reports for JavaScript/TypeScript, scored in the Dependencies dimension. Abstractness is the share of a package's exported type declarations that are interfaces. Test files, `vendor` and `testdata` directories, and imports of other modules stay out of the graph, and a tree without a `go.mod` leaves the dimension out with a warning rather than scoring it clean
+
+### Changed
+
+- A Rust `impl` names its type by the bare identifier, so the methods of `impl G<T>` read `G::m` instead of `G<T>::m`, and `impl G<i32>` and `impl G<String>` are blocks of one type in the cohesion and coupling analyses. An impl for a reference type such as `&Foo` is a block of `Foo`
+
 ### Fixed
 
 - Go, Rust and C++ analysis no longer walks into version control, dependency and build output directories. A directory whose name starts with a dot, such as `.git`, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party` are skipped; a path named on the command line is still analyzed whatever it is called. Before, a Rust project's `target` directory and a Go project's `vendor` directory were analyzed as if they were the project's own code
-
-### Added
-
-- Class cohesion (LCOM4) for Go and Rust. `polyscan analyze` measures, for each type, how many groups its methods fall into when two methods are connected by a shared field or a call between them, and scores the result in a Cohesion dimension with the thresholds pyscn uses (low up to 2, medium up to 5). A Go type is measured over every method of its package, since they may be spread across files; a Rust type over the `impl` blocks in a file. Methods without a receiver parameter, such as Rust associated functions and Go methods with an unnamed receiver, cannot touch instance state and are listed as excluded. Test files and `#[cfg(test)]` code stay out. `--select lcom` runs it alone
-- Dependency analysis for Go. `polyscan analyze` builds the package import graph of a Go tree, resolving each import through the nearest `go.mod`, and reports the same instability, abstractness, main-sequence distance, depth and longest chains it reports for JavaScript/TypeScript, scored in the Dependencies dimension. Abstractness is the share of a package's exported type declarations that are interfaces. Test files, `vendor` and `testdata` directories, and imports of other modules stay out of the graph, and a tree without a `go.mod` leaves the dimension out with a warning rather than scoring it clean
 
 ## [0.2.2] - 2026-09-05
 

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -1,6 +1,6 @@
 # polyscan
 
-A multi-language code quality analyzer. It detects the language of each file by its extension. Go, Rust and C++ get cyclomatic complexity and code clone detection from the generic engine, Go and Rust also class cohesion (LCOM4) and Go package dependencies; JavaScript/TypeScript files get the full [jscan](../jscan/README.md) analysis (complexity, dead code, clones, coupling, dependencies). Every language lands in one report with one health score: each analyzed dimension is scored against what it could have charged, and a dimension a language does not have is left out of the score rather than scored as clean.
+A multi-language code quality analyzer. It detects the language of each file by its extension. Go, Rust and C++ get cyclomatic complexity and code clone detection from the generic engine, Go and Rust also class coupling (CBO) and cohesion (LCOM4), and Go package dependencies; JavaScript/TypeScript files get the full [jscan](../jscan/README.md) analysis (complexity, dead code, clones, coupling, dependencies). Every language lands in one report with one health score: each analyzed dimension is scored against what it could have charged, and a dimension a language does not have is left out of the score rather than scored as clean.
 
 ## Installation
 
@@ -34,7 +34,7 @@ polyscan analyze --select clone .
 polyscan analyze --min-complexity 10 .
 ```
 
-`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo`, `lcom` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `lcom` for Go and Rust, `deadcode` and `cbo` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
+`--select` takes any of `complexity`, `deadcode`, `clone`, `cbo`, `lcom` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `cbo` for Go, Rust and JavaScript/TypeScript, `lcom` for Go and Rust, `deadcode` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
 
 Version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -52,10 +52,11 @@ The language of each file is detected from its extension. Supported: Go, Rust,
 C++ and JavaScript/TypeScript.
 
 Complexity and clone analysis cover every language; dependency analysis covers
-Go and JavaScript/TypeScript; cohesion (LCOM4) covers Go and Rust; dead code
-and coupling (CBO) exist for JavaScript/TypeScript only. The health score is
-computed over the dimensions that ran: a dimension a language does not have is
-left out, not scored as clean.
+Go and JavaScript/TypeScript; coupling (CBO) covers Go, Rust and
+JavaScript/TypeScript; cohesion (LCOM4) covers Go and Rust; dead code exists
+for JavaScript/TypeScript only. The health score is computed over the
+dimensions that ran: a dimension a language does not have is left out, not
+scored as clean.
 
 By default, generates an HTML report and opens it in your browser.
 
@@ -154,8 +155,8 @@ Examples:
 
 	cmd.Flags().StringSliceVarP(&selected, "select", "s", allAnalyses,
 		"Analyses to run (comma-separated): complexity,deadcode,clone,cbo,lcom,deps\n"+
-			"deps applies to Go and JavaScript/TypeScript; lcom to Go and Rust;\n"+
-			"deadcode and cbo to JavaScript/TypeScript only")
+			"deps applies to Go and JavaScript/TypeScript; cbo to Go, Rust and\n"+
+			"JavaScript/TypeScript; lcom to Go and Rust; deadcode to JavaScript/TypeScript only")
 	cmd.Flags().StringVarP(&format, "format", "f", "html", "Output format: html, json, text")
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "HTML report path (default: "+defaultReportPath+")")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
@@ -251,8 +252,8 @@ func writeReportFile(path string, write func(io.Writer, jsdomain.OutputFormat) e
 }
 
 // parseSelection maps the selected analysis names onto the generic engine's
-// options and the JavaScript/TypeScript selection. deadcode and cbo exist
-// only for JavaScript/TypeScript, lcom only for the generic engine.
+// options and the JavaScript/TypeScript selection. deadcode exists only for
+// JavaScript/TypeScript, lcom only for the generic engine.
 func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 	var options analysis.Options
 	var selection js.Selection
@@ -267,6 +268,7 @@ func parseSelection(selected []string) (analysis.Options, js.Selection, error) {
 		case selectDeadCode:
 			selection.DeadCode = true
 		case selectCBO:
+			options.CBO = true
 			selection.CBO = true
 		case selectLCOM:
 			options.LCOM = true

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -34,7 +35,20 @@ type analyzeJSON struct {
 		} `json:"summary"`
 	} `json:"complexity"`
 	DeadCode json.RawMessage `json:"dead_code"`
-	Clone    *struct {
+	CBO      *struct {
+		Classes []struct {
+			Name     string `json:"Name"`
+			Language string `json:"language"`
+			Metrics  struct {
+				CouplingCount    int      `json:"CouplingCount"`
+				DependentClasses []string `json:"DependentClasses"`
+			} `json:"Metrics"`
+		} `json:"classes"`
+		Summary struct {
+			TotalClasses int `json:"TotalClasses"`
+		} `json:"summary"`
+	} `json:"cbo"`
+	Clone *struct {
 		ClonePairs []struct {
 			Clone1 struct {
 				Language string `json:"language"`
@@ -67,6 +81,8 @@ type analyzeJSON struct {
 		HealthScore       int    `json:"health_score"`
 		CohesionScore     int    `json:"cohesion_score"`
 		LCOMEnabled       bool   `json:"lcom_enabled"`
+		CBOEnabled        bool   `json:"cbo_enabled"`
+		CBOClasses        int    `json:"cbo_classes"`
 		DependencyScore   int    `json:"dependency_score"`
 		DepsEnabled       bool   `json:"deps_enabled"`
 		Grade             string `json:"grade"`
@@ -436,6 +452,55 @@ func TestAnalyzeCohesion(t *testing.T) {
 		t.Fatalf("analyze text: %v\n%s", err, out)
 	}
 	for _, want := range []string{"=== LCOM Analysis ===", "T: LCOM4=2 [low]", "Cohesion:         100/100"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("text output lacks %q:\n%s", want, out)
+		}
+	}
+}
+
+func TestAnalyzeCoupling(t *testing.T) {
+	dir := t.TempDir()
+	files := map[string]string{
+		"go.mod":        "module example.com/app\n",
+		"app.go":        "package app\n\nimport \"example.com/app/model\"\n\ntype Server struct {\n\tusers []model.User\n\tcfg   Config\n}\n\ntype Config struct{}\n",
+		"model/user.go": "package model\n\ntype User struct{}\n",
+		"a.js":          "import { z } from 'zod';\nexport function f() { return z; }\n",
+	}
+	for name, content := range files {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	out, err := run(t, "analyze", "--format", "json", "--select", "cbo", dir)
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	doc := decodeAnalyzeJSON(t, out)
+	if doc.CBO == nil || len(doc.CBO.Classes) != 2 || doc.CBO.Summary.TotalClasses != 2 {
+		t.Fatalf("cbo = %+v, want the Go type and the JavaScript module", doc.CBO)
+	}
+	server := doc.CBO.Classes[0]
+	if server.Name != "Server" || server.Language != "Go" || server.Metrics.CouplingCount != 2 ||
+		!reflect.DeepEqual(server.Metrics.DependentClasses, []string{"Config", "model.User"}) {
+		t.Errorf("class = %+v, want Server (Go) coupled to Config and model.User", server)
+	}
+	if module := doc.CBO.Classes[1]; module.Name != "a" || module.Language != "" {
+		t.Errorf("class = %+v, want the JavaScript module a", module)
+	}
+	if doc.Summary == nil || !doc.Summary.CBOEnabled || doc.Summary.CBOClasses != 2 {
+		t.Errorf("summary = %+v, want coupling enabled over 2 classes", doc.Summary)
+	}
+
+	out, err = run(t, "analyze", "--format", "text", "--select", "cbo", dir)
+	if err != nil {
+		t.Fatalf("analyze text: %v\n%s", err, out)
+	}
+	for _, want := range []string{"=== CBO Analysis ===", "Server: CBO=2 [low]", "Coupling:         100/100"} {
 		if !strings.Contains(out, want) {
 			t.Errorf("text output lacks %q:\n%s", want, out)
 		}

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -29,6 +29,9 @@ type Options struct {
 	// LCOM measures the cohesion of each type's methods, for the languages
 	// whose definition declares how a method reaches its fields.
 	LCOM bool
+	// CBO counts, for each type, the other types of the tree it refers to,
+	// for the languages whose definition declares types and references.
+	CBO bool
 }
 
 // Function is the complexity result for one function.
@@ -92,6 +95,9 @@ type Report struct {
 	// Cohesion is the LCOM4 analysis, or nil when no analyzed file belongs
 	// to a language that has one.
 	Cohesion *Cohesion `json:"cohesion,omitempty"`
+	// Coupling is the CBO analysis, or nil when no analyzed file belongs to
+	// a language that has one.
+	Coupling *Coupling `json:"coupling,omitempty"`
 	// FileLines is the source line count of every analyzed file, keyed by
 	// its reported path. The unified report shows lines per hotspot file,
 	// and this run is the only place the contents are in hand.
@@ -138,6 +144,7 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	cloneLines, cloneFiles := 0, 0
 	cohesion := newCohesionBuilder()
 	cohesionFiles := 0
+	coupling := newCouplingBuilder()
 
 	for _, file := range files {
 		language, ok := lang.ByPath(file)
@@ -146,12 +153,13 @@ func Analyze(paths []string, options Options) (*Report, error) {
 			panic(fmt.Sprintf("no language for %s", file))
 		}
 		display := displayPath(file)
-		result, lines, err := analyzeFile(language, file)
+		result, content, err := analyzeFile(language, file)
 		if err != nil {
 			report.Files.Skipped++
 			report.Errors = append(report.Errors, fmt.Sprintf("%s: %v", display, err))
 			continue
 		}
+		lines := countLines(content)
 		report.Files.Analyzed++
 		report.FileLines[display] = lines
 		if result.SyntaxError != nil {
@@ -190,6 +198,11 @@ func Analyze(paths []string, options Options) (*Report, error) {
 				}
 			}
 		}
+		if options.CBO && language.HasCoupling() && !language.IsTestFile(display) {
+			if err := coupling.add(language, display, file, content, result); err != nil {
+				return nil, err
+			}
+		}
 	}
 
 	if options.Complexity {
@@ -203,6 +216,9 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	}
 	if cohesionFiles > 0 {
 		report.Cohesion = cohesion.build()
+	}
+	if len(coupling.files) > 0 {
+		report.Coupling = coupling.build()
 	}
 	return report, nil
 }
@@ -234,16 +250,18 @@ func analyzeDeps(report *Report, files []string) error {
 	return nil
 }
 
-func analyzeFile(language *engine.Language, path string) (result *engine.Result, lines int, err error) {
+// analyzeFile reads and analyzes one file, returning its contents as well
+// for the analyses that read more of it than the engine extracts.
+func analyzeFile(language *engine.Language, path string) (*engine.Result, []byte, error) {
 	content, err := os.ReadFile(path)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
-	result, err = language.Analyze(content)
+	result, err := language.Analyze(content)
 	if err != nil {
-		return nil, 0, err
+		return nil, nil, err
 	}
-	return result, countLines(content), nil
+	return result, content, nil
 }
 
 // countLines counts source lines the way the JavaScript analysis does, so

--- a/polyscan/internal/analysis/coupling.go
+++ b/polyscan/internal/analysis/coupling.go
@@ -1,0 +1,321 @@
+package analysis
+
+import (
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ludo-technologies/polyscan/core/cbo"
+	"github.com/ludo-technologies/polyscan/core/domain"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/godeps"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang/golang"
+)
+
+// CoupledClass is the coupling result for one type.
+type CoupledClass struct {
+	Name     string `json:"name"`
+	FilePath string `json:"file_path"`
+	Language string `json:"language"`
+	// StartLine and EndLine span the type's declaration.
+	StartLine int `json:"start_line"`
+	EndLine   int `json:"end_line"`
+	// CBO is the number of distinct types of the analyzed tree that the
+	// type's declaration and methods refer to. Types outside the tree, such
+	// as the standard library's, do not count.
+	CBO              int      `json:"cbo"`
+	DependentClasses []string `json:"dependent_classes"`
+	// Inheritance counts the references that embed or implement another
+	// type; TypeHint every other reference.
+	Inheritance int              `json:"inheritance"`
+	TypeHint    int              `json:"type_hint"`
+	IsAbstract  bool             `json:"is_abstract"`
+	RiskLevel   domain.RiskLevel `json:"risk_level"`
+}
+
+// Coupling is the CBO analysis of a set of paths.
+type Coupling struct {
+	// Classes lists every type coupled to at least one other, sorted by
+	// descending CBO, then by location.
+	Classes       []CoupledClass `json:"classes"`
+	FilesAnalyzed int            `json:"files_analyzed"`
+	Warnings      []string       `json:"warnings,omitempty"`
+}
+
+// couplingFile is what the coupling analysis keeps of one file.
+type couplingFile struct {
+	language *engine.Language
+	display  string
+	// location identifies the unit a type belongs to: the directory when
+	// the language spreads a type over one, otherwise the file.
+	location string
+	// importPath, pkg and imports are set for Go files inside a module.
+	importPath string
+	pkg        string
+	imports    []godeps.Import
+	types      []engine.Type
+}
+
+// coupledType accumulates one type of the tree before it is measured.
+type coupledType struct {
+	key      string
+	name     string
+	language *engine.Language
+	file     string
+	start    int
+	end      int
+	declared bool
+	abstract bool
+	refs     []siteReference
+}
+
+// siteReference is a reference together with the file that makes it, which
+// decides how the name resolves.
+type siteReference struct {
+	file *couplingFile
+	ref  engine.Reference
+}
+
+// couplingBuilder collects the types of every file and resolves their
+// references once the whole tree is known.
+type couplingBuilder struct {
+	files    []*couplingFile
+	resolver *godeps.Resolver
+	noModule map[string]bool
+	warnings []string
+}
+
+func newCouplingBuilder() *couplingBuilder {
+	return &couplingBuilder{resolver: godeps.NewResolver(), noModule: map[string]bool{}}
+}
+
+// add records the types of one file. A Go file also contributes its package
+// clause and imports, through which qualified references resolve; a Go file
+// with no go.mod above it keeps its unqualified references only, with one
+// warning per directory.
+func (b *couplingBuilder) add(language *engine.Language, display, path string, content []byte, result *engine.Result) error {
+	file := &couplingFile{language: language, display: display, location: display}
+	if language.TypeSpansDirectory {
+		file.location = filepath.Dir(display)
+	}
+	for _, t := range result.Types {
+		if !t.IsTest {
+			file.types = append(file.types, t)
+		}
+	}
+	if language == golang.Language {
+		info, err := godeps.ParseFile(content)
+		if err != nil {
+			b.warnings = append(b.warnings, fmt.Sprintf("%s: %v; its types are absent from the coupling analysis", display, err))
+			return nil
+		}
+		absolute, err := filepath.Abs(path)
+		if err != nil {
+			return err
+		}
+		dir := filepath.Dir(absolute)
+		importPath, noModule, err := b.resolver.ImportPath(dir)
+		if err != nil {
+			return err
+		}
+		if noModule && !b.noModule[dir] {
+			b.noModule[dir] = true
+			b.warnings = append(b.warnings, fmt.Sprintf("%s: no go.mod above it; references to types of other packages are not resolved", file.location))
+		}
+		file.importPath, file.pkg, file.imports = importPath, info.Package, info.Imports
+	}
+	b.files = append(b.files, file)
+	return nil
+}
+
+// build resolves every reference and measures the types. A reference counts
+// when it names a type the tree declares: for Go an unqualified name is a
+// type of the same package and a qualified one is looked up through the
+// file's imports; for Rust a bare name is a type of the same file, or else
+// of any file. A type whose methods a file holds without declaring it, as a
+// Go type is across its package and a Rust type across impl blocks, joins
+// its declaration; a Rust impl for a type no file declares is left out.
+func (b *couplingBuilder) build() *Coupling {
+	types := map[string]*coupledType{}
+	var order []string
+	typeOf := func(file *couplingFile, name string) *coupledType {
+		key := file.language.Name + "\x00" + file.location + "\x00" + name
+		t, ok := types[key]
+		if !ok {
+			t = &coupledType{key: key, name: name, language: file.language}
+			types[key] = t
+			order = append(order, key)
+		}
+		return t
+	}
+	// byImportPath maps a Go package's import path and type name to the
+	// declared type; byBare maps a language and bare type name to the
+	// declared types of the whole tree, byFileBare to those of one file.
+	byImportPath := map[string]*coupledType{}
+	packageNames := map[string]string{}
+	byBare := map[string][]*coupledType{}
+	byFileBare := map[*couplingFile]map[string]*coupledType{}
+	bareKey := func(language *engine.Language, name string) string {
+		return language.Name + "\x00" + bareName(language, name)
+	}
+
+	for _, file := range b.files {
+		if file.importPath != "" {
+			packageNames[file.importPath] = file.pkg
+		}
+		byFileBare[file] = map[string]*coupledType{}
+		for _, et := range file.types {
+			t := typeOf(file, et.Name)
+			if et.Declared && !t.declared {
+				t.declared = true
+				t.file, t.start, t.end = file.display, et.StartLine, et.EndLine
+				t.abstract = et.Abstract
+				if file.importPath != "" {
+					byImportPath[file.importPath+"."+et.Name] = t
+				}
+				bare := bareKey(file.language, et.Name)
+				byBare[bare] = append(byBare[bare], t)
+				byFileBare[file][bareName(file.language, et.Name)] = t
+			}
+			for _, ref := range et.References {
+				t.refs = append(t.refs, siteReference{file: file, ref: ref})
+			}
+		}
+	}
+
+	// A Rust impl block or a method group in a file that does not declare
+	// its type belongs to the declaration elsewhere when there is exactly
+	// one.
+	for _, key := range order {
+		t := types[key]
+		if t.declared || t.language.TypeSpansDirectory {
+			continue
+		}
+		if candidates := byBare[bareKey(t.language, t.name)]; len(candidates) == 1 {
+			candidates[0].refs = append(candidates[0].refs, t.refs...)
+		}
+	}
+
+	resolve := func(site siteReference) (*coupledType, string) {
+		file, ref := site.file, site.ref
+		switch {
+		case ref.Package != "":
+			target, ok := b.resolveQualified(file, ref, byImportPath, packageNames)
+			if !ok {
+				return nil, ""
+			}
+			return target, ref.Package + "." + ref.Name
+		case file.language.TypeSpansDirectory:
+			target, ok := types[file.language.Name+"\x00"+file.location+"\x00"+ref.Name]
+			if !ok || !target.declared {
+				return nil, ""
+			}
+			return target, ref.Name
+		default:
+			if target, ok := byFileBare[file][ref.Name]; ok {
+				return target, ref.Name
+			}
+			if candidates := byBare[bareKey(file.language, ref.Name)]; len(candidates) > 0 {
+				return candidates[0], ref.Name
+			}
+			return nil, ""
+		}
+	}
+
+	// ComputeCBO returns one result per class, in order.
+	var classes []*cbo.ClassInfo
+	var owners []*coupledType
+	for _, key := range order {
+		t := types[key]
+		if !t.declared {
+			continue
+		}
+		class := &cbo.ClassInfo{
+			Name:       t.name,
+			FilePath:   t.file,
+			StartLine:  t.start,
+			EndLine:    t.end,
+			IsAbstract: t.abstract,
+		}
+		// The breakdown counts dependencies, so a type referred to twice
+		// in the same way is one dependency.
+		seen := map[cbo.ClassDependency]bool{}
+		for _, site := range t.refs {
+			target, display := resolve(site)
+			if target == nil || target == t {
+				continue
+			}
+			dep := cbo.ClassDependency{ClassName: display, Kind: cbo.DepTypeHint}
+			if site.ref.Embedded {
+				dep.Kind = cbo.DepInheritance
+			}
+			if !seen[dep] {
+				seen[dep] = true
+				class.Dependencies = append(class.Dependencies, dep)
+			}
+		}
+		classes = append(classes, class)
+		owners = append(owners, t)
+	}
+
+	coupling := &Coupling{Classes: []CoupledClass{}, FilesAnalyzed: len(b.files), Warnings: b.warnings}
+	for i, result := range cbo.ComputeCBO(classes, cbo.DefaultConfig()) {
+		if result.CouplingCount == 0 {
+			continue
+		}
+		coupling.Classes = append(coupling.Classes, CoupledClass{
+			Name:             result.ClassName,
+			FilePath:         result.FilePath,
+			Language:         owners[i].language.Name,
+			StartLine:        result.StartLine,
+			EndLine:          result.EndLine,
+			CBO:              result.CouplingCount,
+			DependentClasses: result.DependentClasses,
+			Inheritance:      result.DependencyBreakdown[cbo.DepInheritance],
+			TypeHint:         result.DependencyBreakdown[cbo.DepTypeHint],
+			IsAbstract:       result.IsAbstract,
+			RiskLevel:        result.RiskLevel,
+		})
+	}
+	sort.SliceStable(coupling.Classes, func(i, j int) bool {
+		a, b := coupling.Classes[i], coupling.Classes[j]
+		if a.CBO != b.CBO {
+			return a.CBO > b.CBO
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		return a.StartLine < b.StartLine
+	})
+	return coupling
+}
+
+// resolveQualified finds the type a Go reference pkg.T names: the file's
+// import whose name is pkg, explicit or the package's own, must lead to a
+// package of the tree that declares T.
+func (b *couplingBuilder) resolveQualified(file *couplingFile, ref engine.Reference, byImportPath map[string]*coupledType, packageNames map[string]string) (*coupledType, bool) {
+	for _, imported := range file.imports {
+		name := imported.Name
+		switch name {
+		case "_", ".":
+			continue
+		case "":
+			name = packageNames[imported.Path]
+		}
+		if name != ref.Package {
+			continue
+		}
+		target, ok := byImportPath[imported.Path+"."+ref.Name]
+		return target, ok
+	}
+	return nil, false
+}
+
+// bareName strips the scope prefix from a type name.
+func bareName(language *engine.Language, name string) string {
+	if i := strings.LastIndex(name, language.Separator()); i >= 0 {
+		return name[i+len(language.Separator()):]
+	}
+	return name
+}

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -1,0 +1,185 @@
+package analysis
+
+import (
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ludo-technologies/polyscan/core/domain"
+)
+
+func TestAnalyzeCouplingGo(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"go.mod": "module example.com/app\n",
+		// Server depends on its own package's Handler and Config, on
+		// model.User and store.Store through imports, one of them aliased,
+		// and on nothing from the standard library or other modules.
+		"server.go": `package app
+
+import (
+	"context"
+	"sync"
+
+	"example.com/app/model"
+	st "example.com/app/store"
+	"github.com/other/lib"
+)
+
+type Server struct {
+	mu      sync.Mutex
+	users   []model.User
+	store   *st.Store
+	handler Handler
+	client  lib.Client
+}
+
+type Handler func(context.Context) error
+
+type Config struct{ Name string }
+
+func (s *Server) Start(cfg Config) error { return nil }
+`,
+		// A method in another file of the package still belongs to Server.
+		"log.go": `package app
+
+func (s *Server) Log(l Logger) {}
+
+type Logger interface{ Log(string) }
+`,
+		// A type in a test file is a fixture, and a type nothing refers to
+		// couples to nothing.
+		"server_test.go": `package app
+
+type fake struct{ s *Server }
+`,
+		"model/user.go": `package model
+
+type User struct{ ID int }
+`,
+		// store declares its own Server, which must not be confused with
+		// app's, and depends on model.User.
+		"store/store.go": `package store
+
+import "example.com/app/model"
+
+type Store struct{ users map[int]model.User }
+
+type Server struct{ s Store }
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{CBO: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Coupling == nil {
+		t.Fatal("coupling is nil for a Go tree")
+	}
+	if report.Cohesion != nil || report.Complexity != nil {
+		t.Error("only coupling was selected")
+	}
+	if report.Coupling.FilesAnalyzed != 4 || len(report.Coupling.Warnings) != 0 {
+		t.Errorf("files = %d, warnings = %v; want 4 files and no warnings", report.Coupling.FilesAnalyzed, report.Coupling.Warnings)
+	}
+	got := map[string][]string{}
+	for _, class := range report.Coupling.Classes {
+		got[strings.TrimPrefix(class.FilePath, dir+"/")+":"+class.Name] = class.DependentClasses
+	}
+	want := map[string][]string{
+		"server.go:Server":      {"Config", "Handler", "Logger", "model.User", "st.Store"},
+		"store/store.go:Store":  {"model.User"},
+		"store/store.go:Server": {"Store"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dependencies = %v, want %v", got, want)
+	}
+	server := report.Coupling.Classes[0]
+	if server.Name != "Server" || server.Language != "Go" || server.CBO != 5 || server.RiskLevel != domain.RiskLevelMedium ||
+		server.StartLine != 12 || server.EndLine != 18 || server.TypeHint != 5 {
+		t.Errorf("Server = %+v, want CBO 5 (medium) at server.go:12-18", server)
+	}
+}
+
+func TestAnalyzeCouplingGoWithoutModule(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"a.go": `package p
+
+import "example.com/x/model"
+
+type A struct{ b B; u model.User }
+type B struct{}
+`,
+	})
+	report, err := Analyze([]string{dir}, Options{CBO: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	classes := report.Coupling.Classes
+	if len(classes) != 1 || classes[0].Name != "A" || !reflect.DeepEqual(classes[0].DependentClasses, []string{"B"}) {
+		t.Errorf("classes = %+v, want A depending on B only", classes)
+	}
+	if len(report.Coupling.Warnings) != 1 || !strings.Contains(report.Coupling.Warnings[0], "no go.mod") {
+		t.Errorf("warnings = %v, want one about the missing go.mod", report.Coupling.Warnings)
+	}
+}
+
+func TestAnalyzeCouplingRust(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"types.rs": `
+pub struct Foo { bar: Bar, items: Vec<Baz> }
+pub struct Bar;
+pub trait Shape { fn area(&self) -> Unit; }
+pub struct Unit;
+`,
+		// The impl blocks of Foo live in another file and add Shape and
+		// Baz; a Go type named like a Rust one is a different language's.
+		"ops.rs": `
+impl Shape for Foo { fn area(&self) -> Unit { Unit } }
+impl Foo { pub fn baz(&self) -> Baz { Baz::new() } }
+pub struct Baz;
+impl Baz { pub fn new() -> Self { Baz } }
+`,
+		"tests.rs": `
+struct Fixture { f: Foo }
+`,
+		"other.go": `package other
+
+type Unit struct{ foo Foo }
+`,
+	})
+	report, err := Analyze([]string{dir}, Options{CBO: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	got := map[string][]string{}
+	for _, class := range report.Coupling.Classes {
+		got[class.Language+":"+class.Name] = class.DependentClasses
+	}
+	want := map[string][]string{
+		"Rust:Foo":   {"Bar", "Baz", "Shape", "Unit"},
+		"Rust:Shape": {"Unit"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dependencies = %v, want %v", got, want)
+	}
+	foo := report.Coupling.Classes[0]
+	if foo.Name != "Foo" || filepath.Base(foo.FilePath) != "types.rs" || foo.Inheritance != 1 || foo.TypeHint != 3 || foo.RiskLevel != domain.RiskLevelMedium {
+		t.Errorf("Foo = %+v, want CBO 4 with one inheritance at types.rs", foo)
+	}
+	shape := report.Coupling.Classes[1]
+	if shape.Name != "Shape" || !shape.IsAbstract {
+		t.Errorf("Shape = %+v, want an abstract class", shape)
+	}
+}
+
+func TestAnalyzeCouplingAbsentWithoutSupportedLanguage(t *testing.T) {
+	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; };\n"})
+	report, err := Analyze([]string{dir}, Options{CBO: true})
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Coupling != nil {
+		t.Errorf("coupling = %+v, want none for a C++ tree", report.Coupling)
+	}
+}

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -69,6 +69,21 @@ type Language struct {
 	// out of scope. A Members match whose @object is shadowed at that point
 	// is not an access to the receiver.
 	Bindings string
+	// Types is an optional tree-sitter query for the named types a file
+	// declares, which the coupling (CBO) analysis measures: @name is the
+	// type's name and the capture that spans the match says what it is,
+	// @type a concrete declaration, @abstract an interface or trait, @impl a
+	// block that adds to a type without declaring it, as a Rust impl does. A
+	// language without a Types query has no coupling analysis.
+	Types string
+	// References is an optional tree-sitter query, paired with Types, for
+	// the places a type is referred to: @reference is the name node, and an
+	// optional @package the qualifier it is reached through, as in Go's
+	// pkg.T. A match may capture @embedded instead of @reference for an
+	// embedded field or interface or an implemented trait, which is
+	// inheritance rather than use. A reference belongs to the type whose
+	// method or declaration contains it.
+	References string
 	// Nesting is a tree-sitter query whose captures are the constructs that
 	// open a nesting level: branches, loops, switches and try blocks. A
 	// capture named @continuation marks a construct that continues the
@@ -104,6 +119,8 @@ type Language struct {
 	scopes      *sitter.Query
 	members     *sitter.Query
 	bindings    *sitter.Query
+	types       *sitter.Query
+	references  *sitter.Query
 	testCode    *sitter.Query
 	identifiers map[string]struct{}
 	literals    map[string]struct{}
@@ -190,6 +207,39 @@ type Function struct {
 	self      string
 }
 
+// Type is one named type of a source file, with every reference to another
+// type that its declaration and its methods in the file make.
+type Type struct {
+	// Name is the type name, prefixed with its enclosing scopes the way
+	// function names are.
+	Name string
+	// StartLine and EndLine span the declaration, or the first block that
+	// adds to the type when the file declares it elsewhere or not at all.
+	StartLine int
+	EndLine   int
+	// Declared reports that the file declares the type. A file may only add
+	// methods to a type, as Go files of one package and Rust impl blocks do;
+	// such a type is not Declared here.
+	Declared bool
+	// Abstract reports an interface or trait.
+	Abstract bool
+	// IsTest reports that every part of the type lies in test code.
+	IsTest bool
+	// References lists the types referred to, in source order without
+	// duplicates.
+	References []Reference
+}
+
+// Reference is one type named by another type's declaration or methods.
+type Reference struct {
+	// Name is the referenced type's name; Package the qualifier it is
+	// reached through, or empty for an unqualified name.
+	Name    string
+	Package string
+	// Embedded marks an embedded field or interface or an implemented trait.
+	Embedded bool
+}
+
 const (
 	definitionPrefix    = "definition."
 	nameCapture         = "name"
@@ -203,6 +253,12 @@ const (
 	bindingCapture      = "binding"
 	declarationCapture  = "declaration"
 	continuationCapture = "continuation"
+	typeCapture         = "type"
+	abstractCapture     = "abstract"
+	implCapture         = "impl"
+	referenceCapture    = "reference"
+	embeddedCapture     = "embedded"
+	packageCapture      = "package"
 	operatorField       = "operator"
 )
 
@@ -210,6 +266,12 @@ const (
 // with its type, which the cohesion (LCOM4) analysis needs.
 func (l *Language) HasCohesion() bool {
 	return l.Members != ""
+}
+
+// HasCoupling reports whether the language declares its types and their
+// references, which the coupling (CBO) analysis needs.
+func (l *Language) HasCoupling() bool {
+	return l.Types != ""
 }
 
 // Separator is the ScopeSeparator, or "." when none is set.
@@ -244,6 +306,10 @@ func (l *Language) IsTestFile(path string) bool {
 // Result is the analysis of one file.
 type Result struct {
 	Functions []Function
+	// Types lists the file's named types with their references, per the
+	// language's Types and References queries, in order of first appearance.
+	// It is nil for a language without a Types query.
+	Types []Type
 	// SyntaxError is the first syntax error in the file, or nil when the
 	// file parsed cleanly. A tree-sitter parse always yields a tree and
 	// recovers around what it cannot parse, so the functions that contain
@@ -276,11 +342,14 @@ func (l *Language) Analyze(source []byte) (*Result, error) {
 	result := &Result{SyntaxError: checkSyntax(root)}
 
 	functions := l.extractFunctions(root, source)
-	l.applyScopes(root, source, functions)
+	scopes := l.collectScopes(root, source)
+	applyScopes(scopes, functions, l.Separator())
 	l.countDecisions(root, source, functions)
 	l.measureNesting(root, source, functions)
 	l.collectMembers(root, source, functions)
-	l.markTests(root, source, functions)
+	tests := l.testSpans(root, source)
+	markTests(tests, functions)
+	result.Types = l.collectTypes(root, source, functions, scopes, tests)
 	for i := range functions {
 		functions[i].Complexity = 1
 		for _, count := range functions[i].Decisions {
@@ -341,6 +410,19 @@ func (l *Language) compile() error {
 				return
 			}
 			l.bindings = bindings
+		}
+		if l.Types != "" {
+			types, err := sitter.NewQuery([]byte(l.Types), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s types query: %w", l.Name, err)
+				return
+			}
+			references, err := sitter.NewQuery([]byte(l.References), l.Grammar)
+			if err != nil {
+				l.compileErr = fmt.Errorf("%s references query: %w", l.Name, err)
+				return
+			}
+			l.types, l.references = types, references
 		}
 		if l.TestCode != "" {
 			testCode, err := sitter.NewQuery([]byte(l.TestCode), l.Grammar)
@@ -549,14 +631,11 @@ type scope struct {
 	isType     bool
 }
 
-// applyScopes prefixes each function with the names of the scopes that
-// contain it, outermost first, and makes a function whose innermost scope
-// is a type a method of that type, named with the same prefix. Functions
-// and scopes are both in start order, so one sweep with a stack of the open
-// scopes covers them.
-func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Function) {
+// collectScopes gathers the file's named scopes in start order, or nothing
+// for a language without a Scopes query.
+func (l *Language) collectScopes(root *sitter.Node, source []byte) []scope {
 	if l.scopes == nil {
-		return
+		return nil
 	}
 	var scopes []scope
 	ForEachMatch(l.scopes, root, source, func(match *sitter.QueryMatch) {
@@ -577,34 +656,39 @@ func (l *Language) applyScopes(root *sitter.Node, source []byte, functions []Fun
 		}
 	})
 	sort.Slice(scopes, func(i, j int) bool { return scopes[i].start < scopes[j].start })
+	return scopes
+}
 
-	var open []scope
-	next := 0
+// enclosing returns the names of the scopes that contain the byte range,
+// outermost first, and whether the innermost of them is a type.
+func enclosing(scopes []scope, start, end uint32) (names []string, innermostIsType bool) {
+	for _, s := range scopes {
+		if s.start > start {
+			break
+		}
+		if s.start <= start && s.end >= end {
+			names = append(names, s.name)
+			innermostIsType = s.isType
+		}
+	}
+	return names, innermostIsType
+}
+
+// applyScopes prefixes each function with the names of the scopes that
+// contain it, outermost first, and makes a function whose innermost scope
+// is a type a method of that type, named with the same prefix.
+func applyScopes(scopes []scope, functions []Function, separator string) {
 	for i := range functions {
 		fn := &functions[i]
-		for next < len(scopes) && scopes[next].start <= fn.startByte {
-			open = append(open, scopes[next])
-			next++
-		}
-		for len(open) > 0 && open[len(open)-1].end < fn.startByte {
-			open = open[:len(open)-1]
-		}
-		var names []string
-		innermostIsType := false
-		for _, s := range open {
-			if s.end >= fn.endByte {
-				names = append(names, s.name)
-				innermostIsType = s.isType
-			}
-		}
+		names, innermostIsType := enclosing(scopes, fn.startByte, fn.endByte)
 		if len(names) == 0 {
 			continue
 		}
-		prefix := strings.Join(names, l.Separator())
-		fn.Name = prefix + l.Separator() + fn.Name
+		prefix := strings.Join(names, separator)
+		fn.Name = prefix + separator + fn.Name
 		switch {
 		case fn.Receiver != "":
-			fn.Receiver = prefix + l.Separator() + fn.Receiver
+			fn.Receiver = prefix + separator + fn.Receiver
 		case innermostIsType:
 			fn.Receiver = prefix
 		}
@@ -720,21 +804,228 @@ func (b bindings) shadows(name string, position uint32) bool {
 	return false
 }
 
-// markTests flags every function inside a span the TestCode query captures.
-func (l *Language) markTests(root *sitter.Node, source []byte, functions []Function) {
+// span is a byte range of the source.
+type span struct {
+	start, end uint32
+}
+
+func (s span) contains(start, end uint32) bool {
+	return s.start <= start && s.end >= end
+}
+
+// testSpans returns the spans the TestCode query captures.
+func (l *Language) testSpans(root *sitter.Node, source []byte) []span {
 	if l.testCode == nil {
-		return
+		return nil
 	}
+	var spans []span
 	ForEachMatch(l.testCode, root, source, func(match *sitter.QueryMatch) {
 		for _, capture := range match.Captures {
-			start, end := capture.Node.StartByte(), capture.Node.EndByte()
-			for i := range functions {
-				if functions[i].startByte >= start && functions[i].endByte <= end {
-					functions[i].IsTest = true
-				}
-			}
+			spans = append(spans, span{capture.Node.StartByte(), capture.Node.EndByte()})
 		}
 	})
+	return spans
+}
+
+func inTest(tests []span, start, end uint32) bool {
+	for _, test := range tests {
+		if test.contains(start, end) {
+			return true
+		}
+	}
+	return false
+}
+
+// markTests flags every function inside a test span.
+func markTests(tests []span, functions []Function) {
+	for i := range functions {
+		if inTest(tests, functions[i].startByte, functions[i].endByte) {
+			functions[i].IsTest = true
+		}
+	}
+}
+
+// typeSpan is one match of the Types query: a declaration or a block that
+// adds to a type.
+type typeSpan struct {
+	span
+	startLine, endLine int
+	name               string
+	declared           bool
+	abstract           bool
+}
+
+// collectTypes gathers the file's types and attributes every reference to
+// the type whose declaration or method contains it. A reference inside a
+// method belongs to the method's receiver type; inside a function without a
+// receiver, such as a trait's default method, to the innermost type span
+// around that function; outside any function, to the innermost type span
+// around it; and a reference in none of these, as in a free function or a
+// package-level variable, belongs to no type. A type declared inside a
+// function is local to it and is not a type of the file. References in test
+// code are dropped, and a type is a test type when every span of it is.
+func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Function, scopes []scope, tests []span) []Type {
+	if l.types == nil {
+		return nil
+	}
+	separator := l.Separator()
+
+	// A declaration that two patterns match, as an interface does when one
+	// pattern matches every type and another only interfaces, is one span.
+	byNode := map[uintptr]int{}
+	names := map[uintptr]struct{}{}
+	var spans []typeSpan
+	ForEachMatch(l.types, root, source, func(match *sitter.QueryMatch) {
+		var node, name *sitter.Node
+		var kind string
+		for _, capture := range match.Captures {
+			switch captureName := l.types.CaptureNameForId(capture.Index); captureName {
+			case nameCapture:
+				name = capture.Node
+			case typeCapture, abstractCapture, implCapture:
+				node = capture.Node
+				kind = captureName
+			}
+		}
+		if node == nil || name == nil {
+			return
+		}
+		names[name.ID()] = struct{}{}
+		if i, ok := byNode[node.ID()]; ok {
+			spans[i].abstract = spans[i].abstract || kind == abstractCapture
+			return
+		}
+		if innermost(functions, node.StartByte(), node.EndByte()) != nil {
+			return
+		}
+		s := typeSpan{
+			span:      span{node.StartByte(), node.EndByte()},
+			startLine: int(node.StartPoint().Row) + 1,
+			endLine:   int(node.EndPoint().Row) + 1,
+			name:      name.Content(source),
+			declared:  kind != implCapture,
+			abstract:  kind == abstractCapture,
+		}
+		if prefix, _ := enclosing(scopes, s.start, s.end); len(prefix) > 0 {
+			s.name = strings.Join(prefix, separator) + separator + s.name
+		}
+		byNode[node.ID()] = len(spans)
+		spans = append(spans, s)
+	})
+	sort.SliceStable(spans, func(i, j int) bool { return spans[i].start < spans[j].start })
+
+	var types []Type
+	index := map[string]int{}
+	typeOf := func(name string) *Type {
+		if i, ok := index[name]; ok {
+			return &types[i]
+		}
+		index[name] = len(types)
+		types = append(types, Type{Name: name, IsTest: true})
+		return &types[len(types)-1]
+	}
+	for _, s := range spans {
+		t := typeOf(s.name)
+		t.IsTest = t.IsTest && inTest(tests, s.start, s.end)
+		if s.declared && !t.Declared || t.StartLine == 0 {
+			t.StartLine, t.EndLine = s.startLine, s.endLine
+		}
+		t.Declared = t.Declared || s.declared
+		t.Abstract = t.Abstract || s.abstract
+	}
+	for i := range functions {
+		if fn := &functions[i]; fn.Receiver != "" && !fn.IsTest {
+			t := typeOf(fn.Receiver)
+			t.IsTest = false
+			if t.StartLine == 0 {
+				t.StartLine, t.EndLine = fn.StartLine, fn.EndLine
+			}
+		}
+	}
+
+	// owner returns the type a reference at the byte range belongs to.
+	owner := func(start, end uint32) *Type {
+		if fn := innermost(functions, start, end); fn != nil {
+			if fn.IsTest {
+				return nil
+			}
+			if fn.Receiver != "" {
+				return typeOf(fn.Receiver)
+			}
+			start, end = fn.startByte, fn.endByte
+		}
+		var found *typeSpan
+		for i := range spans {
+			if spans[i].start > start {
+				break
+			}
+			if spans[i].contains(start, end) {
+				found = &spans[i]
+			}
+		}
+		if found == nil || inTest(tests, found.start, found.end) {
+			return nil
+		}
+		return typeOf(found.name)
+	}
+
+	type reference struct {
+		node     *sitter.Node
+		pkg      *sitter.Node
+		embedded bool
+	}
+	refs := map[uintptr]reference{}
+	var order []uintptr
+	ForEachMatch(l.references, root, source, func(match *sitter.QueryMatch) {
+		var ref reference
+		for _, capture := range match.Captures {
+			switch l.references.CaptureNameForId(capture.Index) {
+			case referenceCapture:
+				ref.node = capture.Node
+			case embeddedCapture:
+				ref.node = capture.Node
+				ref.embedded = true
+			case packageCapture:
+				ref.pkg = capture.Node
+			}
+		}
+		if ref.node == nil {
+			return
+		}
+		if _, isName := names[ref.node.ID()]; isName {
+			return
+		}
+		// The plain pattern also matches the name inside a qualified or
+		// embedded form; the more specific match wins.
+		if existing, ok := refs[ref.node.ID()]; ok {
+			if existing.embedded || (existing.pkg != nil && ref.pkg == nil) {
+				return
+			}
+		} else {
+			order = append(order, ref.node.ID())
+		}
+		refs[ref.node.ID()] = ref
+	})
+	seen := map[string]map[Reference]bool{}
+	for _, id := range order {
+		ref := refs[id]
+		t := owner(ref.node.StartByte(), ref.node.EndByte())
+		if t == nil {
+			continue
+		}
+		r := Reference{Name: ref.node.Content(source), Embedded: ref.embedded}
+		if ref.pkg != nil {
+			r.Package = ref.pkg.Content(source)
+		}
+		if seen[t.Name] == nil {
+			seen[t.Name] = map[Reference]bool{}
+		}
+		if !seen[t.Name][r] {
+			seen[t.Name][r] = true
+			t.References = append(t.References, r)
+		}
+	}
+	return types
 }
 
 // innermost returns the function whose span most tightly contains the byte

--- a/polyscan/internal/godeps/file.go
+++ b/polyscan/internal/godeps/file.go
@@ -13,12 +13,13 @@ import (
 	sitter "github.com/smacker/go-tree-sitter"
 )
 
-// fileInfo is what the dependency graph needs from one Go file.
-type fileInfo struct {
+// FileInfo is what the dependency graph and the coupling analysis need from
+// one Go file.
+type FileInfo struct {
 	// Package is the name in the package clause.
 	Package string
-	// Imports are the import paths, in source order, with duplicates kept.
-	Imports []string
+	// Imports are the imports, in source order, with duplicates kept.
+	Imports []Import
 	// ExportedTypes counts the exported type declarations and
 	// ExportedInterfaces the ones among them that declare an interface.
 	// Type aliases are not declarations of their own and are not counted.
@@ -26,12 +27,21 @@ type fileInfo struct {
 	ExportedInterfaces int
 }
 
-// query captures the package clause, every import path and every declared
-// type. An interface type matches both type patterns, so the two captures are
+// Import is one import declaration of a file.
+type Import struct {
+	// Name is the explicit package name, or empty when the import uses the
+	// package's own name; "_" and "." are kept as written.
+	Name string
+	// Path is the import path without its quotes.
+	Path string
+}
+
+// query captures the package clause, every import with its optional name and
+// every declared type. An interface type matches both type patterns, so the two captures are
 // counted separately rather than the second subtracted from the first.
 const query = `
 (package_clause (package_identifier) @package)
-(import_spec path: [(interpreted_string_literal) (raw_string_literal)] @path)
+(import_spec name: (_)? @import.name path: [(interpreted_string_literal) (raw_string_literal)] @path)
 (type_declaration (type_spec name: (type_identifier) @type))
 (type_declaration (type_spec name: (type_identifier) @interface type: (interface_type)))
 `
@@ -52,10 +62,10 @@ func compile() (*sitter.Query, error) {
 	return compiled, compileErr
 }
 
-// parseFile extracts the package clause, imports and type declarations of one
+// ParseFile extracts the package clause, imports and type declarations of one
 // Go source. A file without a package clause, which a syntax error at the top
 // of the file can cause, is an error: nothing places it in a package.
-func parseFile(source []byte) (*fileInfo, error) {
+func ParseFile(source []byte) (*FileInfo, error) {
 	q, err := compile()
 	if err != nil {
 		return nil, err
@@ -69,8 +79,9 @@ func parseFile(source []byte) (*fileInfo, error) {
 	}
 	defer tree.Close()
 
-	info := &fileInfo{}
+	info := &FileInfo{}
 	engine.ForEachMatch(q, tree.RootNode(), source, func(match *sitter.QueryMatch) {
+		var imported Import
 		for _, capture := range match.Captures {
 			text := capture.Node.Content(source)
 			switch q.CaptureNameForId(capture.Index) {
@@ -78,8 +89,11 @@ func parseFile(source []byte) (*fileInfo, error) {
 				if info.Package == "" {
 					info.Package = text
 				}
+			case "import.name":
+				imported.Name = text
 			case "path":
-				info.Imports = append(info.Imports, strings.Trim(text, "\"`"))
+				imported.Path = strings.Trim(text, "\"`")
+				info.Imports = append(info.Imports, imported)
 			case "type":
 				if isExported(text) {
 					info.ExportedTypes++

--- a/polyscan/internal/godeps/file_test.go
+++ b/polyscan/internal/godeps/file_test.go
@@ -6,7 +6,7 @@ import (
 )
 
 func TestParseFile(t *testing.T) {
-	info, err := parseFile([]byte(`package model
+	info, err := ParseFile([]byte(`package model
 
 import "fmt"
 
@@ -32,9 +32,12 @@ var _ = fmt.Sprint(strings.ToUpper(alias.X), Pi)
 	if err != nil {
 		t.Fatal(err)
 	}
-	want := &fileInfo{
-		Package:            "model",
-		Imports:            []string{"fmt", "strings", "embed", "math", "example.com/x/y", "example.com/raw"},
+	want := &FileInfo{
+		Package: "model",
+		Imports: []Import{
+			{Path: "fmt"}, {Path: "strings"}, {Name: "_", Path: "embed"}, {Name: ".", Path: "math"},
+			{Name: "alias", Path: "example.com/x/y"}, {Path: "example.com/raw"},
+		},
 		ExportedTypes:      3,
 		ExportedInterfaces: 2,
 	}
@@ -44,7 +47,7 @@ var _ = fmt.Sprint(strings.ToUpper(alias.X), Pi)
 }
 
 func TestParseFileWithoutPackageClause(t *testing.T) {
-	if _, err := parseFile([]byte("func main() {}\n")); err == nil {
+	if _, err := ParseFile([]byte("func main() {}\n")); err == nil {
 		t.Error("expected an error for a file without a package clause")
 	}
 }

--- a/polyscan/internal/godeps/graph.go
+++ b/polyscan/internal/godeps/graph.go
@@ -73,7 +73,7 @@ func Build(files []string, display func(string) string) (*domain.DependencyGraph
 			warn("%s: %v", display(file), err)
 			continue
 		}
-		info, err := parseFile(content)
+		info, err := ParseFile(content)
 		if err != nil {
 			warn("%s: %v; excluded from the dependency graph", display(file), err)
 			continue
@@ -87,9 +87,9 @@ func Build(files []string, display func(string) string) (*domain.DependencyGraph
 		}
 		seen := map[string]bool{}
 		for _, imported := range info.Imports {
-			if !seen[imported] {
-				seen[imported] = true
-				p.imports[imported]++
+			if !seen[imported.Path] {
+				seen[imported.Path] = true
+				p.imports[imported.Path]++
 			}
 		}
 		p.exportedTypes += info.ExportedTypes

--- a/polyscan/internal/godeps/module.go
+++ b/polyscan/internal/godeps/module.go
@@ -106,3 +106,34 @@ func (m *module) importPath(dir string) (path string, ignored bool, err error) {
 	}
 	return m.path + "/" + rel, false, nil
 }
+
+// Resolver maps directories to import paths and remembers every go.mod it
+// finds, so an analysis that asks about each directory of a tree reads each
+// go.mod once.
+type Resolver struct {
+	finder *moduleFinder
+}
+
+// NewResolver returns an empty Resolver.
+func NewResolver() *Resolver {
+	return &Resolver{finder: newModuleFinder()}
+}
+
+// ImportPath returns the import path of the package in dir. The path is
+// empty when the go tool would not build dir as part of a module: noModule
+// reports that no go.mod lies at or above it, and otherwise the directory is
+// one the tool ignores, such as vendor or testdata.
+func (r *Resolver) ImportPath(dir string) (path string, noModule bool, err error) {
+	m, err := r.finder.find(dir)
+	if err != nil {
+		return "", false, err
+	}
+	if m == nil {
+		return "", true, nil
+	}
+	path, ignored, err := m.importPath(dir)
+	if err != nil || ignored {
+		return "", false, err
+	}
+	return path, false, nil
+}

--- a/polyscan/internal/js/domain/cbo.go
+++ b/polyscan/internal/js/domain/cbo.go
@@ -59,8 +59,12 @@ type CBOMetrics struct {
 // ClassCoupling represents CBO analysis result for a single class
 type ClassCoupling struct {
 	// Class identification
-	Name      string
-	FilePath  string
+	Name     string
+	FilePath string
+	// Language names the language of a type the generic engine measured;
+	// the JavaScript/TypeScript analysis, whose unit is the file, leaves it
+	// empty.
+	Language  string `json:"language,omitempty" yaml:"language,omitempty"`
 	StartLine int
 	EndLine   int
 

--- a/polyscan/internal/js/service/cbo_service.go
+++ b/polyscan/internal/js/service/cbo_service.go
@@ -112,8 +112,7 @@ func (s *CBOServiceImpl) buildResponse(ctx context.Context, results []fileAnalys
 	filteredClasses := s.filterClasses(allClasses, req)
 	sortedClasses := s.sortClasses(filteredClasses, req.SortBy)
 
-	// Generate summary
-	summary := s.generateSummary(sortedClasses, filesProcessed, req)
+	summary := SummarizeCoupling(sortedClasses, filesProcessed)
 
 	return &domain.CBOResponse{
 		Classes:     sortedClasses,
@@ -240,8 +239,10 @@ func classPrecedes(a, b domain.ClassCoupling) bool {
 	return a.Name < b.Name
 }
 
-// generateSummary generates a summary of the CBO analysis
-func (s *CBOServiceImpl) generateSummary(classes []domain.ClassCoupling, filesProcessed int, req domain.CBORequest) domain.CBOSummary {
+// SummarizeCoupling aggregates coupling results, in any order, into the
+// summary the report renders: totals, risk counts, the distribution and the
+// most coupled classes.
+func SummarizeCoupling(classes []domain.ClassCoupling, filesProcessed int) domain.CBOSummary {
 	summary := domain.CBOSummary{
 		TotalClasses:    len(classes),
 		ClassesAnalyzed: len(classes),
@@ -280,7 +281,7 @@ func (s *CBOServiceImpl) generateSummary(classes []domain.ClassCoupling, filesPr
 		}
 
 		// Build distribution
-		rangeKey := s.getCBORange(cbo)
+		rangeKey := cboRange(cbo)
 		summary.CBODistribution[rangeKey]++
 	}
 
@@ -302,8 +303,8 @@ func (s *CBOServiceImpl) generateSummary(classes []domain.ClassCoupling, filesPr
 	return summary
 }
 
-// getCBORange returns a string representing the CBO range for distribution
-func (s *CBOServiceImpl) getCBORange(cbo int) string {
+// cboRange returns a string representing the CBO range for distribution
+func cboRange(cbo int) string {
 	switch {
 	case cbo == 0:
 		return "0"

--- a/polyscan/internal/js/service/cbo_service_test.go
+++ b/polyscan/internal/js/service/cbo_service_test.go
@@ -81,9 +81,7 @@ func TestCBOService_sortClasses_TiesOrderedBySourceLocation(t *testing.T) {
 // A tie at the top-10 cutoff must not let ranking membership depend on input
 // order: previously, whichever tied class the concurrent schedule happened to
 // place earlier won the last slot.
-func TestCBOService_generateSummary_MostCoupledClassesStableAtTiedCutoff(t *testing.T) {
-	service := NewCBOServiceWithDefaults()
-
+func TestSummarizeCoupling_MostCoupledClassesStableAtTiedCutoff(t *testing.T) {
 	classes := make([]domain.ClassCoupling, 0, mostCoupledClassesLimit+2)
 	for i := 0; i < mostCoupledClassesLimit-1; i++ {
 		classes = append(classes, couplingClass("Popular", "src/popular.js", 100+i))
@@ -95,8 +93,8 @@ func TestCBOService_generateSummary_MostCoupledClassesStableAtTiedCutoff(t *test
 		couplingClass("TieB", "src/tie_b.js", 13),
 	)
 
-	forward := service.generateSummary(classes, 1, domain.CBORequest{})
-	backward := service.generateSummary(reversed(classes), 1, domain.CBORequest{})
+	forward := SummarizeCoupling(classes, 1)
+	backward := SummarizeCoupling(reversed(classes), 1)
 
 	if len(forward.MostCoupledClasses) != mostCoupledClassesLimit {
 		t.Fatalf("expected %d most coupled classes, got %d", mostCoupledClassesLimit, len(forward.MostCoupledClasses))

--- a/polyscan/internal/js/service/html_formatter.go
+++ b/polyscan/internal/js/service/html_formatter.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/version"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang"
 )
 
 //go:embed templates/analyze/report.html templates/analyze/report.css templates/analyze/report.js
@@ -631,12 +632,14 @@ func buildReportFacts(summary *domain.AnalyzeSummary, moduleQuality []domain.Mod
 
 // countClasses counts the distinct types the coupling and cohesion analyses
 // report between them. A Go or Rust type can appear in both, under one name
-// in one package directory or file; a JavaScript module appears in coupling
-// only.
+// in the unit its language scopes a type to: the package directory when the
+// language lets a type's methods span one, as Go does, and the file
+// otherwise, so two Rust types of one name in sibling files stay two. A
+// JavaScript module appears in coupling only.
 func countClasses(cbo *domain.CBOResponse, lcom *domain.LCOMResponse) int {
 	seen := map[string]bool{}
 	key := func(language, path, name string) string {
-		return language + "\x00" + filepath.Dir(path) + "\x00" + name
+		return language + "\x00" + classUnit(language, path) + "\x00" + name
 	}
 	if cbo != nil {
 		for _, class := range cbo.Classes {
@@ -649,6 +652,18 @@ func countClasses(cbo *domain.CBOResponse, lcom *domain.LCOMResponse) int {
 		}
 	}
 	return len(seen)
+}
+
+// classUnit is the location that, with its name, identifies a type of the
+// given language: the directory for a language whose types span one, else
+// the file.
+func classUnit(language, path string) string {
+	for _, l := range lang.All {
+		if l.Name == language && l.TypeSpansDirectory {
+			return filepath.Dir(path)
+		}
+	}
+	return path
 }
 
 // formatPercent renders a 0-1 ratio as a percentage. Similarity is reported

--- a/polyscan/internal/js/service/html_formatter.go
+++ b/polyscan/internal/js/service/html_formatter.go
@@ -282,7 +282,7 @@ func buildAnalyzeReportView(
 	view.Tabs = buildReportTabs(summary, results.Complexity, moduleQuality, results.Deps)
 	view.Dimensions = buildReportDimensions(summary, view.Tabs)
 	view.Verdict = buildReportVerdict(summary, view.Dimensions)
-	view.Facts = buildReportFacts(summary, moduleQuality)
+	view.Facts = buildReportFacts(summary, moduleQuality, countClasses(results.CBO, results.LCOM))
 	view.Hotspots = buildReportHotspots(moduleQuality, results.Clone, risk)
 	view.Histogram = buildReportHistogram(results.Complexity, risk)
 	view.Duplication = buildReportDuplication(summary, results.Clone)
@@ -404,6 +404,8 @@ func buildReportTabs(
 		}
 		tabs = append(tabs, tab)
 	}
+	// A type may be both highly coupled and poorly cohesive; those are two
+	// findings on it.
 	if summary.CBOEnabled || summary.LCOMEnabled {
 		tab := reportTab{ID: "classes", Label: "Classes", Count: summary.HighCouplingClasses + summary.HighLCOMClasses}
 		if tab.Count > 0 {
@@ -605,7 +607,7 @@ func isAre(n int) string {
 	return "are"
 }
 
-func buildReportFacts(summary *domain.AnalyzeSummary, moduleQuality []domain.ModuleQualityMetrics) []reportFact {
+func buildReportFacts(summary *domain.AnalyzeSummary, moduleQuality []domain.ModuleQualityMetrics, classes int) []reportFact {
 	var facts []reportFact
 	lines := 0
 	for _, module := range moduleQuality {
@@ -621,11 +623,32 @@ func buildReportFacts(summary *domain.AnalyzeSummary, moduleQuality []domain.Mod
 	if summary.ComplexityEnabled {
 		facts = append(facts, reportFact{Value: formatThousands(summary.TotalFunctions), Label: "functions"})
 	}
-	// CBO and LCOM cover disjoint languages, so their class counts add up.
-	if classes := summary.CBOClasses + summary.LCOMClasses; summary.CBOEnabled || summary.LCOMEnabled {
+	if summary.CBOEnabled || summary.LCOMEnabled {
 		facts = append(facts, reportFact{Value: formatThousands(classes), Label: "classes"})
 	}
 	return facts
+}
+
+// countClasses counts the distinct types the coupling and cohesion analyses
+// report between them. A Go or Rust type can appear in both, under one name
+// in one package directory or file; a JavaScript module appears in coupling
+// only.
+func countClasses(cbo *domain.CBOResponse, lcom *domain.LCOMResponse) int {
+	seen := map[string]bool{}
+	key := func(language, path, name string) string {
+		return language + "\x00" + filepath.Dir(path) + "\x00" + name
+	}
+	if cbo != nil {
+		for _, class := range cbo.Classes {
+			seen[key(class.Language, class.FilePath, class.Name)] = true
+		}
+	}
+	if lcom != nil {
+		for _, class := range lcom.Classes {
+			seen[key(class.Language, class.FilePath, class.Name)] = true
+		}
+	}
+	return len(seen)
 }
 
 // formatPercent renders a 0-1 ratio as a percentage. Similarity is reported
@@ -1125,8 +1148,8 @@ func cloneContent(fragment *domain.Clone) string {
 }
 
 // buildReportClasses summarizes the class analyses that ran: coupling for
-// JavaScript/TypeScript, cohesion for Go and Rust. The two cover disjoint
-// languages, so the class counts add up.
+// Go, Rust and JavaScript/TypeScript, cohesion for Go and Rust. A type the
+// two share is counted once.
 func buildReportClasses(summary *domain.AnalyzeSummary, cbo *domain.CBOResponse, lcom *domain.LCOMResponse) *reportClasses {
 	if !summary.CBOEnabled || cbo == nil {
 		cbo = nil
@@ -1137,9 +1160,8 @@ func buildReportClasses(summary *domain.AnalyzeSummary, cbo *domain.CBOResponse,
 	if cbo == nil && lcom == nil {
 		return nil
 	}
-	classes := &reportClasses{}
+	classes := &reportClasses{Total: countClasses(cbo, lcom)}
 	if cbo != nil {
-		classes.Total += cbo.Summary.TotalClasses
 		classes.Facts = append(classes.Facts,
 			reportKV{Key: "High coupling", Value: formatThousands(cbo.Summary.HighRiskClasses), Band: warnIfPositive(cbo.Summary.HighRiskClasses)},
 			reportKV{Key: "Medium coupling", Value: formatThousands(cbo.Summary.MediumRiskClasses)},
@@ -1154,7 +1176,6 @@ func buildReportClasses(summary *domain.AnalyzeSummary, cbo *domain.CBOResponse,
 		}
 	}
 	if lcom != nil {
-		classes.Total += lcom.Summary.TotalClasses
 		classes.Facts = append(classes.Facts,
 			reportKV{Key: "Low cohesion", Value: formatThousands(lcom.Summary.HighRiskClasses), Band: warnIfPositive(lcom.Summary.HighRiskClasses)},
 			reportKV{Key: "Medium cohesion", Value: formatThousands(lcom.Summary.MediumRiskClasses)},

--- a/polyscan/internal/js/service/html_formatter_test.go
+++ b/polyscan/internal/js/service/html_formatter_test.go
@@ -486,3 +486,34 @@ func TestReportProject_RelativePathsResolveToTheRealDirectory(t *testing.T) {
 		t.Fatalf("root = %q, want %q", root, want)
 	}
 }
+
+func TestCountClassesScopesTypesPerLanguage(t *testing.T) {
+	coupling := func(language, path, name string) domain.ClassCoupling {
+		return domain.ClassCoupling{Name: name, FilePath: path, Language: language}
+	}
+	cohesion := func(language, path, name string) domain.ClassCohesion {
+		return domain.ClassCohesion{Name: name, FilePath: path, Language: language}
+	}
+	cbo := &domain.CBOResponse{Classes: []domain.ClassCoupling{
+		// A Go type is one over its package: coupling places it in the
+		// declaring file, cohesion in the first file with a method.
+		coupling("Go", "pkg/server.go", "Server"),
+		// Two Rust types of one name in sibling files are two types.
+		coupling("Rust", "src/shapes/circle.rs", "Point"),
+		coupling("Rust", "src/shapes/vector.rs", "Point"),
+		// A JavaScript module has no cohesion row.
+		coupling("", "src/app.js", "app"),
+	}}
+	lcom := &domain.LCOMResponse{Classes: []domain.ClassCohesion{
+		cohesion("Go", "pkg/log.go", "Server"),
+		cohesion("Rust", "src/shapes/circle.rs", "Point"),
+		cohesion("Rust", "src/shapes/vector.rs", "Point"),
+		cohesion("Rust", "src/shapes/polygon.rs", "Polygon"),
+	}}
+	if got := countClasses(cbo, lcom); got != 5 {
+		t.Errorf("countClasses = %d, want 5 (Server, two Points, Polygon, app)", got)
+	}
+	if got := countClasses(cbo, nil); got != 4 {
+		t.Errorf("countClasses without cohesion = %d, want 4", got)
+	}
+}

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -68,6 +68,33 @@ var Language = &engine.Language{
 (func_literal parameters: (parameter_list [(parameter_declaration name: (identifier) @binding) (variadic_parameter_declaration name: (identifier) @binding)] @declaration)) @scope
 (func_literal result: (parameter_list (parameter_declaration name: (identifier) @binding) @declaration)) @scope
 `,
+	// Every type_spec is a type; an alias (type_alias) only names another.
+	// The span is the spec rather than the whole declaration, since a
+	// grouped declaration holds several specs. An interface matches both
+	// patterns and the engine keeps one span, abstract.
+	Types: `
+(type_spec name: (type_identifier) @name) @type
+(type_spec name: (type_identifier) @name type: (interface_type)) @abstract
+`,
+	// Every type_identifier is a reference, including predeclared types and
+	// type parameters, which the analysis drops because nothing declares
+	// them; the qualified form adds the package. An embedded field is a
+	// field_declaration without a name, and the star of an embedded *T is a
+	// bare token, so the type is the identifier itself. An embedded
+	// interface is a type_elem of one term; a type set such as int | MyInt
+	// is a constraint, not embedding.
+	References: `
+(type_identifier) @reference
+(qualified_type package: (package_identifier) @package name: (type_identifier) @reference)
+(field_declaration !name type: [
+  (type_identifier) @embedded
+  (qualified_type package: (package_identifier) @package name: (type_identifier) @embedded)
+  (generic_type type: (type_identifier) @embedded)
+  (generic_type type: (qualified_type package: (package_identifier) @package name: (type_identifier) @embedded))
+])
+(interface_type (type_elem . (type_identifier) @embedded .))
+(interface_type (type_elem . (qualified_type package: (package_identifier) @package name: (type_identifier) @embedded) .))
+`,
 	// Methods of one type may be spread over the files of its package.
 	TypeSpansDirectory: true,
 	// default_case is deliberately absent: the default arm is the no-match

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -2,6 +2,7 @@ package golang
 
 import (
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -414,5 +415,90 @@ func (x *License) Closure() {
 		if got := slices.Sorted(maps.Keys(fn.Calls)); !equalStrings(got, tc.calls) {
 			t.Errorf("%s: calls = %v, want %v", tc.name, got, tc.calls)
 		}
+	}
+}
+
+func TestTypesAndReferences(t *testing.T) {
+	result, err := Language.Analyze([]byte(`package p
+
+import (
+	"context"
+	m "example.com/x/model"
+)
+
+type (
+	Base struct{}
+	ID   int
+)
+
+type Alias = Base
+
+type Server struct {
+	Base
+	*m.Embedded
+	Gen[ID]
+	users []m.User
+	ctx   context.Context
+	byID  map[ID]Item
+}
+
+type Repo interface {
+	Closer
+	m.Reader
+	Find(id ID) (Item, error)
+}
+
+type Number interface{ int | ID }
+
+func (s *Server) Handle(ctx context.Context, item Item) error {
+	type local struct{ n int }
+	_ = Other{}
+	_ = ID(3)
+	var l local
+	_ = l
+	return nil
+}
+
+func Free(x Item) {}
+`))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	want := []engine.Type{
+		{Name: "Base", StartLine: 9, EndLine: 9, Declared: true},
+		{Name: "ID", StartLine: 10, EndLine: 10, Declared: true, References: []engine.Reference{{Name: "int"}}},
+		{Name: "Server", StartLine: 15, EndLine: 22, Declared: true, References: []engine.Reference{
+			{Name: "Base", Embedded: true}, {Name: "Embedded", Package: "m", Embedded: true}, {Name: "Gen", Embedded: true},
+			{Name: "ID"}, {Name: "User", Package: "m"}, {Name: "Context", Package: "context"}, {Name: "Item"},
+			// The method's receiver and body. The local type is not a type
+			// of the file, but a reference to it is still one.
+			{Name: "Server"}, {Name: "error"}, {Name: "int"}, {Name: "Other"}, {Name: "local"},
+		}},
+		{Name: "Repo", StartLine: 24, EndLine: 28, Declared: true, Abstract: true, References: []engine.Reference{
+			{Name: "Closer", Embedded: true}, {Name: "Reader", Package: "m", Embedded: true},
+			{Name: "ID"}, {Name: "Item"}, {Name: "error"},
+		}},
+		{Name: "Number", StartLine: 30, EndLine: 30, Declared: true, Abstract: true, References: []engine.Reference{
+			{Name: "int"}, {Name: "ID"},
+		}},
+	}
+	if !reflect.DeepEqual(result.Types, want) {
+		t.Errorf("types = %+v\nwant   %+v", result.Types, want)
+	}
+}
+
+func TestTypesInAnotherFileOfThePackage(t *testing.T) {
+	result, err := Language.Analyze([]byte(`package p
+
+func (s *Server) Log(msg Message) { s.sink.Write(msg) }
+
+func Helper(x Other) {}
+`))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	want := []engine.Type{{Name: "Server", StartLine: 3, EndLine: 3, References: []engine.Reference{{Name: "Server"}, {Name: "Message"}}}}
+	if !reflect.DeepEqual(result.Types, want) {
+		t.Errorf("types = %+v\nwant   %+v", result.Types, want)
 	}
 }

--- a/polyscan/internal/lang/rust/rust.go
+++ b/polyscan/internal/lang/rust/rust.go
@@ -51,10 +51,66 @@ var Language = &engine.Language{
   name: (identifier) @name
   parameters: (parameters [(self_parameter) (parameter pattern: (self))]? @self)) @definition.function
 `,
+	// An impl names its type by the bare identifier, so impl G<T> and
+	// impl G<i32> are blocks of one type G, a path keeps its last segment,
+	// and a reference such as &G is G, since its methods still touch self.
+	// An impl for any other form, a trait object, tuple, array or pointer,
+	// keeps its text as a module so its functions stay qualified without
+	// becoming methods of a type.
 	Scopes: `
-(impl_item type: (_) @receiver body: (declaration_list) @scope)
+(impl_item type: [
+  (type_identifier) @receiver
+  (generic_type type: (type_identifier) @receiver)
+  (scoped_type_identifier name: (type_identifier) @receiver)
+  (generic_type type: (scoped_type_identifier name: (type_identifier) @receiver))
+  (reference_type type: [
+    (type_identifier) @receiver
+    (generic_type type: (type_identifier) @receiver)
+    (scoped_type_identifier name: (type_identifier) @receiver)
+    (generic_type type: (scoped_type_identifier name: (type_identifier) @receiver))
+  ])
+  [(dynamic_type) (tuple_type) (array_type) (pointer_type) (abstract_type) (function_type) (unit_type)] @module
+] body: (declaration_list) @scope)
 (trait_item name: (type_identifier) @module body: (declaration_list) @scope)
 (mod_item name: (identifier) @module body: (declaration_list) @scope)
+`,
+	// Structs, enums and unions are types, a trait an abstract one, and an
+	// impl adds to the type it names without declaring it; an alias
+	// (type_item) only names another type.
+	Types: `
+(struct_item name: (type_identifier) @name) @type
+(enum_item name: (type_identifier) @name) @type
+(union_item name: (type_identifier) @name) @type
+(trait_item name: (type_identifier) @name) @abstract
+(impl_item type: [
+  (type_identifier) @name
+  (generic_type type: (type_identifier) @name)
+  (scoped_type_identifier name: (type_identifier) @name)
+  (generic_type type: (scoped_type_identifier name: (type_identifier) @name))
+  (reference_type type: [
+    (type_identifier) @name
+    (generic_type type: (type_identifier) @name)
+    (scoped_type_identifier name: (type_identifier) @name)
+    (generic_type type: (scoped_type_identifier name: (type_identifier) @name))
+  ])
+]) @impl
+`,
+	// Every type_identifier is a reference except Self; primitive types are
+	// their own node and never match. A path expression such as Foo::new()
+	// or Color::Red names its type in the path's identifiers, and a tuple
+	// struct pattern names it in the pattern; module segments and generic
+	// parameters caught this way are dropped by the analysis because
+	// nothing declares them. The trait an impl implements is inheritance.
+	References: `
+((type_identifier) @reference (#not-eq? @reference "Self"))
+((scoped_identifier path: [(identifier) @reference (scoped_identifier name: (identifier) @reference)])
+  (#not-eq? @reference "Self"))
+(tuple_struct_pattern type: (identifier) @reference)
+(impl_item trait: [
+  (type_identifier) @embedded
+  (generic_type type: (type_identifier) @embedded)
+  (scoped_type_identifier name: (type_identifier) @embedded)
+])
 `,
 	// A field is anything reached from self, including a tuple struct's
 	// numbered fields; a sibling method is a method call on self or an

--- a/polyscan/internal/lang/rust/rust_test.go
+++ b/polyscan/internal/lang/rust/rust_test.go
@@ -2,6 +2,7 @@ package rust
 
 import (
 	"maps"
+	"reflect"
 	"slices"
 	"strings"
 	"testing"
@@ -39,14 +40,14 @@ fn with_closure() { let f = |x| x; f(1); }
 `)
 
 	want := map[string]string{
-		"free":          "function",
-		"S::method":     "function",
-		"G<T>::generic": "function",
-		"S::fmt":        "function",
-		"Tr::provided":  "function",
-		"m::inner":      "function",
-		"m::nested":     "function",
-		"with_closure":  "function",
+		"free":         "function",
+		"S::method":    "function",
+		"G::generic":   "function",
+		"S::fmt":       "function",
+		"Tr::provided": "function",
+		"m::inner":     "function",
+		"m::nested":    "function",
+		"with_closure": "function",
 	}
 	if len(functions) != len(want) {
 		t.Fatalf("got %d functions, want %d: %v", len(functions), len(want), functions)
@@ -295,11 +296,11 @@ mod inner {
 		fields   []string
 		calls    []string
 	}{
-		{"S<T>::new", "S<T>", false, nil, nil},
-		{"S<T>::fields", "S<T>", true, []string{"a", "b"}, []string{}},
-		{"S<T>::calls", "S<T>", true, []string{"cb"}, []string{"fields", "helper", "new"}},
-		{"S<T>::helper", "S<T>", false, nil, nil},
-		{"S<T>::boxed", "S<T>", true, []string{"b"}, []string{}},
+		{"S::new", "S", false, nil, nil},
+		{"S::fields", "S", true, []string{"a", "b"}, []string{}},
+		{"S::calls", "S", true, []string{"cb"}, []string{"fields", "helper", "new"}},
+		{"S::helper", "S", false, nil, nil},
+		{"S::boxed", "S", true, []string{"b"}, []string{}},
 		{"Pair::sum", "Pair", true, []string{"0", "1"}, []string{}},
 		{"Tr::default_method", "", true, nil, nil},
 		{"inner::free", "", true, nil, nil},
@@ -333,4 +334,57 @@ func equalStrings(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+func TestTypesAndReferences(t *testing.T) {
+	result, err := Language.Analyze([]byte(`
+use std::collections::HashMap;
+pub struct Foo { a: Bar, m: HashMap<String, Baz> }
+pub enum Color { Red, Green(Bar) }
+pub trait Tr { fn d(&self) -> Bar { Bar::new() } fn r(&self); }
+impl Tr for Foo { fn r(&self) {} }
+impl<T: Clone> G<T> { fn new() -> Self { Self::default() } }
+impl Iterator for &Foo { type Item = Baz; fn next(&mut self) -> Option<Baz> { None } }
+impl dyn Tr { fn x(&self) -> Qux { Qux } }
+mod m { pub struct Inner(super::Bar); impl Inner { fn f(&self) { let Inner(b) = self; match c { Color::Red => {} } } } }
+fn free() -> Bar { Foo::new() }
+#[cfg(test)]
+mod tests { struct Fixture; impl Fixture { fn f(&self) -> Bar {} } impl Foo { fn t(&self) -> Baz {} } }
+`))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	want := []engine.Type{
+		// Foo's declaration, its two impls, the impl for &Foo; the impl in
+		// the test module is a test span of another scope.
+		{Name: "Foo", StartLine: 3, EndLine: 3, Declared: true, References: []engine.Reference{
+			{Name: "Bar"}, {Name: "HashMap"}, {Name: "String"}, {Name: "Baz"},
+			{Name: "Tr", Embedded: true}, {Name: "Iterator", Embedded: true}, {Name: "Item"}, {Name: "Option"},
+		}},
+		{Name: "Color", StartLine: 4, EndLine: 4, Declared: true, References: []engine.Reference{{Name: "Bar"}}},
+		// A default method's references belong to the trait.
+		{Name: "Tr", StartLine: 5, EndLine: 5, Declared: true, Abstract: true, References: []engine.Reference{{Name: "Bar"}}},
+		// An impl of an undeclared type is not declared here.
+		{Name: "G", StartLine: 7, EndLine: 7, References: []engine.Reference{{Name: "T"}, {Name: "Clone"}}},
+		{Name: "m::Inner", StartLine: 10, EndLine: 10, Declared: true, References: []engine.Reference{
+			{Name: "Bar"}, {Name: "Inner"}, {Name: "Color"},
+		}},
+		{Name: "tests::Fixture", StartLine: 13, EndLine: 13, Declared: true, IsTest: true},
+		{Name: "tests::Foo", StartLine: 13, EndLine: 13, IsTest: true},
+	}
+	if !reflect.DeepEqual(result.Types, want) {
+		t.Errorf("types = %+v\nwant   %+v", result.Types, want)
+	}
+	if fn := result.Functions[0]; fn.Name != "Tr::d" || fn.Receiver != "" {
+		t.Errorf("trait default method = %+v, want Tr::d without a receiver", fn)
+	}
+	for _, name := range []string{"Foo::r", "G::new", "Foo::next", "dyn Tr::x", "m::Inner::f"} {
+		found := false
+		for _, fn := range result.Functions {
+			found = found || fn.Name == name
+		}
+		if !found {
+			t.Errorf("missing function %q", name)
+		}
+	}
 }

--- a/polyscan/internal/report/report.go
+++ b/polyscan/internal/report/report.go
@@ -21,13 +21,12 @@ import (
 )
 
 // Combine merges the generic-engine report with the JavaScript/TypeScript
-// result into the shape the output formatter renders. Complexity, clone and
-// dependency results merge across languages; dead code and coupling exist
-// only for JavaScript/TypeScript and pass through, and cohesion only for the
-// generic engine. The file accounting adds
-// up across both sides, so the health score charges every unparsable file
-// whichever analyses ran. Either input may be nil when its side found no
-// files.
+// result into the shape the output formatter renders. Complexity, clone,
+// coupling and dependency results merge across languages; dead code exists
+// only for JavaScript/TypeScript and passes through, and cohesion only for
+// the generic engine. The file accounting adds up across both sides, so the
+// health score charges every unparsable file whichever analyses ran. Either
+// input may be nil when its side found no files.
 func Combine(generic *analysis.Report, javascript *js.Result) (domain.AnalysisResults, error) {
 	results := domain.AnalysisResults{}
 	if javascript != nil {
@@ -51,6 +50,7 @@ func Combine(generic *analysis.Report, javascript *js.Result) (domain.AnalysisRe
 		results.Complexity = mergeComplexity(complexity, results.Complexity)
 		results.Clone = mergeClones(genericClones(generic), results.Clone)
 		results.LCOM = genericCohesion(generic)
+		results.CBO = mergeCoupling(genericCoupling(generic), results.CBO)
 		results.Deps, err = mergeDeps(generic.Deps, results.Deps)
 		if err != nil {
 			return domain.AnalysisResults{}, err
@@ -299,6 +299,79 @@ func genericCohesion(report *analysis.Report) *domain.LCOMResponse {
 			"low_threshold":    coredomain.DefaultLCOMLowThreshold,
 			"medium_threshold": coredomain.DefaultLCOMMediumThreshold,
 		},
+	}
+}
+
+// genericCoupling converts the generic engine's coupling analysis into the
+// formatter's CBO response.
+func genericCoupling(report *analysis.Report) *domain.CBOResponse {
+	if report.Coupling == nil {
+		return nil
+	}
+	src := report.Coupling
+	classes := make([]domain.ClassCoupling, 0, len(src.Classes))
+	for _, class := range src.Classes {
+		classes = append(classes, domain.ClassCoupling{
+			Name:      class.Name,
+			FilePath:  class.FilePath,
+			Language:  class.Language,
+			StartLine: class.StartLine,
+			EndLine:   class.EndLine,
+			Metrics: domain.CBOMetrics{
+				CouplingCount:           class.CBO,
+				InheritanceDependencies: class.Inheritance,
+				TypeHintDependencies:    class.TypeHint,
+				DependentClasses:        class.DependentClasses,
+			},
+			RiskLevel:  domain.RiskLevel(class.RiskLevel),
+			IsAbstract: class.IsAbstract,
+		})
+	}
+	return &domain.CBOResponse{
+		Classes:     classes,
+		Summary:     service.SummarizeCoupling(classes, src.FilesAnalyzed),
+		Warnings:    append([]string{}, src.Warnings...),
+		Errors:      []string{},
+		GeneratedAt: time.Now().Format(time.RFC3339),
+		Version:     version.Version,
+		Config: map[string]interface{}{
+			"low_threshold":    coredomain.DefaultCBOLowThreshold,
+			"medium_threshold": coredomain.DefaultCBOMediumThreshold,
+		},
+	}
+}
+
+// mergeCoupling merges the generic and JavaScript coupling responses into
+// one population, re-ranked and re-summarized. The JavaScript configuration
+// wins, as in mergeComplexity.
+func mergeCoupling(generic, javascript *domain.CBOResponse) *domain.CBOResponse {
+	if generic == nil {
+		return javascript
+	}
+	if javascript == nil {
+		return generic
+	}
+	classes := make([]domain.ClassCoupling, 0, len(generic.Classes)+len(javascript.Classes))
+	classes = append(classes, generic.Classes...)
+	classes = append(classes, javascript.Classes...)
+	sort.SliceStable(classes, func(i, j int) bool {
+		a, b := classes[i], classes[j]
+		if a.Metrics.CouplingCount != b.Metrics.CouplingCount {
+			return a.Metrics.CouplingCount > b.Metrics.CouplingCount
+		}
+		if a.FilePath != b.FilePath {
+			return a.FilePath < b.FilePath
+		}
+		return a.StartLine < b.StartLine
+	})
+	return &domain.CBOResponse{
+		Classes:     classes,
+		Summary:     service.SummarizeCoupling(classes, generic.Summary.FilesAnalyzed+javascript.Summary.FilesAnalyzed),
+		Warnings:    mergeStrings(generic.Warnings, javascript.Warnings),
+		Errors:      mergeStrings(generic.Errors, javascript.Errors),
+		GeneratedAt: javascript.GeneratedAt,
+		Version:     javascript.Version,
+		Config:      javascript.Config,
 	}
 }
 

--- a/polyscan/internal/report/report_test.go
+++ b/polyscan/internal/report/report_test.go
@@ -311,3 +311,67 @@ func TestCombineGoDependencies(t *testing.T) {
 		t.Errorf("warnings = %v, want %v", deps.Warnings, want)
 	}
 }
+
+func TestCombineCoupling(t *testing.T) {
+	generic := &analysis.Report{Coupling: &analysis.Coupling{
+		Classes: []analysis.CoupledClass{
+			{Name: "Server", FilePath: "a.go", Language: "Go", StartLine: 3, EndLine: 9, CBO: 4, DependentClasses: []string{"Base", "Config", "model.User", "st.Store"}, Inheritance: 1, TypeHint: 3, RiskLevel: coredomain.RiskLevelMedium},
+			{Name: "Config", FilePath: "b.go", Language: "Go", StartLine: 1, EndLine: 2, CBO: 1, DependentClasses: []string{"Base"}, TypeHint: 1, RiskLevel: coredomain.RiskLevelLow},
+		},
+		FilesAnalyzed: 2,
+		Warnings:      []string{"x: no go.mod above it"},
+	}}
+
+	results, err := Combine(generic, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cbo := results.CBO
+	if cbo == nil || len(cbo.Classes) != 2 {
+		t.Fatalf("cbo = %+v, want two classes", cbo)
+	}
+	server := cbo.Classes[0]
+	if server.Name != "Server" || server.Language != "Go" || server.Metrics.CouplingCount != 4 ||
+		server.Metrics.InheritanceDependencies != 1 || server.Metrics.TypeHintDependencies != 3 ||
+		server.RiskLevel != domain.RiskLevelMedium || !reflect.DeepEqual(server.Metrics.DependentClasses, []string{"Base", "Config", "model.User", "st.Store"}) {
+		t.Errorf("Server = %+v", server)
+	}
+	summary := cbo.Summary
+	if summary.TotalClasses != 2 || summary.FilesAnalyzed != 2 || summary.MaxCBO != 4 || summary.MinCBO != 1 ||
+		summary.AverageCBO != 2.5 || summary.MediumRiskClasses != 1 || summary.LowRiskClasses != 1 ||
+		len(summary.MostCoupledClasses) != 2 || summary.CBODistribution["4-7"] != 1 {
+		t.Errorf("summary = %+v", summary)
+	}
+	if !reflect.DeepEqual(cbo.Warnings, []string{"x: no go.mod above it"}) {
+		t.Errorf("warnings = %v", cbo.Warnings)
+	}
+
+	javascript := &js.Result{CBO: &domain.CBOResponse{
+		Classes: []domain.ClassCoupling{{Name: "app", FilePath: "src/app.js", StartLine: 1, EndLine: 40,
+			Metrics: domain.CBOMetrics{CouplingCount: 3, DependentClasses: []string{"react", "util", "zod"}}, RiskLevel: domain.RiskLevelLow}},
+		Summary:     domain.CBOSummary{TotalClasses: 1, FilesAnalyzed: 1},
+		Warnings:    []string{"js warning"},
+		GeneratedAt: "then",
+		Version:     "1",
+		Config:      map[string]any{"low_threshold": 7},
+	}}
+	results, err = Combine(generic, javascript)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cbo = results.CBO
+	names := []string{cbo.Classes[0].Name, cbo.Classes[1].Name, cbo.Classes[2].Name}
+	if !reflect.DeepEqual(names, []string{"Server", "app", "Config"}) {
+		t.Errorf("merged ranking = %v, want Server, app, Config", names)
+	}
+	if cbo.Classes[1].Language != "" {
+		t.Errorf("the JavaScript module carries no language, got %q", cbo.Classes[1].Language)
+	}
+	summary = cbo.Summary
+	if summary.TotalClasses != 3 || summary.FilesAnalyzed != 3 || summary.LowRiskClasses != 2 || summary.MediumRiskClasses != 1 {
+		t.Errorf("merged summary = %+v", summary)
+	}
+	if !reflect.DeepEqual(cbo.Warnings, []string{"x: no go.mod above it", "js warning"}) || cbo.GeneratedAt != "then" || cbo.Config.(map[string]any)["low_threshold"] != 7 {
+		t.Errorf("merged metadata = warnings %v at %q with %v; the JavaScript configuration wins", cbo.Warnings, cbo.GeneratedAt, cbo.Config)
+	}
+}

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -25,7 +25,7 @@ polyscan analyze src/ test/ scripts/build.ts             # Several paths at once
 
 | Flag | Short | Default | Description |
 | --- | --- | --- | --- |
-| `--select` | `-s` | `complexity,deadcode,clone,cbo,deps` | Comma-separated list of analyses to run. `deps` applies to Go and JavaScript/TypeScript; `deadcode` and `cbo` to JavaScript/TypeScript only |
+| `--select` | `-s` | `complexity,deadcode,clone,cbo,lcom,deps` | Comma-separated list of analyses to run. `deps` applies to Go and JavaScript/TypeScript; `cbo` to Go, Rust and JavaScript/TypeScript; `lcom` to Go and Rust; `deadcode` to JavaScript/TypeScript only |
 | `--format` | `-f` | `html` | Output format. Accepts `html`, `json`, or `text` |
 | `--no-open` | | `false` | Write the HTML report without opening a browser |
 | `--output` | `-o` | `polyscan-report.html` | Path for the HTML report file |
@@ -35,7 +35,7 @@ The configuration file for the JavaScript/TypeScript analysis is discovered auto
 
 ## Language coverage
 
-The language of each file is detected from its extension. Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Dead code and coupling (CBO) exist for JavaScript/TypeScript only, and the health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
+The language of each file is detected from its extension. Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Coupling (CBO) covers Go, Rust and JavaScript/TypeScript, and cohesion (LCOM4) Go and Rust. Dead code exists for JavaScript/TypeScript only, and the health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
 For Go, Rust and C++, version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. JavaScript/TypeScript exclusions come from `jscan.config.json`. A file that cannot be read is skipped and listed under errors. A file with a syntax error is analyzed without the functions that contain it, counted as partial, and listed under warnings. C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
@@ -131,11 +131,15 @@ In Go, Rust and C++, test code is analyzed for complexity but excluded from clon
 
 ### Coupling between objects {#cbo}
 
-*JavaScript/TypeScript only.* Counts how many other types each unit depends on, across four kinds of dependency: imports, `new` expressions, TypeScript type annotations, and method calls on other objects.
+*Go, Rust and JavaScript/TypeScript.* Counts how many other types each unit depends on.
 
-!!! info "This metric is per file, not per class"
+For Go and Rust the unit is a type: a Go struct, interface or other named type, a Rust struct, enum, union or trait. Its dependencies are the types named by its declaration (fields, embedded types, method signatures of an interface) and by the bodies of its methods, and only types declared somewhere in the analyzed tree count. A Go name `pkg.T` resolves through the nearest `go.mod` to a package of the tree; a tree without one resolves same-package names only and says so in a warning. A Rust name resolves to a declaration in the same file, or else anywhere in the tree. The standard library, third-party crates and other modules therefore never count. An embedded field or interface and an implemented trait count as inheritance. A type coupled to nothing is not listed, and test files and `#[cfg(test)]` code stay out.
 
-    Despite the name, polyscan produces one coupling entry per source file, named after the module. The terminal output and the JSON field names still say "classes", which they inherit from the shared metric definition. Read every count as a per-module count.
+For JavaScript/TypeScript the dependencies come in four kinds: imports, `new` expressions, TypeScript type annotations, and method calls on other objects.
+
+!!! info "For JavaScript/TypeScript this metric is per file, not per class"
+
+    polyscan produces one coupling entry per JavaScript/TypeScript source file, named after the module. The terminal output and the JSON field names still say "classes", which they inherit from the shared metric definition. For those languages, read every count as a per-module count.
 
 | Risk | Condition |
 | --- | --- |

--- a/website/docs/output/json-schema.md
+++ b/website/docs/output/json-schema.md
@@ -17,6 +17,7 @@ polyscan analyze --format json src/ > report.json
   "dead_code": { },
   "clone": { },
   "cbo": { },
+  "lcom": { },
   "deps": { },
   "module_quality": [ ],
   "summary": { }
@@ -31,12 +32,13 @@ polyscan analyze --format json src/ > report.json
 | `complexity` | object | Present only when complexity analysis ran |
 | `dead_code` | object | Present only when dead code detection ran (JavaScript/TypeScript) |
 | `clone` | object | Present only when clone detection ran |
-| `cbo` | object | Present only when coupling analysis ran (JavaScript/TypeScript) |
+| `cbo` | object | Present only when coupling analysis ran (Go, Rust, JavaScript/TypeScript) |
+| `lcom` | object | Present only when cohesion analysis ran (Go, Rust) |
 | `deps` | object | Present only when dependency analysis ran (Go, JavaScript/TypeScript) |
 | `module_quality` | array | Per-file rollups joined across the analyses that ran |
 | `summary` | object | Always present |
 
-The five analysis keys are omitted entirely when `--select` excludes them or when no analyzed language has them, so consumers should check for their presence rather than assume it.
+The six analysis keys are omitted entirely when `--select` excludes them or when no analyzed language has them, so consumers should check for their presence rather than assume it.
 
 ## `summary`
 
@@ -95,7 +97,7 @@ A few fields need explanation.
 
 The `*_enabled` flags say which dimensions actually ran and therefore which the health score was computed over. A dimension can be off because `--select` excluded it or because no analyzed language has it: a pure Go project reports `dead_code_enabled: false` even under the default selection. See [the health score page](health-score.md#the-formula).
 
-`cbo_classes`, `high_coupling_classes`, and `medium_coupling_classes` count modules rather than classes, despite the names. See [the analyze reference](../cli/analyze.md#cbo).
+`cbo_classes`, `high_coupling_classes`, and `medium_coupling_classes` count Go and Rust types and JavaScript/TypeScript modules together; for the latter the unit is the file despite the names. See [the analyze reference](../cli/analyze.md#cbo).
 
 `arch_enabled` is always `false` and `architecture_score` is always `0`, because architecture validation is not implemented in polyscan. Ignore both.
 
@@ -300,7 +302,7 @@ The `summary` object carries a `findings_by_reason` map, which is the most conve
 
 ## `cbo`
 
-*JavaScript/TypeScript only.*
+*Go, Rust and JavaScript/TypeScript.*
 
 ```json
 {
@@ -339,7 +341,43 @@ The `summary` object carries a `findings_by_reason` map, which is the most conve
 }
 ```
 
-`CouplingCount` is the CBO value. `DependentClasses` names what this module depends on, and the four `*Dependencies` counters break the total down by how the dependency was formed.
+`CouplingCount` is the CBO value. `DependentClasses` names what this class or module depends on, and the `*Dependencies` counters break the total down by how the dependency was formed. A Go or Rust entry is one type and carries a `language` field (`"Go"` or `"Rust"`), which a JavaScript/TypeScript entry, whose unit is the file, omits; its `DependentClasses` name only types declared in the analyzed tree, and it uses `InheritanceDependencies` for embedded types and implemented traits and `TypeHintDependencies` for every other reference.
+
+## `lcom`
+
+*Go and Rust.*
+
+```json
+{
+  "version": "0.1.0",
+  "generated_at": "2026-08-04T16:20:39+09:00",
+  "classes": [ ],
+  "summary": { },
+  "warnings": [ ],
+  "errors": [ ],
+  "config": { }
+}
+```
+
+```json
+{
+  "name": "Server",
+  "file_path": "internal/server.go",
+  "language": "Go",
+  "start_line": 12,
+  "end_line": 80,
+  "metrics": {
+    "lcom4": 2,
+    "total_methods": 6,
+    "excluded_methods": 1,
+    "instance_variables": 4,
+    "method_groups": [["Start", "Stop", "Log"], ["Version", "Name"]]
+  },
+  "risk_level": "low"
+}
+```
+
+`lcom4` is the number of groups the type's methods fall into when two methods are connected by a shared field or a call between them; `method_groups` lists them. `excluded_methods` counts methods without a receiver parameter, which cannot reach instance state. `summary` carries `total_classes`, `average_lcom`, `max_lcom`, `min_lcom` and the `low_risk_classes`, `medium_risk_classes` and `high_risk_classes` counts.
 
 ## `deps`
 


### PR DESCRIPTION
Adds the Coupling (CBO) dimension for Go and Rust, mirroring how #108 added LCOM4.

- The engine gains `Types` and `References` queries: a Types match is a struct/interface/enum/union/trait declaration or a Rust `impl` block, a References match is a type name, optionally qualified (`pkg.T`) or embedded (embedded field or interface, implemented trait, counted as inheritance). A reference belongs to the type whose declaration or method contains it.
- Only types declared in the analyzed tree count: a Go `pkg.T` resolves through the nearest `go.mod` (a tree without one keeps same-package references and warns), a Rust bare name resolves to a declaration in the same file or elsewhere in the tree. The standard library and other modules never count, so no builtin lists are needed.
- Thresholds are `core/cbo` defaults (3/7). Types coupled to nothing, test files and `#[cfg(test)]` code stay out, as for LCOM.
- `report.Combine` merges the generic result with the JavaScript one through the summary logic extracted from the CBO service; the overview counts a type that has both a coupling and a cohesion row once.
- A Rust `impl` now names its type by the bare identifier (`G::m` instead of `G<T>::m`), so `impl G<T>` and `impl G<i32>` are blocks of one type for both analyses.

On this repository: 160 coupled Go types (avg CBO 3.2), Coupling 65/100.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr
