### PR TITLE
fix(polyscan): see a Go field behind a chained index in LCOM

### DIFF
--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -48,10 +48,14 @@ var Language = &engine.Language{
 	// discards a match whose @object is not the method's receiver. A chained
 	// index such as t.m[k][k] is ambiguous with a generic instantiation, and
 	// tree-sitter-go parses it as one, so the receiver and field arrive as a
-	// qualified type.
+	// qualified type; only that expression is matched, since a qualified
+	// type in a signature or declaration names a package, not the receiver.
 	Members: `
 (selector_expression operand: (identifier) @object field: (field_identifier) @field)
-(qualified_type package: (package_identifier) @object name: (type_identifier) @field)
+(type_instantiation_expression type: [
+  (generic_type type: (qualified_type package: (package_identifier) @object name: (type_identifier) @field))
+  (parenthesized_type (generic_type type: (qualified_type package: (package_identifier) @object name: (type_identifier) @field)))
+])
 (call_expression function: (selector_expression operand: (identifier) @object field: (field_identifier) @call))
 `,
 	// A local declaration hides the receiver from its end to the end of

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -45,9 +45,13 @@ var Language = &engine.Language{
 	// A field is anything selected from the receiver variable, so a promoted
 	// method of an embedded type counts as the embedded field it comes
 	// through; a sibling method is a call through the receiver. The engine
-	// discards a match whose @object is not the method's receiver.
+	// discards a match whose @object is not the method's receiver. A chained
+	// index such as t.m[k][k] is ambiguous with a generic instantiation, and
+	// tree-sitter-go parses it as one, so the receiver and field arrive as a
+	// qualified type.
 	Members: `
 (selector_expression operand: (identifier) @object field: (field_identifier) @field)
+(qualified_type package: (package_identifier) @object name: (type_identifier) @field)
 (call_expression function: (selector_expression operand: (identifier) @object field: (field_identifier) @call))
 `,
 	// A local declaration hides the receiver from its end to the end of

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -236,6 +236,7 @@ func (t *T) Fields() {
 	other.x = 3
 	go func() { t.a++ }()
 	t.m[i][j] = t.m[j][i][i]
+	_ = (t.m[i])[j]
 	other.m[i][j] = 3
 }
 
@@ -296,6 +297,24 @@ func equalStrings(got, want []string) bool {
 		}
 	}
 	return true
+}
+
+func TestMembersIgnoreTypesNamedLikeReceiver(t *testing.T) {
+	functions := analyze(t, `package p
+
+import "context"
+
+type T struct{ a int }
+
+func (context *T) A(ctx context.Context) context.Context {
+	var c context.Context
+	context.a++
+	return c
+}
+`)
+	if got := slices.Sorted(maps.Keys(functions["T.A"].Fields)); !equalStrings(got, []string{"a"}) {
+		t.Errorf("T.A: fields = %v, want [a]", got)
+	}
 }
 
 func TestMembersIgnoreShadowedReceiver(t *testing.T) {

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -227,6 +227,7 @@ type T struct {
 	Base
 	a, b int
 	cb   func()
+	m    map[int]map[int]int
 }
 
 func (t *T) Fields() {
@@ -234,6 +235,8 @@ func (t *T) Fields() {
 	t.b.c = 2
 	other.x = 3
 	go func() { t.a++ }()
+	t.m[i][j] = t.m[j][i][i]
+	other.m[i][j] = 3
 }
 
 func (t *T) Calls() {
@@ -259,7 +262,7 @@ func Free() {}
 		calls    []string
 	}{
 		{"Base.Promoted", "Base", false, nil, nil},
-		{"T.Fields", "T", true, []string{"a", "b"}, []string{}},
+		{"T.Fields", "T", true, []string{"a", "b", "m"}, []string{}},
 		{"T.Calls", "T", true, []string{"Base"}, []string{"Fields", "Promoted", "cb"}},
 		{"T.Static", "T", false, nil, nil},
 		{"T.Blank", "T", false, nil, nil},


### PR DESCRIPTION
tree-sitter-go resolves `t.m[k][k]` as a type instantiation, so the receiver and field arrive as a `qualified_type` and the Go `Members` query did not capture them. Methods linked only by such an access ended up in separate LCOM components.

Adds a `qualified_type` alternative to the query and covers the shape in `TestMembers`. The issue's repro now reports `lcom4: 1` with one group of three methods.

Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr