### PR TITLE
fix: attribute Go type-alias methods to the aliased type in CBO

### DIFF
--- a/polyscan/CHANGELOG.md
+++ b/polyscan/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Go methods declared on a type-alias receiver (`type Alias = Base`; `func (a *Alias) M()`) are attributed to the aliased type in the coupling (CBO) analysis, and a field or parameter typed by an alias credits that type too. Before, the alias was not a declared type, the methods were dropped, and `Base` reported no coupling (#133)
+
 ## [0.3.3] - 2026-09-12
 
 ### Added

--- a/polyscan/internal/analysis/coupling.go
+++ b/polyscan/internal/analysis/coupling.go
@@ -77,6 +77,15 @@ type siteReference struct {
 	ref  engine.Reference
 }
 
+// aliasTarget is the type a Go type alias names. importPath is empty when
+// the target is a name of the same package; qualifier is the package
+// identifier as written on a qualified target, used when displaying it.
+type aliasTarget struct {
+	name       string
+	importPath string
+	qualifier  string
+}
+
 // couplingBuilder collects the types of every file and resolves their
 // references once the whole tree is known.
 type couplingBuilder struct {
@@ -184,6 +193,34 @@ func (b *couplingBuilder) build() *Coupling {
 		}
 	}
 
+	// A Go type alias is not a type of its own: methods on an alias
+	// receiver and references typed by the alias belong to the aliased
+	// named type. packageNames is complete here, so a qualified target
+	// can be resolved through the alias file's imports.
+	aliases := map[string]aliasTarget{}
+	aliasByImport := map[string]aliasTarget{}
+	for _, file := range b.files {
+		for _, et := range file.types {
+			if !et.Alias || et.AliasOf.Name == "" {
+				continue
+			}
+			target := aliasTarget{name: et.AliasOf.Name, qualifier: et.AliasOf.Package}
+			if et.AliasOf.Package != "" {
+				path, ok := importPathOf(file, et.AliasOf.Package, packageNames)
+				if !ok {
+					continue
+				}
+				target.importPath = path
+			}
+			key := file.language.Name + "\x00" + file.location + "\x00" + et.Name
+			aliases[key] = target
+			if file.importPath != "" {
+				aliasByImport[file.importPath+"."+et.Name] = target
+			}
+		}
+	}
+	b.mergeAliasMethods(types, aliases)
+
 	// A Rust impl block or a method group in a file that does not declare
 	// its type belongs to the declaration elsewhere when there is exactly
 	// one. An ambiguous bare name with more than one declaration across
@@ -210,12 +247,15 @@ func (b *couplingBuilder) build() *Coupling {
 		file, ref := site.file, site.ref
 		switch {
 		case ref.Package != "":
-			target, ok := b.resolveQualified(file, ref, byImportPath, packageNames)
+			target, name, ok := b.resolveQualified(file, ref, byImportPath, packageNames, aliasByImport)
 			if !ok {
 				return nil, ""
 			}
-			return target, ref.Package + "." + ref.Name
+			return target, ref.Package + "." + name
 		case file.language.TypeSpansDirectory:
+			if dest, display, ok := b.resolveAlias(file, ref.Name, types, aliases, aliasByImport, byImportPath); ok {
+				return dest, display
+			}
 			target, ok := types[file.language.Name+"\x00"+file.location+"\x00"+ref.Name]
 			if !ok || !target.declared {
 				return nil, ""
@@ -307,8 +347,21 @@ func (b *couplingBuilder) build() *Coupling {
 
 // resolveQualified finds the type a Go reference pkg.T names: the file's
 // import whose name is pkg, explicit or the package's own, must lead to a
-// package of the tree that declares T.
-func (b *couplingBuilder) resolveQualified(file *couplingFile, ref engine.Reference, byImportPath map[string]*coupledType, packageNames map[string]string) (*coupledType, bool) {
+// package of the tree that declares T, following type aliases in that
+// package. The returned name is the declared type, which may differ from
+// ref.Name when T is an alias.
+func (b *couplingBuilder) resolveQualified(file *couplingFile, ref engine.Reference, byImportPath map[string]*coupledType, packageNames map[string]string, aliasByImport map[string]aliasTarget) (*coupledType, string, bool) {
+	path, ok := importPathOf(file, ref.Package, packageNames)
+	if !ok {
+		return nil, "", false
+	}
+	target, name, ok := lookupInPackage(path, ref.Name, byImportPath, aliasByImport)
+	return target, name, ok
+}
+
+// importPathOf returns the import path the file binds to pkg, the name a
+// qualified type is written with.
+func importPathOf(file *couplingFile, pkg string, packageNames map[string]string) (string, bool) {
 	for _, imported := range file.imports {
 		name := imported.Name
 		switch name {
@@ -317,13 +370,119 @@ func (b *couplingBuilder) resolveQualified(file *couplingFile, ref engine.Refere
 		case "":
 			name = packageNames[imported.Path]
 		}
-		if name != ref.Package {
+		if name == pkg {
+			return imported.Path, true
+		}
+	}
+	return "", false
+}
+
+// mergeAliasMethods attributes the references of each same-package type
+// alias, including methods on an alias receiver, to the aliased declared
+// type. An alias of another package cannot hold methods.
+func (b *couplingBuilder) mergeAliasMethods(types map[string]*coupledType, aliases map[string]aliasTarget) {
+	for key, target := range aliases {
+		src := types[key]
+		if src == nil || target.importPath != "" {
 			continue
 		}
-		target, ok := byImportPath[imported.Path+"."+ref.Name]
-		return target, ok
+		parts := strings.SplitN(key, "\x00", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		lang, loc := parts[0], parts[1]
+		seen := map[string]bool{key: true}
+		for {
+			if target.importPath != "" {
+				break
+			}
+			destKey := lang + "\x00" + loc + "\x00" + target.name
+			if seen[destKey] {
+				break
+			}
+			seen[destKey] = true
+			if dest := types[destKey]; dest != nil && dest.declared {
+				dest.refs = append(dest.refs, src.refs...)
+				break
+			}
+			next, ok := aliases[destKey]
+			if !ok {
+				break
+			}
+			target = next
+		}
 	}
-	return nil, false
+}
+
+// resolveAlias follows a same-package alias name to the declared type it
+// names. ok is false when name is not an alias.
+func (b *couplingBuilder) resolveAlias(file *couplingFile, name string, types map[string]*coupledType, aliases map[string]aliasTarget, aliasByImport map[string]aliasTarget, byImportPath map[string]*coupledType) (*coupledType, string, bool) {
+	target, ok := aliases[file.language.Name+"\x00"+file.location+"\x00"+name]
+	if !ok {
+		return nil, "", false
+	}
+	return followAlias(file, target, types, aliases, aliasByImport, byImportPath)
+}
+
+// followAlias walks an alias chain to a declared type. A same-package
+// target is looked up in types; a qualified one through the imported
+// package, following aliases there too.
+func followAlias(file *couplingFile, target aliasTarget, types map[string]*coupledType, aliases map[string]aliasTarget, aliasByImport map[string]aliasTarget, byImportPath map[string]*coupledType) (*coupledType, string, bool) {
+	seen := map[string]bool{}
+	for {
+		id := target.importPath + "\x00" + target.name
+		if target.importPath == "" {
+			id = file.location + "\x00" + target.name
+		}
+		if seen[id] {
+			return nil, "", true
+		}
+		seen[id] = true
+		if target.importPath == "" {
+			key := file.language.Name + "\x00" + file.location + "\x00" + target.name
+			if dest := types[key]; dest != nil && dest.declared {
+				return dest, target.name, true
+			}
+			next, ok := aliases[key]
+			if !ok {
+				return nil, "", true
+			}
+			target = next
+			continue
+		}
+		dest, name, ok := lookupInPackage(target.importPath, target.name, byImportPath, aliasByImport)
+		if !ok {
+			return nil, "", true
+		}
+		display := name
+		if target.qualifier != "" {
+			display = target.qualifier + "." + name
+		}
+		return dest, display, true
+	}
+}
+
+// lookupInPackage finds the declared type name in importPath, following
+// aliases of that package. The returned name is the declared type.
+func lookupInPackage(importPath, name string, byImportPath map[string]*coupledType, aliasByImport map[string]aliasTarget) (*coupledType, string, bool) {
+	seen := map[string]bool{}
+	for {
+		if seen[importPath+"."+name] {
+			return nil, "", false
+		}
+		seen[importPath+"."+name] = true
+		if t, ok := byImportPath[importPath+"."+name]; ok {
+			return t, t.name, true
+		}
+		next, ok := aliasByImport[importPath+"."+name]
+		if !ok {
+			return nil, "", false
+		}
+		if next.importPath != "" {
+			importPath = next.importPath
+		}
+		name = next.name
+	}
 }
 
 // bareName strips the scope prefix from a type name.

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -101,6 +101,81 @@ type Server struct{ s Store }
 	}
 }
 
+func TestAnalyzeCouplingGoTypeAlias(t *testing.T) {
+	dir := writeFiles(t, map[string]string{
+		"go.mod": "module example.com/app\n",
+		// Methods on an alias receiver belong to the aliased struct, as
+		// do a field and parameter typed by the alias.
+		"alias.go": `package app
+
+type Base struct{ n int }
+type Alias = Base
+
+type Dep struct{}
+type Other struct{}
+
+func (a *Alias) Use(d *Dep) {}
+func (a *Alias) Also(o Other) {}
+`,
+		"holder.go": `package app
+
+type Holder struct{ a *Alias }
+
+func (h *Holder) Take(x Alias) {}
+`,
+		// A method in another file of the package still belongs to Base.
+		"more.go": `package app
+
+func (a *Alias) Extra(d *Dep) {}
+`,
+		"lib/parser.go": `package lib
+
+type Parser struct{ n int }
+type Flags = Parser
+`,
+		"wrap.go": `package app
+
+import "example.com/app/lib"
+
+type Local = lib.Flags
+
+type Wrap struct{ fs *Local }
+`,
+	})
+
+	report, err := Analyze([]string{dir}, Options{CBO: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	got := map[string][]string{}
+	for _, class := range report.Coupling.Classes {
+		got[class.Name] = class.DependentClasses
+	}
+	want := map[string][]string{
+		"Base":   {"Dep", "Other"},
+		"Holder": {"Base"},
+		"Wrap":   {"lib.Parser"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("dependencies = %v, want %v", got, want)
+	}
+	for _, class := range report.Coupling.Classes {
+		if class.Name == "Alias" || class.Name == "Local" || class.Name == "Flags" {
+			t.Errorf("unexpected class %s; aliases are not types of their own", class.Name)
+		}
+	}
+	var base CoupledClass
+	for _, class := range report.Coupling.Classes {
+		if class.Name == "Base" {
+			base = class
+			break
+		}
+	}
+	if base.CBO != 2 || base.TypeHint != 2 {
+		t.Errorf("Base = %+v, want coupling_count 2", base)
+	}
+}
+
 func TestAnalyzeCouplingGoWithoutModule(t *testing.T) {
 	dir := writeFiles(t, map[string]string{
 		"a.go": `package p

--- a/polyscan/internal/engine/engine.go
+++ b/polyscan/internal/engine/engine.go
@@ -73,7 +73,8 @@ type Language struct {
 	// declares, which the coupling (CBO) analysis measures: @name is the
 	// type's name and the capture that spans the match says what it is,
 	// @type a concrete declaration, @abstract an interface or trait, @impl a
-	// block that adds to a type without declaring it, as a Rust impl does. A
+	// block that adds to a type without declaring it, as a Rust impl does,
+	// @alias a name that denotes another type, as a Go type alias does. A
 	// language without a Types query has no coupling analysis.
 	Types string
 	// References is an optional tree-sitter query, paired with Types, for
@@ -229,6 +230,10 @@ type Type struct {
 	// References lists the types referred to, in source order without
 	// duplicates.
 	References []Reference
+	// Alias reports that the name is a type alias, not a type of its own.
+	// AliasOf is the type it names, as written at the alias.
+	Alias   bool
+	AliasOf Reference
 }
 
 // Reference is one type named by another type's declaration or methods.
@@ -257,6 +262,7 @@ const (
 	typeCapture         = "type"
 	abstractCapture     = "abstract"
 	implCapture         = "impl"
+	aliasCapture        = "alias"
 	referenceCapture    = "reference"
 	embeddedCapture     = "embedded"
 	packageCapture      = "package"
@@ -854,6 +860,7 @@ type typeSpan struct {
 	name               string
 	declared           bool
 	abstract           bool
+	alias              bool
 }
 
 // collectTypes gathers the file's types and attributes every reference to
@@ -883,7 +890,7 @@ func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Fu
 			switch captureName := l.types.CaptureNameForId(capture.Index); captureName {
 			case nameCapture:
 				name = capture.Node
-			case typeCapture, abstractCapture, implCapture:
+			case typeCapture, abstractCapture, implCapture, aliasCapture:
 				node = capture.Node
 				kind = captureName
 			}
@@ -904,8 +911,9 @@ func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Fu
 			startLine: int(node.StartPoint().Row) + 1,
 			endLine:   int(node.EndPoint().Row) + 1,
 			name:      name.Content(source),
-			declared:  kind != implCapture,
+			declared:  kind != implCapture && kind != aliasCapture,
 			abstract:  kind == abstractCapture,
+			alias:     kind == aliasCapture,
 		}
 		if prefix, _ := enclosing(scopes, s.start, s.end); len(prefix) > 0 {
 			s.name = strings.Join(prefix, separator) + separator + s.name
@@ -933,6 +941,7 @@ func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Fu
 		}
 		t.Declared = t.Declared || s.declared
 		t.Abstract = t.Abstract || s.abstract
+		t.Alias = t.Alias || s.alias
 	}
 	for i := range functions {
 		if fn := &functions[i]; fn.Receiver != "" && !fn.IsTest {
@@ -955,15 +964,7 @@ func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Fu
 			}
 			start, end = fn.startByte, fn.endByte
 		}
-		var found *typeSpan
-		for i := range spans {
-			if spans[i].start > start {
-				break
-			}
-			if spans[i].contains(start, end) {
-				found = &spans[i]
-			}
-		}
+		found := innermostSpan(spans, start, end)
 		if found == nil || inTest(tests, found.start, found.end) {
 			return nil
 		}
@@ -1010,6 +1011,19 @@ func (l *Language) collectTypes(root *sitter.Node, source []byte, functions []Fu
 	seen := map[string]map[Reference]bool{}
 	for _, id := range order {
 		ref := refs[id]
+		// A reference inside an alias declaration is the aliased type, not
+		// a use of that type by the alias name.
+		if s := innermostSpan(spans, ref.node.StartByte(), ref.node.EndByte()); s != nil && s.alias {
+			t := typeOf(s.name)
+			if t.AliasOf.Name == "" {
+				r := Reference{Name: ref.node.Content(source)}
+				if ref.pkg != nil {
+					r.Package = ref.pkg.Content(source)
+				}
+				t.AliasOf = r
+			}
+			continue
+		}
 		t := owner(ref.node.StartByte(), ref.node.EndByte())
 		if t == nil {
 			continue
@@ -1042,6 +1056,22 @@ func innermost(functions []Function, start, end uint32) *Function {
 		}
 		if fn.endByte >= end {
 			found = fn
+		}
+	}
+	return found
+}
+
+// innermostSpan returns the tightest type span that contains the byte
+// range. Spans are sorted by start, so among the containing spans the last
+// one is the innermost.
+func innermostSpan(spans []typeSpan, start, end uint32) *typeSpan {
+	var found *typeSpan
+	for i := range spans {
+		if spans[i].start > start {
+			break
+		}
+		if spans[i].contains(start, end) {
+			found = &spans[i]
 		}
 	}
 	return found

--- a/polyscan/internal/lang/golang/golang.go
+++ b/polyscan/internal/lang/golang/golang.go
@@ -76,13 +76,31 @@ var Language = &engine.Language{
 (func_literal parameters: (parameter_list [(parameter_declaration name: (identifier) @binding) (variadic_parameter_declaration name: (identifier) @binding)] @declaration)) @scope
 (func_literal result: (parameter_list (parameter_declaration name: (identifier) @binding) @declaration)) @scope
 `,
-	// Every type_spec is a type; an alias (type_alias) only names another.
-	// The span is the spec rather than the whole declaration, since a
-	// grouped declaration holds several specs. An interface matches both
-	// patterns and the engine keeps one span, abstract.
+	// Every type_spec is a type. An alias (type_alias) is recorded as a
+	// name that resolves to the aliased named type, so methods on an
+	// alias receiver and fields or parameters typed by the alias credit
+	// that type. The span is the spec rather than the whole declaration,
+	// since a grouped declaration holds several specs. An interface
+	// matches both type patterns and the engine keeps one span, abstract.
 	Types: `
 (type_spec name: (type_identifier) @name) @type
 (type_spec name: (type_identifier) @name type: (interface_type)) @abstract
+(type_alias name: (type_identifier) @name type: [
+  (type_identifier)
+  (qualified_type)
+  (generic_type)
+  (pointer_type (type_identifier))
+  (pointer_type (qualified_type))
+  (pointer_type (generic_type))
+  (parenthesized_type [
+    (type_identifier)
+    (qualified_type)
+    (generic_type)
+    (pointer_type (type_identifier))
+    (pointer_type (qualified_type))
+    (pointer_type (generic_type))
+  ])
+]) @alias
 `,
 	// Every type_identifier is a reference, including predeclared types and
 	// type parameters, which the analysis drops because nothing declares

--- a/polyscan/internal/lang/golang/golang_test.go
+++ b/polyscan/internal/lang/golang/golang_test.go
@@ -489,6 +489,7 @@ func Free(x Item) {}
 	want := []engine.Type{
 		{Name: "Base", StartLine: 9, EndLine: 9, Declared: true},
 		{Name: "ID", StartLine: 10, EndLine: 10, Declared: true, References: []engine.Reference{{Name: "int"}}},
+		{Name: "Alias", StartLine: 13, EndLine: 13, Alias: true, AliasOf: engine.Reference{Name: "Base"}},
 		{Name: "Server", StartLine: 15, EndLine: 22, Declared: true, References: []engine.Reference{
 			{Name: "Base", Embedded: true}, {Name: "Embedded", Package: "m", Embedded: true}, {Name: "Gen", Embedded: true},
 			{Name: "ID"}, {Name: "User", Package: "m"}, {Name: "Context", Package: "context"}, {Name: "Item"},
@@ -522,5 +523,38 @@ func Helper(x Other) {}
 	want := []engine.Type{{Name: "Server", StartLine: 3, EndLine: 3, References: []engine.Reference{{Name: "Server"}, {Name: "Message"}}}}
 	if !reflect.DeepEqual(result.Types, want) {
 		t.Errorf("types = %+v\nwant   %+v", result.Types, want)
+	}
+}
+
+func TestTypeAliasReceiverIsNotADeclaration(t *testing.T) {
+	result, err := Language.Analyze([]byte(`package p
+
+type Base struct{ n int }
+type Alias = Base
+type Qual = m.User
+type Dep struct{}
+
+func (a *Alias) Use(d *Dep) {}
+`))
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	byName := map[string]engine.Type{}
+	for _, t := range result.Types {
+		byName[t.Name] = t
+	}
+	alias, ok := byName["Alias"]
+	if !ok || alias.Declared || !alias.Alias || alias.AliasOf != (engine.Reference{Name: "Base"}) {
+		t.Errorf("Alias = %+v, want an alias of Base, not declared", alias)
+	}
+	if !reflect.DeepEqual(alias.References, []engine.Reference{{Name: "Alias"}, {Name: "Dep"}}) {
+		t.Errorf("Alias references = %+v, want the method's receiver and Dep", alias.References)
+	}
+	qual, ok := byName["Qual"]
+	if !ok || !qual.Alias || qual.AliasOf != (engine.Reference{Name: "User", Package: "m"}) {
+		t.Errorf("Qual = %+v, want an alias of m.User", qual)
+	}
+	if byName["Base"].Declared != true || byName["Base"].Alias {
+		t.Errorf("Base = %+v, want a declared type", byName["Base"])
 	}
 }


### PR DESCRIPTION
The Go Types query only matched `type_spec`, so `type Alias = Base` declared nothing and methods on `*Alias` never reached Base's CBO count. A field or parameter typed by an alias had the same gap.

Aliases are now recorded as a name that resolves to the aliased type, and those methods and uses are attributed to it.

Fixes #133