### PR TITLE
fix: use declaring file in cohesion for cross-file Rust types

### DIFF
--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -201,6 +201,10 @@ func Analyze(paths []string, options Options, exclude []string) (*Report, error)
 		// a type its package declares.
 		if options.LCOM && language.HasCohesion() && !language.IsTestFile(display) {
 			cohesionFiles++
+			// Record the type declarations alongside the methods, so the
+			// cohesion result can attribute a type to its declaring file
+			// with or without the coupling analysis.
+			cohesion.setDeclarations(language, display, result)
 			for _, fn := range functions {
 				if !fn.IsTest {
 					cohesion.add(language, display, fn)
@@ -210,13 +214,6 @@ func Analyze(paths []string, options Options, exclude []string) (*Report, error)
 		if options.CBO && language.HasCoupling() && !language.IsTestFile(display) {
 			if err := coupling.add(language, display, file, content, result); err != nil {
 				return nil, err
-			}
-			// Give the cohesion analysis the type declarations the
-			// coupling analysis already collects, so a Rust type whose
-			// declaration and impl blocks live in different files uses
-			// the declaring file in both results.
-			if options.LCOM && language.HasCohesion() {
-				cohesion.setDeclarations(language, display, result)
 			}
 		}
 	}

--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -211,6 +211,13 @@ func Analyze(paths []string, options Options, exclude []string) (*Report, error)
 			if err := coupling.add(language, display, file, content, result); err != nil {
 				return nil, err
 			}
+			// Give the cohesion analysis the type declarations the
+			// coupling analysis already collects, so a Rust type whose
+			// declaration and impl blocks live in different files uses
+			// the declaring file in both results.
+			if options.LCOM && language.HasCohesion() {
+				cohesion.setDeclarations(language, display, result)
+			}
 		}
 	}
 

