### PR TITLE
fix(cli): suppress usage after runtime errors

### DIFF
--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -94,6 +94,27 @@ type analyzeJSON struct {
 	} `json:"summary"`
 }
 
+func TestRuntimeErrorDoesNotPrintUsage(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "missing")
+	out, err := run(t, "analyze", missing)
+	if err == nil {
+		t.Fatal("analyze returned nil error for a missing path")
+	}
+	if strings.Contains(out, "Usage:") {
+		t.Fatalf("runtime error printed usage:\n%s", out)
+	}
+}
+
+func TestInvalidAnalysisReturnsClearError(t *testing.T) {
+	_, err := run(t, "analyze", "--select", "foo", "../../testdata/go")
+	if err == nil {
+		t.Fatal("invalid analysis returned nil error")
+	}
+	if !strings.Contains(err.Error(), "foo") {
+		t.Fatalf("error %q does not identify the invalid analysis", err)
+	}
+}
+
 func TestAnalyzeText(t *testing.T) {
 	out, err := run(t, "analyze", "--format", "text", "../../testdata/go/sample.go")
 	if err != nil {

--- a/polyscan/cmd/polyscan/main.go
+++ b/polyscan/cmd/polyscan/main.go
@@ -22,8 +22,9 @@ func main() {
 
 func rootCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "polyscan",
-		Short: "polyscan - multi-language static analyzer",
+		Use:          "polyscan",
+		Short:        "polyscan - multi-language static analyzer",
+		SilenceUsage: true,
 		Long: "polyscan is a static analyzer that measures code quality across Go, Rust, C++, " +
 			"and JavaScript/TypeScript.\nIt analyzes cyclomatic complexity, code clones, " +
 			"dependencies, dead code, coupling (CBO), and cohesion (LCOM4), with availability " +


### PR DESCRIPTION
## Summary

- Enable Cobra's `SilenceUsage` setting on the root command
- Prevent runtime errors from printing the full usage guide
- Add regression tests for runtime and invalid-analysis errors

Closes #113