### PR TITLE
feat(polyscan): add --exclude and leave test files out of every analysis by default

### DIFF
--- a/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
+++ b/polyscan/.claude-plugin/polyscan/skills/cli-analysis/SKILL.md
@@ -28,6 +28,8 @@ Key flags:
 - `--no-open`: don't auto-open the HTML report in a browser (use in scripts)
 - `-o <path>`: HTML report path (default: `polyscan-report.html` in the current directory)
 - `--min-complexity <n>`: hide functions below this complexity from the listing (scores still cover everything)
+- `--exclude <patterns>`: leave files and directories out of every analysis; a glob without a slash matches a file name or a directory anywhere on the path (`fixtures`), one with a slash matches a path relative to the analyzed directory with `**` for any number of segments (`src/generated/**`)
+- `--include-tests`: analyze test files and test code, which are left out by default (`*_test.go`, `*.test.*`, `*.spec.*`, `__tests__/`, Rust `#[cfg(test)]` and `tests/`, C++ `*_test.*` and `test/`)
 
 With `--format json`, the machine-readable results go to stdout and the health-score summary goes to stderr, so stdout stays parseable.
 

--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `polyscan analyze --exclude` leaves files and directories out of every analysis, for every language. A pattern without a slash is a glob matched against the file name and against each directory on the path (`fixtures`); a pattern with a slash is matched against the path relative to the analyzed directory, with `**` for any number of segments (`src/generated/**`). The patterns follow the rules of `exclude_patterns` in `jscan.config.json`, and for JavaScript/TypeScript they are added to that file's own exclude patterns
+
+### Changed
+
+- Test files and test code are left out of every analysis by default, where before they were analyzed for complexity and, for JavaScript/TypeScript, for everything. Go `*_test.go`; Rust `#[test]` functions, `#[cfg(test)]` items, `tests.rs`, `*_tests.rs` and `tests/`; C++ `*_test.*`, `*_tests.*`, `test_*.*`, `*Test.*`, `test/` and `tests/`; JavaScript/TypeScript `*.test.*`, `*.spec.*` and `__tests__/`. `--include-tests` restores the previous behavior, with test code still out of clone detection, cohesion, coupling and dependency analysis
+
 ## [0.3.2] - 2026-09-10
 
 ### Changed

--- a/polyscan/README.md
+++ b/polyscan/README.md
@@ -32,11 +32,19 @@ polyscan analyze --select clone .
 
 # List only functions with complexity 10 or higher; the summary still covers every function
 polyscan analyze --min-complexity 10 .
+
+# Leave a generated directory out of every analysis
+polyscan analyze --exclude 'src/generated/**' .
+
+# Analyze test files and test code too; they are left out by default
+polyscan analyze --include-tests .
 ```
 
 `--select` takes any of `complexity`, `deadcode`, `clone`, `cbo`, `lcom` and `deps` (default: all); `deps` exists for Go and JavaScript/TypeScript, `cbo` for Go, Rust and JavaScript/TypeScript, `lcom` for Go and Rust, `deadcode` for JavaScript/TypeScript only, and a deselected or missing dimension is left out of the health score. JavaScript/TypeScript honors a `jscan.config.json` when the project has one. The JSON output is one document for every language, with `language` on every function and clone fragment.
 
-Version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
+Version control, dependency and build output directories are not walked: any directory whose name starts with a dot, and `node_modules`, `vendor`, `target`, `build`, `dist` and `third_party`. A path named on the command line is analyzed whatever it is called. `--exclude` leaves out further files and directories, for every language and every analysis: a pattern without a slash is a glob matched against the file name and against each directory on the path, so `fixtures` drops every `fixtures` directory; a pattern with a slash is matched against the path relative to the analyzed directory, with `**` standing for any number of segments, so `src/generated/**` drops that tree. The flag takes a comma-separated list or may be repeated, and for JavaScript/TypeScript its patterns are added to the `exclude_patterns` of `jscan.config.json`.
+
+Test files and test code are left out of every analysis unless `--include-tests` is given. For Go that is `*_test.go`; for C++ it is `*_test.*`, `*_tests.*`, `test_*.*` and `*Test.*` source files and any `test` or `tests` directory; for Rust it is `#[test]` functions, items under `#[cfg(test)]` or `#[cfg(all(test, ...))]`, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests; for JavaScript/TypeScript it is `*.test.*` and `*.spec.*` files and any `__tests__` directory. With `--include-tests` the test code is analyzed for complexity and dead code, but it still stays out of clone detection, cohesion, coupling and dependency analysis: test functions share a skeleton by convention, and a test's types and imports describe the tests, not the package. A file that cannot be read is skipped and listed under `Errors`. A file with a syntax error is analyzed without the functions that contain the error, counted as partial, and listed under `Warnings`; C++ libraries hit this routinely, because a macro that opens a namespace or declares an attribute is a syntax error without the preprocessor.
 
 ## Complexity
 
@@ -81,7 +89,7 @@ Every function of at least 10 lines of code (blank lines and comments excluded) 
 | Type-2 | Same structure with renamed identifiers or changed literals | Similarity ≥ 0.80 and matching normalized trees |
 | Type-3 | Near copy with statements added, removed or changed | Similarity ≥ 0.80 |
 
-Pairs below 0.80 are not reported. Test code is analyzed for complexity but excluded from clone detection: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs. For Go that is `*_test.go`; for C++ it is `*_test.*`, `*_tests.*`, `test_*.*` and `*Test.*` source files and any `test` or `tests` directory; for Rust it is `#[test]` functions, items under `#[cfg(test)]` or `#[cfg(all(test, ...))]`, `tests.rs` and `*_tests.rs` files and any `tests` directory, the conventional homes of a test module split into its own file and of Cargo's integration tests.
+Pairs below 0.80 are not reported. Test code stays out of clone detection even under `--include-tests`: test functions share a skeleton by convention, and on this repository they made up 92% of the pairs.
 
 C++ files are parsed one at a time without the preprocessor. Every branch of an `#if` is analyzed, macros are not expanded, and code whose syntax only makes sense after expansion is a syntax error: the file is reported as partial and the functions containing the error are left out. Heavily templated code is parsed on a best-effort basis. Header files, `.h` included, are analyzed as C++.
 
@@ -96,7 +104,7 @@ A language is declarative: a tree-sitter grammar and two queries. See `internal/
 - The definitions query matches each function once. `@definition.<kind>` spans the function, `@name` its name, and an optional `@receiver` is prefixed to the name. The bundled `queries/tags.scm` of a grammar is the starting point.
 - In the decisions query every capture is one decision point, attributed to the innermost function that contains it and reported under the capture's name.
 - The optional scopes query names the scopes that enclose functions, such as classes, impl blocks and namespaces, so members read `Type::method`; a `@receiver` capture in the definitions query names a receiver declared on the function itself, as Go methods have.
-- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names test files by file name glob or, with a trailing slash, by directory, and `TestCode` is a query capturing test code inside a file; both are excluded from clone detection.
+- The clone spec lists the node types of identifiers, literals and structural patterns, the cost tiers of the tree edit distance, and pairs of related node types. `TestFiles` names test files by file name glob or, with a trailing slash, by directory, and `TestCode` is a query capturing test code inside a file; both are left out of the analysis by default and, when included, still stay out of clone detection.
 
 ## Development
 

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -92,9 +92,6 @@ Examples:
 				return err
 			}
 			options.IncludeTests = includeTests
-			if !includeTests {
-				exclude = append(exclude, js.TestFilePatterns...)
-			}
 
 			start := time.Now()
 			var generic *analysis.Report
@@ -106,7 +103,7 @@ Examples:
 			}
 			var javascript *js.Result
 			if selection != (js.Selection{}) {
-				javascript, err = analyzeJavaScript(args, selection, exclude, cmd.ErrOrStderr())
+				javascript, err = analyzeJavaScript(args, selection, exclude, includeTests, cmd.ErrOrStderr())
 				if err != nil {
 					return err
 				}
@@ -200,7 +197,7 @@ Examples:
 // A tree without JavaScript skips the pipeline before configuration
 // discovery, so a jscan configuration that would not load cannot fail the
 // other languages' analysis.
-func analyzeJavaScript(paths []string, selection js.Selection, exclude []string, warn io.Writer) (*js.Result, error) {
+func analyzeJavaScript(paths []string, selection js.Selection, exclude []string, includeTests bool, warn io.Writer) (*js.Result, error) {
 	hasJS, err := js.ContainsFiles(paths)
 	if err != nil {
 		return nil, err
@@ -213,7 +210,7 @@ func analyzeJavaScript(paths []string, selection js.Selection, exclude []string,
 		return nil, fmt.Errorf("failed to load the JavaScript configuration: %w", err)
 	}
 	cfg.Analysis.ExcludePatterns = append(cfg.Analysis.ExcludePatterns, exclude...)
-	files, err := js.CollectFiles(paths, cfg)
+	files, err := js.CollectFiles(paths, cfg, includeTests)
 	if err != nil {
 		return nil, err
 	}

--- a/polyscan/cmd/polyscan/analyze.go
+++ b/polyscan/cmd/polyscan/analyze.go
@@ -41,6 +41,8 @@ func analyzeCmd() *cobra.Command {
 		outputPath    string
 		noOpen        bool
 		minComplexity int
+		exclude       []string
+		includeTests  bool
 	)
 
 	cmd := &cobra.Command{
@@ -58,6 +60,11 @@ for JavaScript/TypeScript only. The health score is computed over the
 dimensions that ran: a dimension a language does not have is left out, not
 scored as clean.
 
+Test files and test code are left out of every analysis unless --include-tests
+is given: Go *_test.go; Rust #[test] functions, #[cfg(test)] items, tests.rs,
+*_tests.rs and tests/; C++ *_test.*, *_tests.*, test_*.*, *Test.*, test/ and
+tests/; JavaScript/TypeScript *.test.*, *.spec.* and __tests__/.
+
 By default, generates an HTML report and opens it in your browser.
 
 Examples:
@@ -66,7 +73,9 @@ Examples:
   polyscan analyze --format json src/       # JSON report to stdout
   polyscan analyze --format text src/       # Text report to stdout
   polyscan analyze --select clone .         # Clone detection only
-  polyscan analyze --min-complexity 10 .    # List only functions at or above 10`,
+  polyscan analyze --min-complexity 10 .    # List only functions at or above 10
+  polyscan analyze --exclude 'src/generated/**' .  # Leave a directory out of every analysis
+  polyscan analyze --include-tests .        # Analyze test files and test code too`,
 		Args: cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outputFormat := jsdomain.OutputFormat(format)
@@ -82,18 +91,22 @@ Examples:
 			if err != nil {
 				return err
 			}
+			options.IncludeTests = includeTests
+			if !includeTests {
+				exclude = append(exclude, js.TestFilePatterns...)
+			}
 
 			start := time.Now()
 			var generic *analysis.Report
 			if options != (analysis.Options{}) {
-				generic, err = analysis.Analyze(args, options)
+				generic, err = analysis.Analyze(args, options, exclude)
 				if err != nil && !errors.Is(err, analysis.ErrNoFiles) {
 					return err
 				}
 			}
 			var javascript *js.Result
 			if selection != (js.Selection{}) {
-				javascript, err = analyzeJavaScript(args, selection, cmd.ErrOrStderr())
+				javascript, err = analyzeJavaScript(args, selection, exclude, cmd.ErrOrStderr())
 				if err != nil {
 					return err
 				}
@@ -167,6 +180,12 @@ Examples:
 	cmd.Flags().StringVarP(&outputPath, "output", "o", "", "Report path (HTML default: "+defaultReportPath+"; JSON/text default: stdout)")
 	cmd.Flags().BoolVar(&noOpen, "no-open", false, "Don't open the HTML report in the browser")
 	cmd.Flags().IntVar(&minComplexity, "min-complexity", 1, "List only functions with at least this complexity")
+	cmd.Flags().StringSliceVar(&exclude, "exclude", nil,
+		"Files and directories to leave out (comma-separated or repeated): a glob\n"+
+			"without a slash matches a file name or a directory anywhere on the path,\n"+
+			"one with a slash matches a path relative to the analyzed directory, with\n"+
+			"** for any number of segments (e.g. 'fixtures', 'src/generated/**')")
+	cmd.Flags().BoolVar(&includeTests, "include-tests", false, "Analyze test files and test code, which are left out by default")
 	return cmd
 }
 
@@ -174,13 +193,14 @@ Examples:
 // TypeScript files under paths, or returns nil when there are none. The
 // files are collected with jscan's own configuration discovery and
 // exclusion rules, so a JavaScript project keeps exactly the analysis
-// jscan gave it. An analysis that fails is reported on warn and left out
-// of the report, as in jscan.
+// jscan gave it, with the command line's exclude patterns added to the
+// configuration's own. An analysis that fails is reported on warn and left
+// out of the report, as in jscan.
 //
 // A tree without JavaScript skips the pipeline before configuration
 // discovery, so a jscan configuration that would not load cannot fail the
 // other languages' analysis.
-func analyzeJavaScript(paths []string, selection js.Selection, warn io.Writer) (*js.Result, error) {
+func analyzeJavaScript(paths []string, selection js.Selection, exclude []string, warn io.Writer) (*js.Result, error) {
 	hasJS, err := js.ContainsFiles(paths)
 	if err != nil {
 		return nil, err
@@ -192,6 +212,7 @@ func analyzeJavaScript(paths []string, selection js.Selection, warn io.Writer) (
 	if err != nil {
 		return nil, fmt.Errorf("failed to load the JavaScript configuration: %w", err)
 	}
+	cfg.Analysis.ExcludePatterns = append(cfg.Analysis.ExcludePatterns, exclude...)
 	files, err := js.CollectFiles(paths, cfg)
 	if err != nil {
 		return nil, err

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -133,8 +133,8 @@ func TestAnalyzeJSON(t *testing.T) {
 		t.Fatalf("analyze: %v\n%s", err, out)
 	}
 	doc := decodeAnalyzeJSON(t, out)
-	if len(doc.Complexity.Functions) != 3 || doc.Complexity.Summary.TotalFunctions != 10 {
-		t.Errorf("listed %d functions of %d, want 3 of 10",
+	if len(doc.Complexity.Functions) != 2 || doc.Complexity.Summary.TotalFunctions != 9 {
+		t.Errorf("listed %d functions of %d, want 2 of 9",
 			len(doc.Complexity.Functions), doc.Complexity.Summary.TotalFunctions)
 	}
 	for _, fn := range doc.Complexity.Functions {
@@ -198,6 +198,70 @@ func TestAnalyzeSelect(t *testing.T) {
 	// category lines must not appear as clean results.
 	if strings.Contains(out, "Complexity: ") || !strings.Contains(out, "Code Duplication:") {
 		t.Errorf("category scores should list only the selected analyses:\n%s", out)
+	}
+}
+
+func TestAnalyzeExcludesTestsByDefault(t *testing.T) {
+	out, err := run(t, "analyze", "--format", "text", "--select", "complexity", "../../testdata/go/clones")
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "sum_test.go") || !strings.Contains(out, "sum.go") {
+		t.Errorf("test file analyzed by default:\n%s", out)
+	}
+	out, err = run(t, "analyze", "--format", "text", "--select", "complexity", "--include-tests", "../../testdata/go/clones")
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if !strings.Contains(out, "sum_test.go") {
+		t.Errorf("--include-tests should analyze the test file:\n%s", out)
+	}
+
+	// JavaScript follows the same conventions as its dead code analysis.
+	dir := t.TempDir()
+	for _, name := range []string{"app.ts", "app.test.ts", "app.spec.ts", "__tests__/helper.ts"} {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("export function f(a: number) { return a > 0 ? a : -a }\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	for _, tc := range []struct {
+		args []string
+		want int
+	}{
+		{nil, 1},
+		{[]string{"--include-tests"}, 4},
+	} {
+		out, err := run(t, append([]string{"analyze", "--format", "json", "--select", "complexity"}, append(tc.args, dir)...)...)
+		if err != nil {
+			t.Fatalf("analyze %v: %v\n%s", tc.args, err, out)
+		}
+		report := decodeAnalyzeJSON(t, out)
+		if got := len(report.Complexity.Functions); got != tc.want {
+			t.Errorf("%v: %d functions analyzed, want %d\n%s", tc.args, got, tc.want, out)
+		}
+	}
+}
+
+func TestAnalyzeExclude(t *testing.T) {
+	out, err := run(t, "analyze", "--format", "text", "--select", "complexity", "--exclude", "other", "../../testdata/go/clones")
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if strings.Contains(out, "other/") || !strings.Contains(out, "sum.go") {
+		t.Errorf("excluded directory still analyzed:\n%s", out)
+	}
+	if _, err := run(t, "analyze", "--format", "text", "--exclude", "*.go", "../../testdata/go/clones"); err == nil {
+		t.Error("excluding every file should report that there are none")
+	}
+
+	// JavaScript honors the same flag on top of jscan's configuration.
+	out, err = run(t, "analyze", "--format", "text", "--select", "complexity", "--exclude", "simple", "../../testdata/javascript")
+	if err == nil {
+		t.Errorf("excluding the only JavaScript directory should report no files:\n%s", out)
 	}
 }
 

--- a/polyscan/cmd/polyscan/cmd_test.go
+++ b/polyscan/cmd/polyscan/cmd_test.go
@@ -235,7 +235,7 @@ func TestAnalyzeExcludesTestsByDefault(t *testing.T) {
 		{nil, 1},
 		{[]string{"--include-tests"}, 4},
 	} {
-		out, err := run(t, append([]string{"analyze", "--format", "json", "--select", "complexity"}, append(tc.args, dir)...)...)
+		out, err := run(t, append([]string{"analyze", "--format", "json", "--select", "complexity,deps"}, append(tc.args, dir)...)...)
 		if err != nil {
 			t.Fatalf("analyze %v: %v\n%s", tc.args, err, out)
 		}
@@ -243,6 +243,31 @@ func TestAnalyzeExcludesTestsByDefault(t *testing.T) {
 		if got := len(report.Complexity.Functions); got != tc.want {
 			t.Errorf("%v: %d functions analyzed, want %d\n%s", tc.args, got, tc.want, out)
 		}
+		// Test files count for complexity only; the dependency graph
+		// describes the modules under test.
+		if report.Deps == nil || report.Deps.Analysis.TotalModules != 1 {
+			t.Errorf("%v: deps = %+v, want the one source module", tc.args, report.Deps)
+		}
+	}
+	// A single analysis over test files alone has no module to analyze.
+	out, err = run(t, "analyze", "--format", "json", "--select", "deps", "--include-tests", filepath.Join(dir, "app.test.ts"))
+	if err != nil {
+		t.Fatalf("analyze: %v\n%s", err, out)
+	}
+	if report := decodeAnalyzeJSON(t, out); report.Deps != nil && report.Deps.Analysis.TotalModules != 0 {
+		t.Errorf("deps = %+v, want no modules", report.Deps)
+	}
+
+	// The JavaScript conventions do not reach the other languages.
+	goDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(goDir, "__tests__"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(goDir, "__tests__", "main.go"), []byte("package main\n\nfunc main() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := run(t, "analyze", "--format", "text", "--select", "complexity", goDir); err != nil || !strings.Contains(out, "main") {
+		t.Errorf("__tests__/main.go should be analyzed as Go: %v\n%s", err, out)
 	}
 }
 

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -32,6 +32,12 @@ type Options struct {
 	// CBO counts, for each type, the other types of the tree it refers to,
 	// for the languages whose definition declares types and references.
 	CBO bool
+	// IncludeTests keeps test files and test code in the analysis. By
+	// default both are left out: the files a language names as test files
+	// are not collected, and the functions its test-code query captures are
+	// dropped from the complexity report as they are from every other
+	// analysis.
+	IncludeTests bool
 }
 
 // Function is the complexity result for one function.
@@ -122,8 +128,8 @@ var ErrNoFiles = errors.New("no supported source files found")
 // parse-error penalty, is the same for every selection; the dependency
 // analysis reads its files again and reports the ones it leaves out in
 // Warnings.
-func Analyze(paths []string, options Options) (*Report, error) {
-	files, err := collectFiles(paths)
+func Analyze(paths []string, options Options, exclude []string) (*Report, error) {
+	files, err := collectFiles(paths, exclude, options.IncludeTests)
 	if err != nil {
 		return nil, err
 	}
@@ -167,6 +173,9 @@ func Analyze(paths []string, options Options) (*Report, error) {
 			report.Warnings = append(report.Warnings, fmt.Sprintf("%s: %v; functions containing it were not analyzed", display, result.SyntaxError))
 		}
 		functions := result.Functions
+		if !options.IncludeTests {
+			functions = withoutTests(functions)
+		}
 
 		if options.Complexity {
 			for _, fn := range functions {
@@ -221,6 +230,17 @@ func Analyze(paths []string, options Options) (*Report, error) {
 		report.Coupling = coupling.build()
 	}
 	return report, nil
+}
+
+// withoutTests returns the functions that do not lie in test code.
+func withoutTests(functions []engine.Function) []engine.Function {
+	kept := functions[:0:0]
+	for _, fn := range functions {
+		if !fn.IsTest {
+			kept = append(kept, fn)
+		}
+	}
+	return kept
 }
 
 // analyzeDeps builds the dependency graph of the Go files among files. Test

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -35,7 +35,7 @@ func fixtures(t *testing.T) string {
 }
 
 func TestAnalyzeComplexity(t *testing.T) {
-	report, err := Analyze([]string{fixtures(t)}, Options{Complexity: true})
+	report, err := Analyze([]string{fixtures(t)}, Options{Complexity: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestAnalyzeComplexity(t *testing.T) {
 }
 
 func TestAnalyzeClones(t *testing.T) {
-	report, err := Analyze([]string{"../../testdata/go/clones"}, Options{Clones: true})
+	report, err := Analyze([]string{"../../testdata/go/clones"}, Options{Clones: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -115,7 +115,7 @@ func TestAnalyzeClones(t *testing.T) {
 }
 
 func TestAnalyzeWithoutSupportedFiles(t *testing.T) {
-	if _, err := Analyze([]string{t.TempDir()}, Options{Complexity: true}); err == nil || !strings.Contains(err.Error(), "no supported source files") {
+	if _, err := Analyze([]string{t.TempDir()}, Options{Complexity: true}, nil); err == nil || !strings.Contains(err.Error(), "no supported source files") {
 		t.Errorf("err = %v, want no supported source files", err)
 	}
 }
@@ -134,7 +134,7 @@ func TestRiskLevel(t *testing.T) {
 }
 
 func TestAnalyzeRust(t *testing.T) {
-	report, err := Analyze([]string{"../../testdata/rust"}, Options{Complexity: true, Clones: true})
+	report, err := Analyze([]string{"../../testdata/rust"}, Options{Complexity: true, Clones: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -146,12 +146,11 @@ func TestAnalyzeRust(t *testing.T) {
 	if fn := byName["Server::handle"]; fn.Complexity != 8 || fn.Language != "Rust" {
 		t.Errorf("Server::handle = %+v, want complexity 8 in Rust", fn)
 	}
-	if _, ok := byName["tests::sums_positive_values"]; !ok {
-		t.Error("test functions must still be analyzed for complexity")
+	if _, ok := byName["tests::sums_positive_values"]; ok {
+		t.Error("test functions are left out by default")
 	}
-
-	if _, ok := byName["roundtrip"]; !ok {
-		t.Error("functions in tests.rs must still be analyzed for complexity")
+	if _, ok := byName["roundtrip"]; ok {
+		t.Error("functions in tests.rs are left out by default")
 	}
 
 	// sums_positive_values is a copy of sum_positive but lies in #[cfg(test)],
@@ -163,7 +162,7 @@ func TestAnalyzeRust(t *testing.T) {
 }
 
 func TestAnalyzeMergesLanguages(t *testing.T) {
-	report, err := Analyze([]string{"../../testdata/go/clones", "../../testdata/rust"}, Options{Clones: true})
+	report, err := Analyze([]string{"../../testdata/go/clones", "../../testdata/rust"}, Options{Clones: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -236,7 +235,7 @@ func TestRankOrdersGroupsLikeCore(t *testing.T) {
 }
 
 func TestAnalyzeCpp(t *testing.T) {
-	report, err := Analyze([]string{"../../testdata/cpp"}, Options{Complexity: true, Clones: true})
+	report, err := Analyze([]string{"../../testdata/cpp"}, Options{Complexity: true, Clones: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -247,8 +246,8 @@ func TestAnalyzeCpp(t *testing.T) {
 	if fn := byName["Server::handle"]; fn.Complexity != 9 || fn.Language != "C++" {
 		t.Errorf("Server::handle = %+v, want complexity 9 in C++", fn)
 	}
-	if _, ok := byName["sumPositiveAgain"]; !ok {
-		t.Error("functions in test files must still be analyzed for complexity")
+	if _, ok := byName["sumPositiveAgain"]; ok {
+		t.Error("functions in test files are left out by default")
 	}
 	// sumPositiveAgain is a copy of sumPositive but lies in sample_test.cpp.
 	stats := report.Clones.Statistics
@@ -273,7 +272,7 @@ func TestAnalyzeSkipsDependencyAndBuildDirectories(t *testing.T) {
 		}
 	}
 
-	files, err := collectFiles([]string{dir})
+	files, err := collectFiles([]string{dir}, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -283,11 +282,53 @@ func TestAnalyzeSkipsDependencyAndBuildDirectories(t *testing.T) {
 	}
 
 	// A skipped name given explicitly is analyzed.
-	files, err = collectFiles([]string{filepath.Join(dir, "vendor")})
+	files, err = collectFiles([]string{filepath.Join(dir, "vendor")}, nil, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if want := []string{filepath.Join(dir, "vendor", "dep", "sample.go")}; !reflect.DeepEqual(files, want) {
+		t.Errorf("collected %v, want %v", files, want)
+	}
+}
+
+func TestCollectFilesExclude(t *testing.T) {
+	dir := t.TempDir()
+	for _, name := range []string{"sum.go", "sum_test.go", "pkg/sum.go", "pkg/sum_test.go", "pkg/testdata/fixture.go", "gen/api/client.go"} {
+		path := filepath.Join(dir, name)
+		if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(path, []byte("package p\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	files, err := collectFiles([]string{dir}, []string{"testdata", "gen/api/**"}, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := []string{filepath.Join(dir, "pkg", "sum.go"), filepath.Join(dir, "sum.go")}
+	if !reflect.DeepEqual(files, want) {
+		t.Errorf("collected %v, want %v", files, want)
+	}
+
+	// Patterns apply relative to the analyzed directory, so the temporary
+	// directory's own name cannot exclude the tree; a file named directly
+	// is matched on its own name.
+	files, err = collectFiles([]string{filepath.Join(dir, "sum_test.go"), filepath.Join(dir, "pkg", "sum.go")}, []string{filepath.Base(dir), "sum.go"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{filepath.Join(dir, "sum_test.go")}; !reflect.DeepEqual(files, want) {
+		t.Errorf("collected %v, want %v", files, want)
+	}
+
+	// Test files come back with includeTests, still under the other patterns.
+	files, err = collectFiles([]string{dir}, []string{"pkg"}, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if want := []string{filepath.Join(dir, "gen", "api", "client.go"), filepath.Join(dir, "sum.go"), filepath.Join(dir, "sum_test.go")}; !reflect.DeepEqual(files, want) {
 		t.Errorf("collected %v, want %v", files, want)
 	}
 }

--- a/polyscan/internal/analysis/cohesion_test.go
+++ b/polyscan/internal/analysis/cohesion_test.go
@@ -63,7 +63,7 @@ func (s *Server) B() {}
 `,
 	})
 
-	report, err := Analyze([]string{dir}, Options{LCOM: true})
+	report, err := Analyze([]string{dir}, Options{LCOM: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -135,7 +135,7 @@ mod tests {
 `,
 	})
 
-	report, err := Analyze([]string{dir}, Options{LCOM: true})
+	report, err := Analyze([]string{dir}, Options{LCOM: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -151,7 +151,7 @@ mod tests {
 
 func TestAnalyzeCohesionAbsentWithoutSupportedLanguage(t *testing.T) {
 	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; void m() { a = 1; } };\n"})
-	report, err := Analyze([]string{dir}, Options{LCOM: true, Complexity: true})
+	report, err := Analyze([]string{dir}, Options{LCOM: true, Complexity: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -159,7 +159,7 @@ func TestAnalyzeCohesionAbsentWithoutSupportedLanguage(t *testing.T) {
 		t.Errorf("cohesion = %+v, want none for a C++ tree", report.Cohesion)
 	}
 	dir = writeFiles(t, map[string]string{"a.go": "package p\n\nfunc F() {}\n"})
-	report, err = Analyze([]string{dir}, Options{LCOM: true})
+	report, err = Analyze([]string{dir}, Options{LCOM: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}

--- a/polyscan/internal/analysis/collect.go
+++ b/polyscan/internal/analysis/collect.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/ludo-technologies/polyscan/polyscan/internal/lang"
+	"github.com/ludo-technologies/polyscan/polyscan/internal/pathmatch"
 )
 
 // skippedDirs are the directories a walk never descends into: version
@@ -31,15 +32,25 @@ func skipDir(name string) bool {
 
 // collectFiles returns, sorted and without duplicates, the absolute paths
 // of the files of a supported language under paths. A path that is a file
-// is taken as given when its language is supported.
-func collectFiles(paths []string) ([]string, error) {
+// is taken as given when its language is supported, unless its name matches
+// an exclude pattern. Under a directory, exclude patterns apply to the path
+// relative to that directory, so a directory above the root cannot exclude
+// the whole tree; a directory that matches is not walked. Unless
+// includeTests is set, the files a language names as test files are left
+// out under the same relative-path rule.
+func collectFiles(paths []string, exclude []string, includeTests bool) ([]string, error) {
 	seen := map[string]bool{}
 	var files []string
-	add := func(path string) {
-		if _, ok := lang.ByPath(path); ok && !seen[path] {
-			seen[path] = true
-			files = append(files, path)
+	add := func(path, rel string) {
+		language, ok := lang.ByPath(path)
+		if !ok || seen[path] || pathmatch.Matches(rel, exclude) {
+			return
 		}
+		if !includeTests && language.IsTestFile(rel) {
+			return
+		}
+		seen[path] = true
+		files = append(files, path)
 	}
 	for _, p := range paths {
 		root, err := filepath.Abs(p)
@@ -51,20 +62,27 @@ func collectFiles(paths []string) ([]string, error) {
 			return nil, err
 		}
 		if !info.IsDir() {
-			add(root)
+			add(root, filepath.Base(root))
 			continue
 		}
 		err = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
+			if path == root {
+				return nil
+			}
+			rel, err := filepath.Rel(root, path)
+			if err != nil {
+				return err
+			}
 			if d.IsDir() {
-				if path != root && skipDir(d.Name()) {
+				if skipDir(d.Name()) || pathmatch.Matches(rel, exclude) {
 					return fs.SkipDir
 				}
 				return nil
 			}
-			add(path)
+			add(path, rel)
 			return nil
 		})
 		if err != nil {

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -69,7 +69,7 @@ type Server struct{ s Store }
 `,
 	})
 
-	report, err := Analyze([]string{dir}, Options{CBO: true})
+	report, err := Analyze([]string{dir}, Options{CBO: true, IncludeTests: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -111,7 +111,7 @@ type A struct{ b B; u model.User }
 type B struct{}
 `,
 	})
-	report, err := Analyze([]string{dir}, Options{CBO: true})
+	report, err := Analyze([]string{dir}, Options{CBO: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -148,7 +148,7 @@ struct Fixture { f: Foo }
 type Unit struct{ foo Foo }
 `,
 	})
-	report, err := Analyze([]string{dir}, Options{CBO: true})
+	report, err := Analyze([]string{dir}, Options{CBO: true, IncludeTests: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
@@ -175,7 +175,7 @@ type Unit struct{ foo Foo }
 
 func TestAnalyzeCouplingAbsentWithoutSupportedLanguage(t *testing.T) {
 	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; };\n"})
-	report, err := Analyze([]string{dir}, Options{CBO: true})
+	report, err := Analyze([]string{dir}, Options{CBO: true}, nil)
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -100,9 +100,10 @@ type Language struct {
 	// pattern ending in a slash names a directory anywhere on the path.
 	// TestCode is an optional tree-sitter query whose captures span test
 	// code inside a file, such as attribute-marked test functions or
-	// modules. Both are analyzed for complexity but excluded from clone
-	// detection, where the shared skeleton of test functions swamps the
-	// report.
+	// modules. Both are left out of every analysis by default; when they
+	// are included, they still stay out of clone detection, where the
+	// shared skeleton of test functions swamps the report, and of cohesion,
+	// coupling and dependency analysis, which describe the code under test.
 	TestFiles []string
 	TestCode  string
 	// TypeSpansDirectory reports that the methods of one type may be

--- a/polyscan/internal/js/analyzer/unused_code.go
+++ b/polyscan/internal/js/analyzer/unused_code.go
@@ -233,7 +233,7 @@ func DetectUnusedExports(allModuleInfos map[string]*domain.ModuleInfo, graph *Im
 			continue
 		}
 		// Skip test files
-		if isTestFile(filePath) {
+		if IsTestFile(filePath) {
 			continue
 		}
 
@@ -349,8 +349,12 @@ func isEntryPointFile(filePath string) bool {
 	return false
 }
 
-// isTestFile checks if a file is a test file.
-func isTestFile(filePath string) bool {
+// IsTestFile reports whether the path names a test file under the
+// conventions of Jest, Vitest and Mocha: a *.test.* or *.spec.* file, or a
+// file under a __tests__ directory. It is the one definition of a
+// JavaScript/TypeScript test file, shared by file collection, the
+// per-analysis file sets and dead code analysis.
+func IsTestFile(filePath string) bool {
 	base := filepath.Base(filePath)
 
 	// Check for *.test.* and *.spec.* patterns
@@ -403,7 +407,7 @@ func DetectOrphanFiles(allModuleInfos map[string]*domain.ModuleInfo, graph *Impo
 	// 2. Files not imported by any other file (root files with no reverse edges)
 	entryPoints := make(map[string]bool)
 	for filePath := range allModuleInfos {
-		if isTestFile(filePath) || isConfigFile(filePath) {
+		if IsTestFile(filePath) || isConfigFile(filePath) {
 			continue
 		}
 		if isEntryPointFile(filePath) {
@@ -441,7 +445,7 @@ func DetectOrphanFiles(allModuleInfos map[string]*domain.ModuleInfo, graph *Impo
 		if reachable[filePath] {
 			continue
 		}
-		if isTestFile(filePath) || isConfigFile(filePath) {
+		if IsTestFile(filePath) || isConfigFile(filePath) {
 			continue
 		}
 		findings = append(findings, &DeadCodeFinding{
@@ -472,7 +476,7 @@ func DetectUnusedExportedFunctions(allModuleInfos map[string]*domain.ModuleInfo,
 		if isEntryPointFile(filePath) {
 			continue
 		}
-		if isTestFile(filePath) {
+		if IsTestFile(filePath) {
 			continue
 		}
 

--- a/polyscan/internal/js/analyzer/unused_code_test.go
+++ b/polyscan/internal/js/analyzer/unused_code_test.go
@@ -552,9 +552,9 @@ func TestIsTestFile(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		result := isTestFile(tc.path)
+		result := IsTestFile(tc.path)
 		if result != tc.expected {
-			t.Errorf("isTestFile(%q) = %v, want %v", tc.path, result, tc.expected)
+			t.Errorf("IsTestFile(%q) = %v, want %v", tc.path, result, tc.expected)
 		}
 	}
 }

--- a/polyscan/internal/js/app/file_helper.go
+++ b/polyscan/internal/js/app/file_helper.go
@@ -5,6 +5,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/ludo-technologies/polyscan/polyscan/internal/pathmatch"
 	ignore "github.com/sabhiram/go-gitignore"
 )
 
@@ -154,96 +155,12 @@ func (h *FileHelper) isIncluded(path string, includePatterns []string) bool {
 	if len(includePatterns) == 0 {
 		return true
 	}
-	return matchesAnyPattern(path, includePatterns)
+	return pathmatch.Matches(path, includePatterns)
 }
 
 // isExcluded checks if a path matches any exclude pattern.
 func (h *FileHelper) isExcluded(path string, excludePatterns []string) bool {
-	return matchesAnyPattern(path, excludePatterns)
-}
-
-// matchesAnyPattern reports whether a path matches at least one of the patterns.
-//
-// Patterns without a slash are matched against the file name and against each
-// directory segment of the path, so "dist" matches "dist/bundle.js" but not
-// "src/utils/distance.ts". Patterns with a slash are matched against the path
-// as a whole, with "**" matching any number of segments.
-//
-// Matching ignores case, on both sides, so that the default include pattern
-// "**/*.ts" selects Widget.TS exactly as isJSFile accepts it. Treating the two
-// differently would drop such a file with nothing said about it.
-//
-// Note: filepath.Match errors are ignored throughout (invalid patterns simply
-// don't match) so that the remaining valid patterns still apply.
-func matchesAnyPattern(path string, patterns []string) bool {
-	segments := strings.Split(strings.ToLower(filepath.ToSlash(path)), "/")
-	baseName := segments[len(segments)-1]
-	dirSegments := segments[:len(segments)-1]
-
-	for _, pattern := range patterns {
-		pattern = strings.ToLower(strings.Trim(filepath.ToSlash(pattern), "/"))
-		if pattern == "" {
-			continue
-		}
-
-		if strings.Contains(pattern, "/") {
-			if matchesPathPattern(pattern, segments) {
-				return true
-			}
-			continue
-		}
-
-		if matched, err := filepath.Match(pattern, baseName); err == nil && matched {
-			return true
-		}
-		for _, segment := range dirSegments {
-			if segment == pattern {
-				return true
-			}
-			if matched, err := filepath.Match(pattern, segment); err == nil && matched {
-				return true
-			}
-		}
-	}
-	return false
-}
-
-// matchesPathPattern reports whether a multi-segment pattern such as
-// "src/generated/**" matches the given path segments. The pattern may start at
-// any segment boundary, so it behaves like a relative path fragment.
-func matchesPathPattern(pattern string, segments []string) bool {
-	patternSegments := strings.Split(pattern, "/")
-	for i := range segments {
-		if matchSegments(patternSegments, segments[i:]) {
-			return true
-		}
-	}
-	return false
-}
-
-// matchSegments matches pattern segments against a leading run of path
-// segments, where "**" matches zero or more segments and every other segment is
-// a glob. Matching a prefix is enough, so a pattern naming a directory such as
-// "src/generated" also matches everything below it.
-func matchSegments(pattern, segments []string) bool {
-	if len(pattern) == 0 {
-		return true
-	}
-	if pattern[0] == "**" {
-		for i := 0; i <= len(segments); i++ {
-			if matchSegments(pattern[1:], segments[i:]) {
-				return true
-			}
-		}
-		return false
-	}
-	if len(segments) == 0 {
-		return false
-	}
-	if matched, err := filepath.Match(pattern[0], segments[0]); err != nil || !matched {
-		return false
-	}
-	return matchSegments(pattern[1:], segments[1:])
+	return pathmatch.Matches(path, excludePatterns)
 }
 
 // loadGitIgnore loads a .gitignore file from the root directory.

