### PR TITLE
docs(website): clone thresholds for Go, Rust and C++ are 0.80

### DIFF
--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -121,8 +121,8 @@ Clones are graded by how much the copies differ:
 | Type | Description | Default threshold | Enabled by default (JS/TS) |
 | --- | --- | --- | --- |
 | Type 1 | Identical apart from whitespace and comments | 0.85 | Yes |
-| Type 2 | Identical after renaming identifiers and literals | 0.75 | Yes |
-| Type 3 | Copies with statements added, removed, or changed | 0.70 | No (JS/TS); reported for Go, Rust and C++ |
+| Type 2 | Identical after renaming identifiers and literals | 0.80 for Go, Rust and C++; 0.75 for JS/TS | Yes |
+| Type 3 | Copies with statements added, removed, or changed | 0.80 for Go, Rust and C++; 0.70 for JS/TS | No (JS/TS); reported for Go, Rust and C++ |
 | Type 4 | Different code that computes the same thing | 0.65 | Yes (JS/TS only) |
 
 A fragment must be at least 10 lines and 20 syntax tree nodes to be considered, which keeps short boilerplate such as getters out of the results.


### PR DESCRIPTION
The clone type table on the analyze page still listed the pre-#105 Type 2 and Type 3 thresholds. It now gives the 0.80 value for Go, Rust and C++ next to the JS/TS values, matching the duplicate code guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr