### PR TITLE
fix: keep displayPath relative when target is outside cwd

### DIFF
--- a/polyscan/internal/analysis/analysis.go
+++ b/polyscan/internal/analysis/analysis.go
@@ -461,14 +461,15 @@ func summarize(functions []Function) ComplexitySummary {
 }
 
 // displayPath shortens an absolute path to one relative to the working
-// directory when the file lies under it.
+// directory. Paths outside cwd stay relative (../...) so Go/Rust/C++ findings
+// use the same form as the JS pipeline when the target is not under cwd.
 func displayPath(path string) string {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return path
 	}
 	rel, err := filepath.Rel(cwd, path)
-	if err != nil || !filepath.IsLocal(rel) {
+	if err != nil {
 		return path
 	}
 	return rel

--- a/polyscan/internal/analysis/analysis_test.go
+++ b/polyscan/internal/analysis/analysis_test.go
@@ -332,3 +332,65 @@ func TestCollectFilesExclude(t *testing.T) {
 		t.Errorf("collected %v, want %v", files, want)
 	}
 }
+
+func TestDisplayPathOutsideCwd(t *testing.T) {
+	root := t.TempDir()
+	mix := filepath.Join(root, "mix", "pkg")
+	elsewhere := filepath.Join(root, "elsewhere")
+	if err := os.MkdirAll(mix, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(elsewhere, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	src := filepath.Join(mix, "p.go")
+	if err := os.WriteFile(src, []byte("package pkg\n\nfunc F(x int) int {\n\tif x > 0 {\n\t\treturn 1\n\t}\n\treturn 0\n}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(elsewhere)
+
+	abs, err := filepath.Abs(src)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := displayPath(abs)
+	if filepath.IsAbs(got) {
+		t.Fatalf("displayPath(%q) = %q, want a relative path", abs, got)
+	}
+	want, err := filepath.Rel(elsewhere, abs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != want {
+		t.Fatalf("displayPath = %q, want %q", got, want)
+	}
+
+	report, err := Analyze([]string{filepath.Join("..", "mix")}, Options{Complexity: true}, nil)
+	if err != nil {
+		t.Fatalf("Analyze: %v", err)
+	}
+	if len(report.Complexity.Functions) == 0 {
+		t.Fatal("no functions")
+	}
+	for _, fn := range report.Complexity.Functions {
+		if filepath.IsAbs(fn.FilePath) {
+			t.Errorf("%s FilePath = %q, want relative", fn.Name, fn.FilePath)
+		}
+		if !strings.Contains(fn.FilePath, "mix") || !strings.HasSuffix(fn.FilePath, "p.go") {
+			t.Errorf("%s FilePath = %q, want ../mix/.../p.go", fn.Name, fn.FilePath)
+		}
+	}
+}
+
+func TestDisplayPathUnderCwd(t *testing.T) {
+	dir := t.TempDir()
+	src := filepath.Join(dir, "p.go")
+	if err := os.WriteFile(src, []byte("package p\n\nfunc F() {}\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+	got := displayPath(src)
+	if got != "p.go" {
+		t.Fatalf("displayPath under cwd = %q, want p.go", got)
+	}
+}

--- a/polyscan/internal/analysis/coupling_test.go
+++ b/polyscan/internal/analysis/coupling_test.go
@@ -82,9 +82,24 @@ type Server struct{ s Store }
 	if report.Coupling.FilesAnalyzed != 4 || len(report.Coupling.Warnings) != 0 {
 		t.Errorf("files = %d, warnings = %v; want 4 files and no warnings", report.Coupling.FilesAnalyzed, report.Coupling.Warnings)
 	}
+	relToDir := func(p string) string {
+		abs := p
+		if !filepath.IsAbs(p) {
+			a, err := filepath.Abs(p)
+			if err != nil {
+				return p
+			}
+			abs = a
+		}
+		rel, err := filepath.Rel(dir, abs)
+		if err != nil {
+			return strings.TrimPrefix(p, dir+"/")
+		}
+		return rel
+	}
 	got := map[string][]string{}
 	for _, class := range report.Coupling.Classes {
-		got[strings.TrimPrefix(class.FilePath, dir+"/")+":"+class.Name] = class.DependentClasses
+		got[relToDir(class.FilePath)+":"+class.Name] = class.DependentClasses
 	}
 	want := map[string][]string{
 		"server.go:Server":      {"Config", "Handler", "Logger", "model.User", "st.Store"},


### PR DESCRIPTION
Fixes #136

Go/Rust/C++ findings used an absolute file_path when filepath.Rel was not local (target outside cwd). JS kept the as-given relative path, so mixed reports could not join on file_path.

displayPath now returns Rel even for ../. Tests cover outside-cwd and under-cwd.

`go test ./internal/analysis/ -count=1` passes.