### PR TITLE
fix(polyscan): resolve NodeNext-style relative imports to their TypeScript sources

### DIFF
--- a/polyscan/internal/js/analyzer/dependency_graph.go
+++ b/polyscan/internal/js/analyzer/dependency_graph.go
@@ -249,28 +249,9 @@ func (b *DependencyGraphBuilder) resolveImportTarget(source string, sourceType d
 		resolved = filepath.Clean(resolved)
 		normalized := b.normalizeModuleID(resolved)
 
-		// If the normalized ID matches a known node, return it directly
-		if knownNodeIDs[normalized] {
-			return normalized
+		if target := resolveModuleCandidate(normalized, knownNodeIDs); target != "" {
+			return target
 		}
-
-		// Try appending common extensions
-		extensions := []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
-		for _, ext := range extensions {
-			candidate := normalized + ext
-			if knownNodeIDs[candidate] {
-				return candidate
-			}
-		}
-
-		// Try directory index files
-		for _, ext := range extensions {
-			candidate := normalized + "/index" + ext
-			if knownNodeIDs[candidate] {
-				return candidate
-			}
-		}
-
 		// No match found; return normalized as-is (will become external)
 		return normalized
 

--- a/polyscan/internal/js/analyzer/dependency_graph_test.go
+++ b/polyscan/internal/js/analyzer/dependency_graph_test.go
@@ -681,3 +681,42 @@ export const app = 1;
 		t.Error("Expected at least one node")
 	}
 }
+
+func TestResolveImportTargetWithEmittedExtension(t *testing.T) {
+	config := DefaultDependencyGraphBuilderConfig()
+	config.ProjectRoot = "/project"
+	builder := NewDependencyGraphBuilder(config)
+
+	knownNodeIDs := map[string]bool{
+		"src/a.ts":         true,
+		"src/b.tsx":        true,
+		"src/c.mts":        true,
+		"src/d.cts":        true,
+		"src/dir/index.ts": true,
+		"src/types.d.ts":   true,
+		"src/plain.js":     true,
+	}
+
+	testCases := []struct {
+		source   string
+		expected string
+	}{
+		{"./a.js", "src/a.ts"},
+		{"./b.jsx", "src/b.tsx"},
+		{"./c.mjs", "src/c.mts"},
+		{"./d.cjs", "src/d.cts"},
+		{"./dir/index.js", "src/dir/index.ts"},
+		{"./types.js", "src/types.d.ts"},
+		{"./plain.js", "src/plain.js"},
+		{"./missing.js", "src/missing.js"},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.source, func(t *testing.T) {
+			result := builder.resolveImportTarget(tc.source, domain.ModuleTypeRelative, "/project/src/index.ts", knownNodeIDs)
+			if result != tc.expected {
+				t.Errorf("resolveImportTarget(%q) = %q, expected %q", tc.source, result, tc.expected)
+			}
+		})
+	}
+}

--- a/polyscan/internal/js/analyzer/module_resolution.go
+++ b/polyscan/internal/js/analyzer/module_resolution.go
@@ -1,0 +1,52 @@
+package analyzer
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// sourceExtensions lists the file extensions a specifier without one may resolve to.
+var sourceExtensions = []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
+
+// emittedExtensionSources maps the extension of an emitted JavaScript file to the
+// TypeScript sources it is compiled from. Under Node16/NodeNext module resolution a
+// TypeScript file is imported by the name of its emitted output, so "./foo.js" refers
+// to foo.ts.
+var emittedExtensionSources = map[string][]string{
+	".js":  {".ts", ".tsx", ".d.ts"},
+	".jsx": {".tsx"},
+	".mjs": {".mts", ".d.mts"},
+	".cjs": {".cts", ".d.cts"},
+}
+
+// moduleCandidates lists the slash-separated paths a relative specifier resolved to
+// base may denote, in priority order: the path itself, its TypeScript sources when the path names an
+// emitted JavaScript file, the path with a source extension appended, then an index
+// file inside the path taken as a directory.
+func moduleCandidates(base string) []string {
+	candidates := []string{base}
+	if sources, ok := emittedExtensionSources[filepath.Ext(base)]; ok {
+		stem := strings.TrimSuffix(base, filepath.Ext(base))
+		for _, ext := range sources {
+			candidates = append(candidates, stem+ext)
+		}
+	}
+	for _, ext := range sourceExtensions {
+		candidates = append(candidates, base+ext)
+	}
+	for _, ext := range sourceExtensions {
+		candidates = append(candidates, base+"/index"+ext)
+	}
+	return candidates
+}
+
+// resolveModuleCandidate returns the first candidate for base that is a known module,
+// or "" when none is.
+func resolveModuleCandidate(base string, known map[string]bool) string {
+	for _, candidate := range moduleCandidates(base) {
+		if known[candidate] {
+			return candidate
+		}
+	}
+	return ""
+}