--- a/polyscan/internal/analysis/cohesion.go
+++ b/polyscan/internal/analysis/cohesion.go
@@ -15,9 +15,11 @@ type Class struct {
 	Name     string `json:"name"`
 	FilePath string `json:"file_path"`
 	Language string `json:"language"`
-	// StartLine and EndLine span the type's methods in FilePath. A type
-	// whose methods are spread over several files is placed in the first of
-	// them.
+	// StartLine and EndLine span the type's methods in FilePath, or the
+	// type's declaration when the class is attributed to a declaring file
+	// that holds none of the measured methods. A type whose methods are
+	// spread over several files without a single declaration is placed in
+	// the first of them.
 	StartLine int `json:"start_line"`
 	EndLine   int `json:"end_line"`
 	// LCOM4 is the number of connected components among the methods, where
@@ -64,22 +66,28 @@ type classMethod struct {
 	file string
 }
 
+// typeDeclaration is the file and line span declaring one type.
+type typeDeclaration struct {
+	file       string
+	start, end int
+}
+
 // cohesionBuilder groups methods by type. A type is identified by its
 // language, its receiver name and the file that declares its methods, or
 // the directory when the language lets a type's methods span one.
 type cohesionBuilder struct {
 	classes map[string]*classMethods
 	keys    []string
-	// typeDeclarations maps language+name to the file that declares the
-	// type. It is populated by setDeclarations from the same engine result
-	// the coupling analysis uses, so the cohesion result can reference the
-	// declaring file instead of the first method's file for a type whose
-	// declaration and impl blocks live in different files.
-	typeDeclarations map[string]string
+	// declarations maps a fully-scoped key (language, location and name,
+	// the same scheme the coupling analysis keys types on) to the type's
+	// declaration, and byBare indexes those declarations by bare name for
+	// cross-file lookup.
+	declarations map[string]*typeDeclaration
+	byBare       map[string][]*typeDeclaration
 }
 
 func newCohesionBuilder() *cohesionBuilder {
-	return &cohesionBuilder{classes: map[string]*classMethods{}, typeDeclarations: map[string]string{}}
+	return &cohesionBuilder{classes: map[string]*classMethods{}, declarations: map[string]*typeDeclaration{}, byBare: map[string][]*typeDeclaration{}}
 }
 
 func (b *cohesionBuilder) add(language *engine.Language, display string, fn engine.Function) {
@@ -100,15 +108,21 @@ func (b *cohesionBuilder) add(language *engine.Language, display string, fn engi
 	class.methods = append(class.methods, classMethod{Function: fn, file: display})
 }
 
-// setDeclarations records the file that declares each type from the engine
-// result. The coupling analysis collects the same information; this method
-// lets the cohesion analysis use it without duplicating the work.
+// setDeclarations records the file and line span declaring each type from
+// the engine result, keyed the way the coupling analysis keys types.
 func (b *cohesionBuilder) setDeclarations(language *engine.Language, display string, result *engine.Result) {
+	location := display
+	if language.TypeSpansDirectory {
+		location = filepath.Dir(display)
+	}
 	for _, t := range result.Types {
-		if t.Declared {
-			key := language.Name + "\x00" + t.Name
-			if _, ok := b.typeDeclarations[key]; !ok {
-				b.typeDeclarations[key] = display
+		if t.Declared && !t.IsTest {
+			full := language.Name + "\x00" + location + "\x00" + t.Name
+			if _, ok := b.declarations[full]; !ok {
+				d := &typeDeclaration{file: display, start: t.StartLine, end: t.EndLine}
+				b.declarations[full] = d
+				bare := language.Name + "\x00" + bareName(language, t.Name)
+				b.byBare[bare] = append(b.byBare[bare], d)
 			}
 		}
 	}
@@ -122,13 +136,20 @@ func (b *cohesionBuilder) build() *Cohesion {
 	for _, key := range b.keys {
 		cm := b.classes[key]
 		class := cm.measure()
-		// When the declaring file is known and the language scopes types
-		// per file, use it instead of the first method's file so the
-		// cohesion result matches the coupling result for a type whose
-		// declaration and impl blocks live in different files.
+		// When the language scopes types per file and the tree declares
+		// the type exactly once, attribute the class to the declaring
+		// file with the declaration's line span, so the cohesion result
+		// matches the coupling result for a type whose declaration and
+		// impl blocks live in different files. An ambiguous name keeps
+		// the first method's file, so unrelated same-named types in
+		// different files stay distinct.
 		if !cm.language.TypeSpansDirectory {
-			if declKey, ok := b.typeDeclarations[cm.language.Name+"\x00"+cm.name]; ok {
-				class.FilePath = declKey
+			bare := cm.language.Name + "\x00" + bareName(cm.language, cm.name)
+			if candidates := b.byBare[bare]; len(candidates) == 1 {
+				if d := candidates[0]; d.file != class.FilePath {
+					class.FilePath = d.file
+					class.StartLine, class.EndLine = d.start, d.end
+				}
 			}
 		}
 		if class.TotalMethods > class.ExcludedMethods {

--- a/polyscan/internal/analysis/cohesion.go
+++ b/polyscan/internal/analysis/cohesion.go
@@ -1,7 +1,6 @@
 package analysis
 
 import (
-	"path/filepath"
 	"sort"
 	"strings"
 
@@ -78,27 +77,19 @@ type typeDeclaration struct {
 type cohesionBuilder struct {
 	classes map[string]*classMethods
 	keys    []string
-	// declarations maps a fully-scoped key (language, location and name,
-	// the same scheme the coupling analysis keys types on) to the type's
-	// declaration, and byBare indexes those declarations by bare name for
-	// cross-file lookup.
-	declarations map[string]*typeDeclaration
-	byBare       map[string][]*typeDeclaration
+	// index tracks the type declarations of the tree; see declIndex.
+	index *declIndex[*typeDeclaration]
 }
 
 func newCohesionBuilder() *cohesionBuilder {
-	return &cohesionBuilder{classes: map[string]*classMethods{}, declarations: map[string]*typeDeclaration{}, byBare: map[string][]*typeDeclaration{}}
+	return &cohesionBuilder{classes: map[string]*classMethods{}, index: newDeclIndex[*typeDeclaration]()}
 }
 
 func (b *cohesionBuilder) add(language *engine.Language, display string, fn engine.Function) {
 	if fn.Receiver == "" {
 		return
 	}
-	location := display
-	if language.TypeSpansDirectory {
-		location = filepath.Dir(display)
-	}
-	key := language.Name + "\x00" + location + "\x00" + fn.Receiver
+	key := scopedKey(language, locationOf(language, display), fn.Receiver)
 	class, ok := b.classes[key]
 	if !ok {
 		class = &classMethods{name: fn.Receiver, language: language}
@@ -109,21 +100,12 @@ func (b *cohesionBuilder) add(language *engine.Language, display string, fn engi
 }
 
 // setDeclarations records the file and line span declaring each type from
-// the engine result, keyed the way the coupling analysis keys types.
+// the engine result.
 func (b *cohesionBuilder) setDeclarations(language *engine.Language, display string, result *engine.Result) {
-	location := display
-	if language.TypeSpansDirectory {
-		location = filepath.Dir(display)
-	}
+	location := locationOf(language, display)
 	for _, t := range result.Types {
 		if t.Declared && !t.IsTest {
-			full := language.Name + "\x00" + location + "\x00" + t.Name
-			if _, ok := b.declarations[full]; !ok {
-				d := &typeDeclaration{file: display, start: t.StartLine, end: t.EndLine}
-				b.declarations[full] = d
-				bare := language.Name + "\x00" + bareName(language, t.Name)
-				b.byBare[bare] = append(b.byBare[bare], d)
-			}
+			b.index.add(language, location, t.Name, &typeDeclaration{file: display, start: t.StartLine, end: t.EndLine})
 		}
 	}
 }
@@ -133,24 +115,42 @@ func (b *cohesionBuilder) setDeclarations(language *engine.Language, display str
 // no cohesion to measure and is left out.
 func (b *cohesionBuilder) build() *Cohesion {
 	cohesion := &Cohesion{Classes: []Class{}}
+	// Merge the per-file groups of an unambiguously-declared type before
+	// measuring, so a type whose declaration and methods span files is
+	// measured once and reported once under its declaring file. An
+	// ambiguous name keeps one group per file, so unrelated same-named
+	// types stay distinct.
+	merged := map[string]*classMethods{}
+	decls := map[string]*typeDeclaration{}
+	var order []string
 	for _, key := range b.keys {
 		cm := b.classes[key]
-		class := cm.measure()
-		// When the language scopes types per file and the tree declares
-		// the type exactly once, attribute the class to the declaring
-		// file with the declaration's line span, so the cohesion result
-		// matches the coupling result for a type whose declaration and
-		// impl blocks live in different files. An ambiguous name keeps
-		// the first method's file, so unrelated same-named types in
-		// different files stay distinct.
+		target := key
+		var decl *typeDeclaration
 		if !cm.language.TypeSpansDirectory {
-			bare := cm.language.Name + "\x00" + bareName(cm.language, cm.name)
-			if candidates := b.byBare[bare]; len(candidates) == 1 {
-				if d := candidates[0]; d.file != class.FilePath {
-					class.FilePath = d.file
-					class.StartLine, class.EndLine = d.start, d.end
-				}
+			if d, ok := b.index.unique(cm.language, cm.name); ok {
+				decl = d
+				target = scopedKey(cm.language, d.file, cm.name)
 			}
+		}
+		m, ok := merged[target]
+		if !ok {
+			m = &classMethods{name: cm.name, language: cm.language}
+			merged[target] = m
+			decls[target] = decl
+			order = append(order, target)
+		}
+		m.methods = append(m.methods, cm.methods...)
+	}
+	for _, key := range order {
+		class := merged[key].measure()
+		// Attribute the merged class to the declaring file with the
+		// declaration's line span when it differs from the first
+		// method's file, so the cohesion result matches the coupling
+		// result.
+		if d := decls[key]; d != nil && d.file != class.FilePath {
+			class.FilePath = d.file
+			class.StartLine, class.EndLine = d.start, d.end
 		}
 		if class.TotalMethods > class.ExcludedMethods {
 			cohesion.Classes = append(cohesion.Classes, class)

--- a/polyscan/internal/analysis/cohesion.go
+++ b/polyscan/internal/analysis/cohesion.go
@@ -70,10 +70,16 @@ type classMethod struct {
 type cohesionBuilder struct {
 	classes map[string]*classMethods
 	keys    []string
+	// typeDeclarations maps language+name to the file that declares the
+	// type. It is populated by setDeclarations from the same engine result
+	// the coupling analysis uses, so the cohesion result can reference the
+	// declaring file instead of the first method's file for a type whose
+	// declaration and impl blocks live in different files.
+	typeDeclarations map[string]string
 }
 
 func newCohesionBuilder() *cohesionBuilder {
-	return &cohesionBuilder{classes: map[string]*classMethods{}}
+	return &cohesionBuilder{classes: map[string]*classMethods{}, typeDeclarations: map[string]string{}}
 }
 
 func (b *cohesionBuilder) add(language *engine.Language, display string, fn engine.Function) {
@@ -94,13 +100,37 @@ func (b *cohesionBuilder) add(language *engine.Language, display string, fn engi
 	class.methods = append(class.methods, classMethod{Function: fn, file: display})
 }
 
+// setDeclarations records the file that declares each type from the engine
+// result. The coupling analysis collects the same information; this method
+// lets the cohesion analysis use it without duplicating the work.
+func (b *cohesionBuilder) setDeclarations(language *engine.Language, display string, result *engine.Result) {
+	for _, t := range result.Types {
+		if t.Declared {
+			key := language.Name + "\x00" + t.Name
+			if _, ok := b.typeDeclarations[key]; !ok {
+				b.typeDeclarations[key] = display
+			}
+		}
+	}
+}
+
 // build measures every type that has at least one method with a receiver
 // parameter. A type with none, such as one that only has constructors, has
 // no cohesion to measure and is left out.
 func (b *cohesionBuilder) build() *Cohesion {
 	cohesion := &Cohesion{Classes: []Class{}}
 	for _, key := range b.keys {
-		class := b.classes[key].measure()
+		cm := b.classes[key]
+		class := cm.measure()
+		// When the declaring file is known and the language scopes types
+		// per file, use it instead of the first method's file so the
+		// cohesion result matches the coupling result for a type whose
+		// declaration and impl blocks live in different files.
+		if !cm.language.TypeSpansDirectory {
+			if declKey, ok := b.typeDeclarations[cm.language.Name+"\x00"+cm.name]; ok {
+				class.FilePath = declKey
+			}
+		}
 		if class.TotalMethods > class.ExcludedMethods {
 			cohesion.Classes = append(cohesion.Classes, class)
 		}

--- a/polyscan/internal/analysis/cohesion_test.go
+++ b/polyscan/internal/analysis/cohesion_test.go
@@ -149,6 +149,69 @@ mod tests {
 	}
 }
 
+func TestAnalyzeCohesionRustUsesDeclaringFile(t *testing.T) {
+	// A Rust type whose declaration and impl blocks live in different
+	// files should use the declaring file in both coupling and cohesion,
+	// so countClasses counts it once.
+	dir := writeFiles(t, map[string]string{
+		"types.rs": `pub struct Foo { n: u32 }
+
+impl Foo {
+    pub fn new() -> Self { Foo { n: 0 } }
+}
+`,
+		"ops.rs": `use crate::types::Foo;
+
+impl Foo {
+    pub fn inc(&mut self) { self.n += 1; }
+    pub fn get(&self) -> u32 { self.n }
+}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true, CBO: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Cohesion == nil {
+		t.Fatal("cohesion is nil for a Rust tree")
+	}
+	classes := report.Cohesion.Classes
+	if len(classes) != 1 {
+		t.Fatalf("got %d classes, want 1 (Foo): %+v", len(classes), classes)
+	}
+	foo := classes[0]
+	if foo.Name != "Foo" || foo.Language != "Rust" {
+		t.Errorf("class = %+v, want Rust Foo", foo)
+	}
+	// The declaring file is types.rs; without the fix it would be ops.rs.
+	if filepath.Base(foo.FilePath) != "types.rs" {
+		t.Errorf("FilePath = %q, want types.rs (the declaring file)", foo.FilePath)
+	}
+	if foo.TotalMethods != 3 {
+		t.Errorf("TotalMethods = %d, want 3 (new, inc, get)", foo.TotalMethods)
+	}
+
+	// Coupling should also use the declaring file.
+	if report.Coupling == nil {
+		t.Fatal("coupling is nil for a Rust tree")
+	}
+	if len(report.Coupling.Classes) != 1 {
+		t.Fatalf("coupling classes = %d, want 1", len(report.Coupling.Classes))
+	}
+	couplingFoo := report.Coupling.Classes[0]
+	if filepath.Base(couplingFoo.FilePath) != "types.rs" {
+		t.Errorf("coupling FilePath = %q, want types.rs", couplingFoo.FilePath)
+	}
+
+	// Both analyses must agree on the declaring file so that
+	// countClasses merges them into one type instead of counting two.
+	if couplingFoo.FilePath != foo.FilePath {
+		t.Errorf("FilePath mismatch: coupling=%q, cohesion=%q, want both types.rs",
+			couplingFoo.FilePath, foo.FilePath)
+	}
+}
+
 func TestAnalyzeCohesionAbsentWithoutSupportedLanguage(t *testing.T) {
 	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; void m() { a = 1; } };\n"})
 	report, err := Analyze([]string{dir}, Options{LCOM: true, Complexity: true}, nil)

--- a/polyscan/internal/analysis/cohesion_test.go
+++ b/polyscan/internal/analysis/cohesion_test.go
@@ -186,14 +186,15 @@ impl Foo {
 	if foo.Name != "Foo" || foo.Language != "Rust" {
 		t.Errorf("class = %+v, want Rust Foo", foo)
 	}
-	// The declaring file is types.rs; without the fix it would be ops.rs.
-	// Only the ops.rs methods are measured (new has no receiver and its
-	// group is left out), and the line span is the declaration's.
+	// The declaring file is types.rs; without the fix the methods would be
+	// reported under ops.rs. All three methods are measured together (new
+	// has no receiver and stays out of the graph), and the line span is
+	// the declaration's.
 	if filepath.Base(foo.FilePath) != "types.rs" {
 		t.Errorf("FilePath = %q, want types.rs (the declaring file)", foo.FilePath)
 	}
-	if foo.TotalMethods != 2 {
-		t.Errorf("TotalMethods = %d, want 2 (inc, get)", foo.TotalMethods)
+	if foo.TotalMethods != 3 || foo.ExcludedMethods != 1 {
+		t.Errorf("methods = %d total, %d excluded; want 3 and 1 (new, inc, get)", foo.TotalMethods, foo.ExcludedMethods)
 	}
 	if foo.StartLine != 1 || foo.EndLine != 1 {
 		t.Errorf("span = %d-%d, want the declaration's 1-1 in types.rs, not the methods' lines in ops.rs", foo.StartLine, foo.EndLine)
@@ -255,6 +256,46 @@ impl Foo {
 	}
 	if foo.StartLine != 1 || foo.EndLine != 1 {
 		t.Errorf("span = %d-%d, want the declaration's 1-1", foo.StartLine, foo.EndLine)
+	}
+}
+
+func TestAnalyzeCohesionRustMergesCrossFileMethods(t *testing.T) {
+	// When the declaring file holds its own impl block and another file
+	// adds more methods, the type must be measured once and reported once
+	// under the declaring file, not once per file.
+	dir := writeFiles(t, map[string]string{
+		"a.rs": `pub struct Foo { n: u32 }
+
+impl Foo {
+    pub fn inc(&mut self) { self.n += 1; }
+    pub fn get(&self) -> u32 { self.n }
+}
+`,
+		"b.rs": `use crate::a::Foo;
+
+impl Foo {
+    pub fn double(&mut self) { self.n *= 2; }
+}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	classes := report.Cohesion.Classes
+	if len(classes) != 1 {
+		t.Fatalf("got %d classes, want 1 (Foo measured once): %+v", len(classes), classes)
+	}
+	foo := classes[0]
+	if foo.Name != "Foo" || foo.Language != "Rust" {
+		t.Errorf("class = %+v, want Rust Foo", foo)
+	}
+	if filepath.Base(foo.FilePath) != "a.rs" {
+		t.Errorf("FilePath = %q, want a.rs (the declaring file)", foo.FilePath)
+	}
+	if foo.TotalMethods != 3 {
+		t.Errorf("TotalMethods = %d, want 3 (inc, get, double)", foo.TotalMethods)
 	}
 }
 

--- a/polyscan/internal/analysis/cohesion_test.go
+++ b/polyscan/internal/analysis/cohesion_test.go
@@ -154,10 +154,12 @@ func TestAnalyzeCohesionRustUsesDeclaringFile(t *testing.T) {
 	// files should use the declaring file in both coupling and cohesion,
 	// so countClasses counts it once.
 	dir := writeFiles(t, map[string]string{
-		"types.rs": `pub struct Foo { n: u32 }
+		"unit.rs": `pub struct Unit;
+`,
+		"types.rs": `pub struct Foo { n: u32, u: Unit }
 
 impl Foo {
-    pub fn new() -> Self { Foo { n: 0 } }
+    pub fn new() -> Self { Foo { n: 0, u: Unit } }
 }
 `,
 		"ops.rs": `use crate::types::Foo;
@@ -185,11 +187,16 @@ impl Foo {
 		t.Errorf("class = %+v, want Rust Foo", foo)
 	}
 	// The declaring file is types.rs; without the fix it would be ops.rs.
+	// Only the ops.rs methods are measured (new has no receiver and its
+	// group is left out), and the line span is the declaration's.
 	if filepath.Base(foo.FilePath) != "types.rs" {
 		t.Errorf("FilePath = %q, want types.rs (the declaring file)", foo.FilePath)
 	}
-	if foo.TotalMethods != 3 {
-		t.Errorf("TotalMethods = %d, want 3 (new, inc, get)", foo.TotalMethods)
+	if foo.TotalMethods != 2 {
+		t.Errorf("TotalMethods = %d, want 2 (inc, get)", foo.TotalMethods)
+	}
+	if foo.StartLine != 1 || foo.EndLine != 1 {
+		t.Errorf("span = %d-%d, want the declaration's 1-1 in types.rs, not the methods' lines in ops.rs", foo.StartLine, foo.EndLine)
 	}
 
 	// Coupling should also use the declaring file.
@@ -209,6 +216,82 @@ impl Foo {
 	if couplingFoo.FilePath != foo.FilePath {
 		t.Errorf("FilePath mismatch: coupling=%q, cohesion=%q, want both types.rs",
 			couplingFoo.FilePath, foo.FilePath)
+	}
+}
+
+func TestAnalyzeCohesionRustLCOMAloneUsesDeclaringFile(t *testing.T) {
+	// The declaring file must be used even without the coupling analysis:
+	// --select lcom alone collects the declarations itself.
+	dir := writeFiles(t, map[string]string{
+		"types.rs": `pub struct Foo { n: u32 }
+
+impl Foo {
+    pub fn new() -> Self { Foo { n: 0 } }
+}
+`,
+		"ops.rs": `use crate::types::Foo;
+
+impl Foo {
+    pub fn inc(&mut self) { self.n += 1; }
+    pub fn get(&self) -> u32 { self.n }
+}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if report.Coupling != nil {
+		t.Fatal("coupling was not selected but is present")
+	}
+	classes := report.Cohesion.Classes
+	if len(classes) != 1 {
+		t.Fatalf("got %d classes, want 1 (Foo): %+v", len(classes), classes)
+	}
+	foo := classes[0]
+	if filepath.Base(foo.FilePath) != "types.rs" {
+		t.Errorf("FilePath = %q, want types.rs (the declaring file)", foo.FilePath)
+	}
+	if foo.StartLine != 1 || foo.EndLine != 1 {
+		t.Errorf("span = %d-%d, want the declaration's 1-1", foo.StartLine, foo.EndLine)
+	}
+}
+
+func TestAnalyzeCohesionRustSameNamedTypesStayDistinct(t *testing.T) {
+	// Two unrelated Foo types in different files must each keep their own
+	// file: an ambiguous bare name is never attributed to the file seen
+	// first.
+	dir := writeFiles(t, map[string]string{
+		"a.rs": `pub struct Foo { n: u32 }
+
+impl Foo {
+    pub fn inc(&mut self) { self.n += 1; }
+    pub fn get(&self) -> u32 { self.n }
+}
+`,
+		"b.rs": `pub struct Foo { s: String }
+
+impl Foo {
+    pub fn push(&mut self, v: String) { self.s.push_str(&v); }
+    pub fn len(&self) -> usize { self.s.len() }
+}
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{LCOM: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	byFile := map[string]int{}
+	for _, class := range report.Cohesion.Classes {
+		if class.Language == "Rust" && class.Name == "Foo" {
+			byFile[filepath.Base(class.FilePath)]++
+		}
+	}
+	want := map[string]int{"a.rs": 1, "b.rs": 1}
+	if !reflect.DeepEqual(byFile, want) {
+		t.Errorf("Foo classes by file = %v, want %v", byFile, want)
 	}
 }
 

--- a/polyscan/internal/analysis/declindex.go
+++ b/polyscan/internal/analysis/declindex.go
@@ -1,0 +1,58 @@
+package analysis
+
+import (
+	"path/filepath"
+
+	"github.com/ludo-technologies/polyscan/polyscan/internal/engine"
+)
+
+// scopedKey identifies one type the way the coupling analysis keys types:
+// language, location and name, where the location is the directory for a
+// language whose types span one, else the file.
+func scopedKey(language *engine.Language, location, name string) string {
+	return language.Name + "\x00" + location + "\x00" + name
+}
+
+// locationOf returns the location a type of the language belongs to: the
+// directory when the language spreads a type over one, otherwise the file.
+func locationOf(language *engine.Language, display string) string {
+	if language.TypeSpansDirectory {
+		return filepath.Dir(display)
+	}
+	return display
+}
+
+// declIndex tracks the declarations of each bare type name across the
+// tree. T is the declaration payload the analysis keeps.
+type declIndex[T any] struct {
+	byKey  map[string]T
+	byBare map[string][]T
+}
+
+func newDeclIndex[T any]() *declIndex[T] {
+	return &declIndex[T]{byKey: map[string]T{}, byBare: map[string][]T{}}
+}
+
+// add records one declaration; a repeat under the same key is ignored, so
+// same-named declarations in different files each keep an entry under the
+// bare name.
+func (ix *declIndex[T]) add(language *engine.Language, location, name string, decl T) {
+	key := scopedKey(language, location, name)
+	if _, ok := ix.byKey[key]; ok {
+		return
+	}
+	ix.byKey[key] = decl
+	bare := language.Name + "\x00" + bareName(language, name)
+	ix.byBare[bare] = append(ix.byBare[bare], decl)
+}
+
+// unique returns the declaration when the bare type name has exactly one
+// across the tree.
+func (ix *declIndex[T]) unique(language *engine.Language, name string) (T, bool) {
+	candidates := ix.byBare[language.Name+"\x00"+bareName(language, name)]
+	if len(candidates) == 1 {
+		return candidates[0], true
+	}
+	var zero T
+	return zero, false
+}


### PR DESCRIPTION
The cohesion analysis set FilePath to the file of a type's first method, while coupling used the declaring file. For a Rust type declared in types.rs with impl blocks in ops.rs, this produced two different keys in countClasses, counting the class twice.

Give the cohesion builder the type declarations the coupling analysis already collects. When the language scopes types per file, the cohesion result now uses the declaring file instead of the first method's file, so both analyses agree and countClasses merges them into one.

The fix is guarded by !TypeSpansDirectory so Go (which spans a package directory) is unaffected.

Closes #119