### PR TITLE
fix: warn on ambiguous Rust type names in coupling analysis

### DIFF
--- a/polyscan/internal/analysis/coupling.go
+++ b/polyscan/internal/analysis/coupling.go
@@ -198,7 +198,11 @@ func (b *couplingBuilder) build() *Coupling {
 		case len(candidates) == 1:
 			candidates[0].refs = append(candidates[0].refs, t.refs...)
 		case len(candidates) > 1:
-			b.warnings = append(b.warnings, fmt.Sprintf("%s: ambiguous type name %q: undeclared impl block matches %d declarations across the tree, references left unresolved", t.file, t.name, len(candidates)))
+			// t.file is only set for declared types; the file of an
+			// undeclared block is the location in its key, which is the
+			// display path for a language scoped per file.
+			loc := strings.SplitN(key, "\x00", 3)[1]
+			b.warnings = append(b.warnings, fmt.Sprintf("%s: ambiguous type name %q: undeclared impl block matches %d declarations across the tree, references left unresolved", loc, t.name, len(candidates)))
 		}
 	}
 

--- a/polyscan/internal/analysis/coupling.go
+++ b/polyscan/internal/analysis/coupling.go
@@ -186,14 +186,19 @@ func (b *couplingBuilder) build() *Coupling {
 
 	// A Rust impl block or a method group in a file that does not declare
 	// its type belongs to the declaration elsewhere when there is exactly
-	// one.
+	// one. An ambiguous bare name with more than one declaration across
+	// the tree is left unresolved with a warning.
 	for _, key := range order {
 		t := types[key]
 		if t.declared || t.language.TypeSpansDirectory {
 			continue
 		}
-		if candidates := byBare[bareKey(t.language, t.name)]; len(candidates) == 1 {
+		candidates := byBare[bareKey(t.language, t.name)]
+		switch {
+		case len(candidates) == 1:
 			candidates[0].refs = append(candidates[0].refs, t.refs...)
+		case len(candidates) > 1:
+			b.warnings = append(b.warnings, fmt.Sprintf("%s: ambiguous type name %q: undeclared impl block matches %d declarations across the tree, references left unresolved", t.file, t.name, len(candidates)))
 		}
 	}
 
@@ -216,8 +221,13 @@ func (b *couplingBuilder) build() *Coupling {
 			if target, ok := byFileBare[file][ref.Name]; ok {
 				return target, ref.Name
 			}
-			if candidates := byBare[bareKey(file.language, ref.Name)]; len(candidates) > 0 {
+			candidates := byBare[bareKey(file.language, ref.Name)]
+			switch {
+			case len(candidates) == 1:
 				return candidates[0], ref.Name
+			case len(candidates) > 1:
+				b.warnings = append(b.warnings, fmt.Sprintf("%s: ambiguous reference %q: resolves to %d declarations across the tree, left unresolved", file.display, ref.Name, len(candidates)))
+				return nil, ""
 			}
 			return nil, ""
 		}

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -178,25 +178,30 @@ func TestAnalyzeCouplingRustAmbiguousTypeName(t *testing.T) {
 	// ambiguous name must not silently merge the impl into one declaration
 	// or resolve references arbitrarily; both sides warn and leave it out.
 	dir := writeFiles(t, map[string]string{
-		"circle.rs": `pub struct Point { x: f64, y: f64 }
+		"unit.rs": `pub struct Unit(pub f64);
+`,
+		"helper.rs": `pub struct Helper;
+`,
+		"circle.rs": `pub struct Point { x: f64, y: f64, u: Unit }
 
 impl Point {
-    pub fn distance(&self, other: &Point) -> f64 { (self.x - other.x).abs() }
+    pub fn distance(&self, other: &Point) -> f64 { (self.x - other.x).abs() + self.u.0 }
 }
 `,
-		"vector.rs": `pub struct Point { x: f64, y: f64 }
+		"vector.rs": `pub struct Point { x: f64, y: f64, u: Unit }
 
 impl Point {
-    pub fn add(&self, other: &Point) -> Point { Point { x: self.x + other.x, y: self.y + other.y } }
+    pub fn add(&self, other: &Point) -> Point { Point { x: self.x + other.x, y: self.y + other.y, u: Unit(self.u.0) } }
 }
 `,
-		// ops.rs declares an impl for Point but does not declare Point
-		// itself. With two declarations of Point in the tree, the impl
-		// block must be left unresolved.
+		// ops.rs holds an impl for Point but declares nothing itself. With
+		// two declarations of Point in the tree, the impl block must be
+		// left unresolved: its references (Helper, Unit) must reach
+		// neither declaration.
 		"ops.rs": `use crate::circle::Point;
 
 impl Point {
-    pub fn origin() -> Point { Point { x: 0.0, y: 0.0 } }
+    pub fn origin(h: &Helper) -> Point { let _ = h; Point { x: 0.0, y: 0.0, u: Unit(0.0) } }
 }
 `,
 	})
@@ -204,29 +209,32 @@ impl Point {
 	if err != nil {
 		t.Fatalf("Analyze: %v", err)
 	}
-	// Both declarations must appear as separate classes.
-	var pointClasses int
+	// Both declarations appear as separate classes, each depending only on
+	// Unit: the references of the orphaned impl block (Helper) reach
+	// neither.
+	byFile := map[string][]string{}
 	for _, class := range report.Coupling.Classes {
 		if class.Language == "Rust" && class.Name == "Point" {
-			pointClasses++
+			byFile[filepath.Base(class.FilePath)] = class.DependentClasses
 		}
 	}
-	if pointClasses != 2 {
-		t.Errorf("Rust Point classes = %d, want 2 (one per declaring file)", pointClasses)
+	want := map[string][]string{
+		"circle.rs": {"Unit"},
+		"vector.rs": {"Unit"},
 	}
-	// The ambiguous impl must produce warnings.
-	if len(report.Coupling.Warnings) == 0 {
-		t.Error("no warnings for ambiguous type name, want at least one")
+	if !reflect.DeepEqual(byFile, want) {
+		t.Errorf("Point dependencies = %v, want %v", byFile, want)
 	}
-	ambiguous := false
+	// The ambiguous impl must produce a warning, not a silent drop.
+	found := false
 	for _, w := range report.Coupling.Warnings {
-		if strings.Contains(w, "ambiguous") {
-			ambiguous = true
+		if strings.Contains(w, "ambiguous") && strings.Contains(w, "undeclared impl block") {
+			found = true
 			break
 		}
 	}
-	if !ambiguous {
-		t.Errorf("warnings = %v, want one containing 'ambiguous'", report.Coupling.Warnings)
+	if !found {
+		t.Errorf("warnings = %v, want one about the ambiguous undeclared impl block", report.Coupling.Warnings)
 	}
 }
 

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -173,6 +173,63 @@ type Unit struct{ foo Foo }
 	}
 }
 
+func TestAnalyzeCouplingRustAmbiguousTypeName(t *testing.T) {
+	// Two files declare Point and a third holds an impl for it. The
+	// ambiguous name must not silently merge the impl into one declaration
+	// or resolve references arbitrarily; both sides warn and leave it out.
+	dir := writeFiles(t, map[string]string{
+		"circle.rs": `pub struct Point { x: f64, y: f64 }
+
+impl Point {
+    pub fn distance(&self, other: &Point) -> f64 { (self.x - other.x).abs() }
+}
+`,
+		"vector.rs": `pub struct Point { x: f64, y: f64 }
+
+impl Point {
+    pub fn add(&self, other: &Point) -> Point { Point { x: self.x + other.x, y: self.y + other.y } }
+}
+`,
+		// ops.rs declares an impl for Point but does not declare Point
+		// itself. With two declarations of Point in the tree, the impl
+		// block must be left unresolved.
+		"ops.rs": `use crate::circle::Point;
+
+impl Point {
+    pub fn origin() -> Point { Point { x: 0.0, y: 0.0 } }
+}
+`,
+	})
+	report, err := Analyze([]string{dir}, Options{CBO: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	// Both declarations must appear as separate classes.
+	var pointClasses int
+	for _, class := range report.Coupling.Classes {
+		if class.Language == "Rust" && class.Name == "Point" {
+			pointClasses++
+		}
+	}
+	if pointClasses != 2 {
+		t.Errorf("Rust Point classes = %d, want 2 (one per declaring file)", pointClasses)
+	}
+	// The ambiguous impl must produce warnings.
+	if len(report.Coupling.Warnings) == 0 {
+		t.Error("no warnings for ambiguous type name, want at least one")
+	}
+	ambiguous := false
+	for _, w := range report.Coupling.Warnings {
+		if strings.Contains(w, "ambiguous") {
+			ambiguous = true
+			break
+		}
+	}
+	if !ambiguous {
+		t.Errorf("warnings = %v, want one containing 'ambiguous'", report.Coupling.Warnings)
+	}
+}
+
 func TestAnalyzeCouplingAbsentWithoutSupportedLanguage(t *testing.T) {
 	dir := writeFiles(t, map[string]string{"a.cpp": "struct S { int a; };\n"})
 	report, err := Analyze([]string{dir}, Options{CBO: true}, nil)


### PR DESCRIPTION
The impl aggregation loop required exactly one candidate to merge an undeclared impl block into its declaration, while the resolve closure took the first candidate whatever the count. Both places now follow one policy: a bare name that resolves to more than one declaration across the tree is left unresolved with a warning, so no references are silently dropped or arbitrarily assigned.

Closes #118