### PR TITLE
fix: gofmt the root command definition

### DIFF
--- a/polyscan/cmd/polyscan/main.go
+++ b/polyscan/cmd/polyscan/main.go
@@ -22,8 +22,8 @@ func main() {
 
 func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "polyscan",
-		Short:   "polyscan - multi-language static analyzer",
+		Use:   "polyscan",
+		Short: "polyscan - multi-language static analyzer",
 		Long: "polyscan is a static analyzer that measures code quality across Go, Rust, C++, " +
 			"and JavaScript/TypeScript.\nIt analyzes cyclomatic complexity, code clones, " +
 			"dependencies, dead code, coupling (CBO), and cohesion (LCOM4), with availability " +


### PR DESCRIPTION
`gofmt -l .` has failed on main since #116. The `Long` description of the root command became a multi-line expression, which changes the alignment gofmt gives the struct literal, and the padding of `Use` and `Short` was left as it was.

This blocks every open PR, including #109.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UxCt5uTUNzcASYoXg7BT54