### PR TITLE
docs: update root command description

### DIFF
--- a/polyscan/cmd/polyscan/main.go
+++ b/polyscan/cmd/polyscan/main.go
@@ -24,7 +24,10 @@ func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "polyscan",
 		Short:   "polyscan - multi-language static analyzer",
-		Long:    "polyscan is a static analyzer that measures code quality across languages.\nIt currently analyzes cyclomatic complexity and code clones for Go, Rust and C++.",
+		Long: "polyscan is a static analyzer that measures code quality across Go, Rust, C++, " +
+			"and JavaScript/TypeScript.\nIt analyzes cyclomatic complexity, code clones, " +
+			"dependencies, dead code, coupling (CBO), and cohesion (LCOM4), with availability " +
+			"depending on the language.",
 		Version: version.Version,
 	}
 	cmd.AddCommand(analyzeCmd())


### PR DESCRIPTION
## What

Update the root command description to include JavaScript/TypeScript and the full set of analyses currently supported by polyscan.

## Why

The existing `polyscan --help` text only mentions complexity and clone analysis for Go, Rust, and C++, so it no longer reflects the CLI's current capabilities.

## How

The description now lists all supported languages and explains that analysis availability depends on the language.

Closes #111

## Tests

- `git diff --check` passed
- Go tests were not run because the Go toolchain was unavailable in the development environment

This is a help-text-only change.