--- a/polyscan/internal/js/js.go
+++ b/polyscan/internal/js/js.go
@@ -88,6 +88,11 @@ func LoadConfig(configPath, targetPath string, warn io.Writer) (*config.Config, 
 	return result.Config, nil
 }
 
+// TestFilePatterns are the exclude patterns that name JavaScript/TypeScript
+// test files: the *.test.* and *.spec.* files and __tests__ directories of
+// Jest, Vitest and Mocha, the conventions dead code analysis recognizes.
+var TestFilePatterns = []string{"*.test.*", "*.spec.*", "__tests__"}
+
 // ContainsFiles reports whether any JavaScript/TypeScript file exists under
 // the paths. Configuration plays no part: polyscan analyze asks before the
 // JavaScript configuration is even discovered, so a tree with no JavaScript

--- a/polyscan/internal/js/js.go
+++ b/polyscan/internal/js/js.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/ludo-technologies/polyscan/polyscan/internal/js/analyzer"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/app"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/config"
 	"github.com/ludo-technologies/polyscan/polyscan/internal/js/domain"
@@ -88,11 +89,6 @@ func LoadConfig(configPath, targetPath string, warn io.Writer) (*config.Config, 
 	return result.Config, nil
 }
 
-// TestFilePatterns are the exclude patterns that name JavaScript/TypeScript
-// test files: the *.test.* and *.spec.* files and __tests__ directories of
-// Jest, Vitest and Mocha, the conventions dead code analysis recognizes.
-var TestFilePatterns = []string{"*.test.*", "*.spec.*", "__tests__"}
-
 // ContainsFiles reports whether any JavaScript/TypeScript file exists under
 // the paths. Configuration plays no part: polyscan analyze asks before the
 // JavaScript configuration is even discovered, so a tree with no JavaScript
@@ -106,8 +102,9 @@ func ContainsFiles(paths []string) (bool, error) {
 }
 
 // CollectFiles collects the JavaScript/TypeScript files under each path,
-// honoring the configuration's include and exclude patterns.
-func CollectFiles(paths []string, cfg *config.Config) ([]string, error) {
+// honoring the configuration's include and exclude patterns. Test files, as
+// analyzer.IsTestFile names them, are left out unless includeTests is set.
+func CollectFiles(paths []string, cfg *config.Config, includeTests bool) ([]string, error) {
 	helper := app.NewFileHelper()
 	var files []string
 	for _, path := range paths {
@@ -115,7 +112,11 @@ func CollectFiles(paths []string, cfg *config.Config) ([]string, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to collect files from %s: %w", path, err)
 		}
-		files = append(files, pathFiles...)
+		for _, file := range pathFiles {
+			if includeTests || !analyzer.IsTestFile(file) {
+				files = append(files, file)
+			}
+		}
 	}
 	return files, nil
 }
@@ -132,12 +133,32 @@ func CollectFiles(paths []string, cfg *config.Config) ([]string, error) {
 // each file inside its fan-out and releases it right after, which holds far
 // fewer parse trees at once. Dependency analysis is the exception: graph
 // construction needs every module's tree at once.
+//
+// Test files among files count for complexity and dead code only. Clone
+// detection, CBO and dependency analysis run over the other files: test
+// functions share a skeleton by convention, and a test's classes and imports
+// describe the tests, not the modules under test.
 func Run(ctx context.Context, files []string, cfg *config.Config, selected Selection) *Result {
+	var sources []string
+	for _, file := range files {
+		if !analyzer.IsTestFile(file) {
+			sources = append(sources, file)
+		}
+	}
+	// The snapshot holds the files some selected analysis reads; a file
+	// no analysis loads would leave the accounting incomplete.
+	if !selected.Complexity && !selected.DeadCode {
+		files = sources
+	}
 	var snapshot *service.ProjectSnapshot
 	if selected.count() > 1 || selected.Deps {
 		snapshot = service.BuildProjectSnapshot(ctx, files)
 	} else {
 		snapshot = service.NewProjectSnapshot(files)
+	}
+	sourceSnapshot := snapshot
+	if len(sources) != len(files) {
+		sourceSnapshot = snapshot.Subset(func(path string) bool { return !analyzer.IsTestFile(path) })
 	}
 
 	result := &Result{}
@@ -170,7 +191,7 @@ func Run(ctx context.Context, files []string, cfg *config.Config, selected Selec
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resp, err := runClones(ctx, snapshot, files)
+			resp, err := runClones(ctx, sourceSnapshot, sources)
 			mu.Lock()
 			result.Clones, result.ClonesErr = resp, err
 			mu.Unlock()
@@ -181,7 +202,7 @@ func Run(ctx context.Context, files []string, cfg *config.Config, selected Selec
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resp, err := runCBO(ctx, snapshot, files)
+			resp, err := runCBO(ctx, sourceSnapshot, sources)
 			mu.Lock()
 			result.CBO, result.CBOErr = resp, err
 			mu.Unlock()
@@ -192,7 +213,7 @@ func Run(ctx context.Context, files []string, cfg *config.Config, selected Selec
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			resp, err := runDeps(ctx, snapshot, files)
+			resp, err := runDeps(ctx, sourceSnapshot, sources)
 			mu.Lock()
 			result.Deps, result.DepsErr = resp, err
 			mu.Unlock()

--- a/polyscan/internal/js/service/project_snapshot.go
+++ b/polyscan/internal/js/service/project_snapshot.go
@@ -66,6 +66,20 @@ func NewProjectSnapshot(paths []string) *ProjectSnapshot {
 	return &ProjectSnapshot{Files: files}
 }
 
+// Subset returns a snapshot over the files keep accepts, sharing their
+// entries and parse trees with s: a file loaded through either snapshot is
+// loaded in both. It lets analyses that run over different file sets, such
+// as clone detection leaving test files out, share one parse.
+func (s *ProjectSnapshot) Subset(keep func(path string) bool) *ProjectSnapshot {
+	subset := &ProjectSnapshot{retain: s.retain}
+	for _, file := range s.Files {
+		if keep(file.Path) {
+			subset.Files = append(subset.Files, file)
+		}
+	}
+	return subset
+}
+
 // BuildProjectSnapshot reads and parses each file once, in parallel, and keeps
 // the parse trees for every analysis that runs over the snapshot. Files come
 // out in path order regardless of scheduling, so downstream reports stay

--- a/polyscan/internal/pathmatch/pathmatch.go
+++ b/polyscan/internal/pathmatch/pathmatch.go
@@ -1,0 +1,93 @@
+// Package pathmatch matches paths against the exclude and include patterns
+// polyscan accepts on the command line and in jscan.config.json.
+package pathmatch
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// Matches reports whether a path matches at least one of the patterns.
+//
+// Patterns without a slash are matched against the file name and against each
+// directory segment of the path, so "dist" matches "dist/bundle.js" but not
+// "src/utils/distance.ts". Patterns with a slash are matched against the path
+// as a whole, with "**" matching any number of segments.
+//
+// Matching ignores case, on both sides, so that the default include pattern
+// "**/*.ts" selects Widget.TS exactly as the extension check accepts it.
+// Treating the two differently would drop such a file with nothing said
+// about it.
+//
+// Note: filepath.Match errors are ignored throughout (invalid patterns simply
+// don't match) so that the remaining valid patterns still apply.
+func Matches(path string, patterns []string) bool {
+	segments := strings.Split(strings.ToLower(filepath.ToSlash(path)), "/")
+	baseName := segments[len(segments)-1]
+	dirSegments := segments[:len(segments)-1]
+
+	for _, pattern := range patterns {
+		pattern = strings.ToLower(strings.Trim(filepath.ToSlash(pattern), "/"))
+		if pattern == "" {
+			continue
+		}
+
+		if strings.Contains(pattern, "/") {
+			if matchesPathPattern(pattern, segments) {
+				return true
+			}
+			continue
+		}
+
+		if matched, err := filepath.Match(pattern, baseName); err == nil && matched {
+			return true
+		}
+		for _, segment := range dirSegments {
+			if segment == pattern {
+				return true
+			}
+			if matched, err := filepath.Match(pattern, segment); err == nil && matched {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// matchesPathPattern reports whether a multi-segment pattern such as
+// "src/generated/**" matches the given path segments. The pattern may start at
+// any segment boundary, so it behaves like a relative path fragment.
+func matchesPathPattern(pattern string, segments []string) bool {
+	patternSegments := strings.Split(pattern, "/")
+	for i := range segments {
+		if matchSegments(patternSegments, segments[i:]) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchSegments matches pattern segments against a leading run of path
+// segments, where "**" matches zero or more segments and every other segment is
+// a glob. Matching a prefix is enough, so a pattern naming a directory such as
+// "src/generated" also matches everything below it.
+func matchSegments(pattern, segments []string) bool {
+	if len(pattern) == 0 {
+		return true
+	}
+	if pattern[0] == "**" {
+		for i := 0; i <= len(segments); i++ {
+			if matchSegments(pattern[1:], segments[i:]) {
+				return true
+			}
+		}
+		return false
+	}
+	if len(segments) == 0 {
+		return false
+	}
+	if matched, err := filepath.Match(pattern[0], segments[0]); err != nil || !matched {
+		return false
+	}
+	return matchSegments(pattern[1:], segments[1:])
+}

--- a/polyscan/internal/pathmatch/pathmatch_test.go
+++ b/polyscan/internal/pathmatch/pathmatch_test.go
@@ -1,0 +1,26 @@
+package pathmatch
+
+import "testing"
+
+func TestMatches(t *testing.T) {
+	for _, tc := range []struct {
+		path     string
+		patterns []string
+		want     bool
+	}{
+		{"pkg/sum_test.go", []string{"*_test.go"}, true},
+		{"pkg/sum.go", []string{"*_test.go"}, false},
+		{"tests/integration.rs", []string{"tests"}, true},
+		{"src/utils/distance.ts", []string{"dist"}, false},
+		{"dist/bundle.js", []string{"dist"}, true},
+		{"src/generated/api/client.ts", []string{"src/generated/**"}, true},
+		{"src/generated/api/client.ts", []string{"src/generated"}, true},
+		{"lib/src/generated/x.go", []string{"src/generated"}, true},
+		{"Widget.TS", []string{"**/*.ts"}, true},
+		{"a.go", []string{"", "["}, false},
+	} {
+		if got := Matches(tc.path, tc.patterns); got != tc.want {
+			t.Errorf("Matches(%q, %v) = %v, want %v", tc.path, tc.patterns, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `polyscan analyze --exclude <patterns>` leaves files and directories out of every analysis, for every language. Patterns follow the rules of `exclude_patterns` in `jscan.config.json`: a glob without a slash matches a file name or a directory anywhere on the path, one with a slash matches a path relative to the analyzed directory, with `**` for any number of segments. For JavaScript/TypeScript the patterns are added to the configuration's own.
- Test files and test code are now left out of every analysis by default. Go `*_test.go`; Rust `#[test]` functions, `#[cfg(test)]` items, `tests.rs`, `*_tests.rs` and `tests/`; C++ `*_test.*`, `*_tests.*`, `test_*.*`, `*Test.*`, `test/` and `tests/`; JavaScript/TypeScript `*.test.*`, `*.spec.*` and `__tests__/`. Before, they were analyzed for complexity and, for JavaScript/TypeScript, for everything.
- `--include-tests` restores the previous behavior. Test code then counts for complexity and dead code, but still stays out of clone detection, cohesion, coupling and dependency analysis.
- The path matcher moves from `internal/js/app` into a new `internal/pathmatch` package shared by both pipelines.

Breaking: complexity numbers of a tree with test files change, since the test functions no longer count. Noted under Changed in the CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WhKJX9EkCGhPKWBpvjfmXr