### PR TITLE
fix(deps): preserve package classification in module metrics

### DIFF
--- a/polyscan/internal/js/analyzer/coupling_metrics.go
+++ b/polyscan/internal/js/analyzer/coupling_metrics.go
@@ -89,6 +89,7 @@ func (c *CouplingMetricsCalculator) CalculateMetrics(graph *domain.DependencyGra
 		metrics[nodeID] = &domain.ModuleDependencyMetrics{
 			ModuleName:             node.Name,
 			FilePath:               node.FilePath,
+			IsPackage:              node.ModuleType == domain.ModuleTypePackage,
 			AfferentCoupling:       m.Ca,
 			EfferentCoupling:       m.Ce,
 			Instability:            m.Instability,

--- a/polyscan/internal/js/analyzer/coupling_metrics_test.go
+++ b/polyscan/internal/js/analyzer/coupling_metrics_test.go
@@ -392,3 +392,33 @@ func TestExportAbstractness(t *testing.T) {
 		}
 	}
 }
+
+func TestCalculateMetricsPreservesPackageClassification(t *testing.T) {
+	cases := []struct {
+		name       string
+		moduleType domain.ModuleType
+		want       bool
+	}{
+		{"package", domain.ModuleTypePackage, true},
+		{"relative", domain.ModuleTypeRelative, false},
+		{"builtin", domain.ModuleTypeBuiltin, false},
+		{"alias", domain.ModuleTypeAlias, false},
+		{"unspecified", "", false},
+	}
+	graph := domain.NewDependencyGraph()
+	for _, tc := range cases {
+		graph.AddNode(&domain.ModuleNode{ID: tc.name, ModuleType: tc.moduleType})
+	}
+	metrics := NewCouplingMetricsCalculator(nil).CalculateMetrics(graph)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			metric, ok := metrics[tc.name]
+			if !ok {
+				t.Fatal("missing module metrics")
+			}
+			if metric.IsPackage != tc.want {
+				t.Errorf("IsPackage = %v, want %v for module type %q", metric.IsPackage, tc.want, tc.moduleType)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Go dependency graph nodes identify packages correctly, but their ModuleMetrics always reported IsPackage=false. Copy the node's package classification into the metrics record so consumers filtering JSON reports receive the matching packages.

Closes #122.

Validation:
- New table-driven regression failed for package nodes before the fix; covers package, relative, builtin, alias, and unspecified classifications.
- go test ./... -count=1 and go vet ./... pass in both polyscan/ and core/ using Go 1.26.8 on macOS arm64.
- Actual CLI JSON output for the issue's two-package Go fixture reports IsPackage=true for both graph packages. Also checked the existing three-package Go fixture.
- gofmt and git diff --check pass.

Only the metrics assignment and its regression test changed. AI-assisted implementation and testing.