--- a/polyscan/internal/js/analyzer/unused_code.go
+++ b/polyscan/internal/js/analyzer/unused_code.go
@@ -317,7 +317,8 @@ func getExportedNames(exp *domain.Export) []string {
 }
 
 // resolveImportPath resolves a relative import source to an actual file path.
-// It tries the raw path, then common extensions, then index files.
+// It tries the raw path, the TypeScript sources behind an emitted JavaScript name,
+// common extensions, then index files.
 func resolveImportPath(importingFile, source string, knownFiles map[string]bool) string {
 	// Only handle relative imports
 	if !strings.HasPrefix(source, "./") && !strings.HasPrefix(source, "../") {
@@ -328,32 +329,12 @@ func resolveImportPath(importingFile, source string, knownFiles map[string]bool)
 	resolved := filepath.Join(dir, source)
 	resolved = filepath.Clean(resolved)
 
-	// Try exact path first
-	if knownFiles[resolved] {
-		return resolved
-	}
-
-	// Try adding extensions
-	extensions := []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
-	for _, ext := range extensions {
-		candidate := resolved + ext
+	for _, candidate := range moduleCandidates(filepath.ToSlash(resolved)) {
+		candidate = filepath.FromSlash(candidate)
 		if knownFiles[candidate] {
 			return candidate
 		}
 	}
-
-	// Try as directory with index files
-	indexFiles := []string{
-		"index.ts", "index.tsx", "index.js", "index.jsx",
-		"index.mts", "index.cts", "index.mjs", "index.cjs",
-	}
-	for _, idx := range indexFiles {
-		candidate := filepath.Join(resolved, idx)
-		if knownFiles[candidate] {
-			return candidate
-		}
-	}
-
 	return ""
 }
 
@@ -640,7 +621,6 @@ func resolveAliasImportPaths(source string, idx *suffixIndex) []string {
 		candidateBases[source[2:]] = true
 	}
 
-	extensions := []string{".ts", ".tsx", ".js", ".jsx", ".mts", ".cts", ".mjs", ".cjs"}
 	matches := make(map[string]bool)
 
 	for base := range candidateBases {
@@ -650,14 +630,7 @@ func resolveAliasImportPaths(source string, idx *suffixIndex) []string {
 			continue
 		}
 
-		candidates := []string{base}
-		for _, ext := range extensions {
-			candidates = append(candidates, base+ext)
-			candidates = append(candidates, filepath.ToSlash(filepath.Join(base, "index"+ext)))
-		}
-
-		for _, c := range candidates {
-			c = filepath.ToSlash(c)
+		for _, c := range moduleCandidates(filepath.ToSlash(base)) {
 			if files, ok := idx.bySuffix[c]; ok {
 				for _, f := range files {
 					matches[f] = true

--- a/polyscan/internal/js/analyzer/unused_code_test.go
+++ b/polyscan/internal/js/analyzer/unused_code_test.go
@@ -462,6 +462,25 @@ func TestResolveImportPath_IndexFile(t *testing.T) {
 	}
 }
 
+func TestResolveImportPath_EmittedExtension(t *testing.T) {
+	knownFiles := map[string]bool{
+		"/src/utils.ts":      true,
+		"/src/widget.tsx":    true,
+		"/src/lib/index.mts": true,
+	}
+
+	cases := map[string]string{
+		"./utils.js":      "/src/utils.ts",
+		"./widget.jsx":    "/src/widget.tsx",
+		"./lib/index.mjs": "/src/lib/index.mts",
+	}
+	for source, expected := range cases {
+		if resolved := resolveImportPath("/src/app.ts", source, knownFiles); resolved != expected {
+			t.Errorf("resolveImportPath(%q) = %q, expected %q", source, resolved, expected)
+		}
+	}
+}
+
 func TestResolveImportPath_ParentDirectory(t *testing.T) {
 	knownFiles := map[string]bool{
 		"/src/utils.js": true,


### PR DESCRIPTION
Fixes #126.

Under `Node16`/`NodeNext` module resolution a TypeScript file is imported by the name of its emitted output, so `./foo.js` refers to `foo.ts`. None of the JS resolvers tried that rewrite, so the specifier became a phantom external node, the real file lost its in-edge (and became an entry point), and its exports were reported as `unused_exported_function`.

- Adds `moduleCandidates` as the single candidate list shared by the dependency graph, dead-code and alias resolvers (they each had their own copy of the extension list).
- Tries `.ts`/`.tsx`/`.d.ts` for `.js`, `.tsx` for `.jsx`, `.mts`/`.d.mts` for `.mjs`, `.cts`/`.d.cts` for `.cjs`, ahead of the appended-extension and index-file candidates. An existing `.js` file still wins.

Verified with the reproduction from the issue: zero findings, all four edges point at the real files.