### PR TITLE
feat(core): export PairClassifier.CapNonTextualSimilarity

### DIFF
--- a/core/clone/classifier.go
+++ b/core/clone/classifier.go
@@ -68,7 +68,7 @@ func (c *PairClassifier) ClassifyPair(f1, f2 *CodeFragment, structuralSimilarity
 		return domain.Type1Clone, structuralSimilarity
 	}
 
-	capped := c.capNonTextualSimilarity(structuralSimilarity)
+	capped := c.CapNonTextualSimilarity(structuralSimilarity)
 	if c.config.EnableType2 && c.syntactic != nil && capped >= c.config.Type2Threshold {
 		syntacticSimilarity := c.syntactic.ComputeSimilarity(f1, f2)
 		if syntacticSimilarity >= c.config.Type2Threshold {
@@ -85,10 +85,12 @@ func (c *PairClassifier) ClassifyPair(f1, f2 *CodeFragment, structuralSimilarity
 	return 0, capped
 }
 
-// capNonTextualSimilarity caps structural similarity just below the Type-1
-// threshold so that pairs without an exact textual match never report a
-// Type-1-level similarity.
-func (c *PairClassifier) capNonTextualSimilarity(similarity float64) float64 {
+// CapNonTextualSimilarity caps similarity just below the Type-1 threshold so
+// that pairs without an exact textual match never report a Type-1-level
+// similarity. ClassifyPair applies it internally; callers that classify pairs
+// outside ClassifyPair (e.g. a semantic Type-4 path) should apply it to the
+// similarity they report so values stay comparable across clone types.
+func (c *PairClassifier) CapNonTextualSimilarity(similarity float64) float64 {
 	if similarity < c.config.Type1Threshold {
 		return similarity
 	}

--- a/core/clone/classifier_test.go
+++ b/core/clone/classifier_test.go
@@ -140,12 +140,12 @@ func TestCapNonTextualSimilarity(t *testing.T) {
 	c := newTestPairClassifier()
 
 	// Below the Type-1 threshold: unchanged.
-	if got := c.capNonTextualSimilarity(0.90); got != 0.90 {
+	if got := c.CapNonTextualSimilarity(0.90); got != 0.90 {
 		t.Errorf("below-threshold similarity must pass through, got %f", got)
 	}
 
 	// At or above the Type-1 threshold: capped just below it.
-	got := c.capNonTextualSimilarity(1.0)
+	got := c.CapNonTextualSimilarity(1.0)
 	if got >= c.config.Type1Threshold {
 		t.Errorf("capped similarity %f must be below Type-1 threshold %f", got, c.config.Type1Threshold)
 	}


### PR DESCRIPTION
## Summary

Exports `PairClassifier.capNonTextualSimilarity` as `CapNonTextualSimilarity` so callers that classify pairs outside `ClassifyPair` can apply the same cap without duplicating it.

Requested in ludo-technologies/pyscn#735 review: pyscn's semantic Type-4 path bypasses `ClassifyPair` and currently needs its own copy of the cap to fix ludo-technologies/pyscn#733. With this exported, pyscn can call `cd.pairClassifier.CapNonTextualSimilarity(result.Similarity)` and drop the local helper, keeping threshold behavior owned by core.

Rename only — no behavior change. `ClassifyPair` still applies the cap internally; the doc comment now says when external callers should use it.

## Test plan

- [x] `go vet ./clone/ && go test ./clone/` in `core/` (existing `TestCapNonTextualSimilarity` updated to the exported name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
