### PR TITLE
fix(polyscan): skip version control, dependency and build directories

### DIFF
--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Go, Rust and C++ analysis no longer walks into version control, dependency and build output directories. A directory whose name starts with a dot, such as `.git`, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party` are skipped; a path named on the command line is still analyzed whatever it is called. Before, a Rust project's `target` directory and a Go project's `vendor` directory were analyzed as if they were the project's own code
+
 ### Added
 
 - Class cohesion (LCOM4) for Go and Rust. `polyscan analyze` measures, for each type, how many groups its methods fall into when two methods are connected by a shared field or a call between them, and scores the result in a Cohesion dimension with the thresholds pyscn uses (low up to 2, medium up to 5). A Go type is measured over every method of its package, since they may be spread across files; a Rust type over the `impl` blocks in a file. Methods without a receiver parameter, such as Rust associated functions and Go methods with an unnamed receiver, cannot touch instance state and are listed as excluded. Test files and `#[cfg(test)]` code stay out. `--select lcom` runs it alone

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -36,7 +36,7 @@ polyscan analyze --min-complexity 10 .
 
 `--select` takes any of `complexity`, `deadcode`, `clone`, `cbo`, `lcom` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `lcom` for Go and Rust, `deadcode` and `cbo` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
 
-A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
+Version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
 ## Complexity
 

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 
 	"github.com/ludo-technologies/polyscan/core/domain"
-	"github.com/ludo-technologies/polyscan/core/source"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/clone"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/godeps"
@@ -118,10 +117,7 @@ var ErrNoFiles = errors.New("no supported source files found")
 // analysis reads its files again and reports the ones it leaves out in
 // Warnings.
 func Analyze(paths []string, options Options) (*Report, error) {
-	files, err := source.CollectFiles(paths, source.FileFilter{
-		IncludePatterns: lang.IncludePatterns(),
-		Recursive:       true,
-	})
+	files, err := collectFiles(paths)
 	if err != nil {
 		return nil, err
 	}
@@ -146,7 +142,7 @@ func Analyze(paths []string, options Options) (*Report, error) {
 	for _, file := range files {
 		language, ok := lang.ByPath(file)
 		if !ok {
-			// CollectFiles only returns registered extensions.
+			// collectFiles only returns registered extensions.
 			panic(fmt.Sprintf("no language for %s", file))
 		}
 		display := displayPath(file)

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -3,6 +3,7 @@ package analysis
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -253,5 +254,40 @@ func TestAnalyzeCpp(t *testing.T) {
 	stats := report.Clones.Statistics
 	if stats.TotalFragments != 3 || stats.TotalClonePairs != 1 || stats.ClonesByType["Type-2"] != 1 {
 		t.Errorf("statistics = %+v, want one Type-2 pair among three fragments", stats)
+	}
+}
+
+func TestAnalyzeSkipsDependencyAndBuildDirectories(t *testing.T) {
+	dir := t.TempDir()
+	sample, err := os.ReadFile("../../testdata/go/sample.go")
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, sub := range []string{"", ".git/hooks", ".cache", "node_modules/dep", "vendor/dep", "target/debug", "build", "dist", "third_party/lib", "pkg"} {
+		path := filepath.Join(dir, sub)
+		if err := os.MkdirAll(path, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(path, "sample.go"), sample, 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectFiles([]string{dir})
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{filepath.Join(dir, "pkg", "sample.go"), filepath.Join(dir, "sample.go")}
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("collected %v, want %v", files, want)
+	}
+
+	// A skipped name given explicitly is analyzed.
+	files, err = collectFiles([]string{filepath.Join(dir, "vendor")})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{filepath.Join(dir, "vendor", "dep", "sample.go")}; !reflect.DeepEqual(files, want) {
+		t.Errorf("collected %v, want %v", files, want)
 	}
 }

--- a/polyscan/internal/analysis/collect.go
+++ b/polyscan/internal/analysis/collect.go
@@ -1,0 +1,76 @@
+package analysis
+
+import (
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/lang"
+)
+
+// skippedDirs are the directories a walk never descends into: version
+// control, dependencies and build output are not the code under review.
+// A path given on the command line is walked whatever its name.
+var skippedDirs = map[string]bool{
+	"node_modules": true,
+	"vendor":       true,
+	"target":       true,
+	"build":        true,
+	"dist":         true,
+	"third_party":  true,
+}
+
+// skipDir reports whether a directory met while walking is left out: the
+// named build and dependency directories, and every hidden one such as
+// .git or .cache.
+func skipDir(name string) bool {
+	return skippedDirs[name] || strings.HasPrefix(name, ".")
+}
+
+// collectFiles returns, sorted and without duplicates, the absolute paths
+// of the files of a supported language under paths. A path that is a file
+// is taken as given when its language is supported.
+func collectFiles(paths []string) ([]string, error) {
+	seen := map[string]bool{}
+	var files []string
+	add := func(path string) {
+		if _, ok := lang.ByPath(path); ok && !seen[path] {
+			seen[path] = true
+			files = append(files, path)
+		}
+	}
+	for _, p := range paths {
+		root, err := filepath.Abs(p)
+		if err != nil {
+			return nil, err
+		}
+		info, err := os.Stat(root)
+		if err != nil {
+			return nil, err
+		}
+		if !info.IsDir() {
+			add(root)
+			continue
+		}
+		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return err
+			}
+			if d.IsDir() {
+				if path != root && skipDir(d.Name()) {
+					return fs.SkipDir
+				}
+				return nil
+			}
+			add(path)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+	sort.Strings(files)
+	return files, nil
+}

--- a/polyscan/internal/lang/lang.go
+++ b/polyscan/internal/lang/lang.go
@@ -26,15 +26,3 @@ func ByPath(path string) (*engine.Language, bool) {
 	}
 	return nil, false
 }
-
-// IncludePatterns returns one glob per supported extension, for file
-// collection.
-func IncludePatterns() []string {
-	var patterns []string
-	for _, language := range All {
-		for _, ext := range language.Extensions {
-			patterns = append(patterns, "*"+ext)
-		}
-	}
-	return patterns
-}

--- a/website/docs/cli/analyze.md
+++ b/website/docs/cli/analyze.md
@@ -37,7 +37,7 @@ The configuration file for the JavaScript/TypeScript analysis is discovered auto
 
 The language of each file is detected from its extension. Complexity and clone detection cover every supported language. Dependency analysis covers Go and JavaScript/TypeScript. Dead code and coupling (CBO) exist for JavaScript/TypeScript only, and the health score is computed over the dimensions that ran: a dimension a language does not have is left out, not scored as clean.
 
-A file that cannot be read is skipped and listed under errors. A file with a syntax error is analyzed without the functions that contain it, counted as partial, and listed under warnings. C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
+For Go, Rust and C++, version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. JavaScript/TypeScript exclusions come from `jscan.config.json`. A file that cannot be read is skipped and listed under errors. A file with a syntax error is analyzed without the functions that contain it, counted as partial, and listed under warnings. C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
 ## Output behavior
 


### PR DESCRIPTION
The generic engine walked every directory under the target, so a Rust project's `target` directory, a Go project's `vendor` directory and even `.git` were analyzed as the project's own code.

Go, Rust and C++ collection now skips hidden directories and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is still analyzed whatever it is called. The unused `lang.IncludePatterns` is removed with the `core/source` collector call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr