### PR TITLE
fix(cli): honor output paths for JSON and text reports

### DIFF
--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -117,9 +117,15 @@ Examples:
 				fmt.Fprint(w, service.FormatCLISummary(summary, duration, results.Files.Errors))
 			}
 
+			writeOutput := func() error {
+				if outputPath != "" {
+					return writeReportFile(outputPath, outputFormat, write)
+				}
+				return write(cmd.OutOrStdout(), outputFormat)
+			}
 			switch outputFormat {
 			case jsdomain.OutputFormatJSON:
-				if err := write(cmd.OutOrStdout(), outputFormat); err != nil {
+				if err := writeOutput(); err != nil {
 					return err
 				}
 				// The summary goes to stderr so it cannot pollute the
@@ -128,13 +134,13 @@ Examples:
 				return nil
 			case jsdomain.OutputFormatText:
 				// The text report carries its own health score section.
-				return write(cmd.OutOrStdout(), outputFormat)
+				return writeOutput()
 			}
 
 			if outputPath == "" {
 				outputPath = defaultReportPath
 			}
-			if err := writeReportFile(outputPath, write); err != nil {
+			if err := writeReportFile(outputPath, outputFormat, write); err != nil {
 				return err
 			}
 			absPath, err := filepath.Abs(outputPath)
@@ -158,7 +164,7 @@ Examples:
 			"deps applies to Go and JavaScript/TypeScript; cbo to Go, Rust and\n"+
 			"JavaScript/TypeScript; lcom to Go and Rust; deadcode to JavaScript/TypeScript only")
 	cmd.Flags().StringVarP(&format, "format", "f", "html", "Output format: html, json, text")
-	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "HTML report path (default: "+defaultReportPath+")")
+	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Report path (HTML default: "+defaultReportPath+"; JSON/text default: stdout)")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
 	cmd.Flags().IntVar(&minComplexity, "min-complexity", 1, "List only functions with at least this complexity")
 	return cmd
@@ -239,12 +245,12 @@ func fileURL(absPath string) string {
 	return (&url.URL{Scheme: "file", Path: path}).String()
 }
 
-func writeReportFile(path string, write func(io.Writer, jsdomain.OutputFormat) error) error {
+func writeReportFile(path string, format jsdomain.OutputFormat, write func(io.Writer, jsdomain.OutputFormat) error) error {
 	file, err := os.Create(path)
 	if err != nil {
-		return fmt.Errorf("create HTML report: %w", err)
+		return fmt.Errorf("create %s report: %w", format, err)
 	}
-	if err := write(file, jsdomain.OutputFormatHTML); err != nil {
+	if err := write(file, format); err != nil {
 		file.Close()
 		return err
 	}

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -527,3 +527,60 @@ func TestAnalyzeCoupling(t *testing.T) {
 		}
 	}
 }
+
+func TestAnalyzeOutputPath(t *testing.T) {
+	for _, format := range []string{"json", "text"} {
+		t.Run(format, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "report."+format)
+			if err := os.WriteFile(path, bytes.Repeat([]byte("stale"), 10000), 0600); err != nil {
+				t.Fatal(err)
+			}
+			cmd := rootCmd()
+			var stdout, stderr bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&stderr)
+			cmd.SetArgs([]string{"analyze", "--select", "complexity", "--format", format, "--output", path, "../../testdata/go/sample.go"})
+			if err := cmd.Execute(); err != nil {
+				t.Fatal(err)
+			}
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if stdout.Len() != 0 {
+				t.Errorf("report leaked to stdout: %s", stdout.String())
+			}
+			if bytes.Contains(data, []byte("stale")) {
+				t.Fatal("output retained stale file contents")
+			}
+			if format == "json" {
+				var doc analyzeJSON
+				if err := json.Unmarshal(data, &doc); err != nil {
+					t.Fatal(err)
+				}
+				if doc.Complexity == nil || doc.Summary == nil {
+					t.Fatal("missing analysis or summary")
+				}
+				if !strings.Contains(stderr.String(), "Health Score:") {
+					t.Error("missing stderr summary")
+				}
+			} else if !bytes.Contains(data, []byte("polyscan Analysis Report")) || !bytes.Contains(data, []byte("Server.Handle: 8")) {
+				t.Errorf("missing text report: %s", data)
+			}
+		})
+	}
+}
+
+func TestAnalyzeOutputPathError(t *testing.T) {
+	for _, format := range []string{"json", "text", "html"} {
+		t.Run(format, func(t *testing.T) {
+			out, err := run(t, "analyze", "--select", "complexity", "--format", format, "--no-open", "--output", t.TempDir(), "../../testdata/go/sample.go")
+			if err == nil {
+				t.Fatal("directory output path returned no error")
+			}
+			if strings.Contains(out, "Health Score:") {
+				t.Errorf("reported success after write failure: %s", out)
+			}
+		})
+	}
+}


### PR DESCRIPTION
JSON and text reports ignored --output and always wrote to stdout. Honor the requested path for both formats, while preserving stdout when no path is supplied and keeping the JSON summary on stderr. Update the flag help to describe each default.

Closes #112.

Validation:
- Four new regression cases failed before the fix (JSON/text file output and file-creation errors); command suite passes after the fix, including existing stdout and HTML tests.
- Tests verify truncation of existing output, valid JSON, expected text content, no stdout leakage, JSON summary on stderr, and directory-path errors for all three formats.
- Full go test ./... -count=1 and go vet ./... pass in polyscan/ using Go 1.26.8 on macOS arm64.
- Actual CLI invocation produced JSON with all six fixture functions in the requested file, empty stdout, and the summary on stderr.
- gofmt and git diff --check pass. Shared core is unchanged from the identical base verified for PR #124.

Only analyze.go and cmd_test.go changed. This branch is independent of #124. AI-assisted implementation and testing.